### PR TITLE
coq-lsp.opam: bump deps

### DIFF
--- a/coq-lsp.opam
+++ b/coq-lsp.opam
@@ -11,22 +11,17 @@ dev-repo: "git+https://github.com/coq/coq-lsp.git"
 authors: [
   "Emilio Jesús Gallego Arias <e@x80.org>"
 ]
-license: "LGPL 2.1"
+license: "LGPL-2.1"
 doc: "https://coq.github.io/coq-lsp/"
 
 depends: [
-  "ocaml"        {         >= "4.07.1" }
-  "dune"         { build & >= "1.6.0"  }
-
-  "coq"          {         >= "8.10~alpha"  }
+  "ocaml"        {         >= "4.13.1" }
+  "dune"         { build & >= "3.0.2"  }
+  "coq"          {         >= "8.15"   }
 
   # lsp dependencies
-  "cmdliner"     { >= "1.0.0" }
-  "yojson"       { >= "1.6.0" }
-
-  # tests
-  # "ppx_inline_test" { with-test }
-
+  "cmdliner"     { >= "1.1.0" }
+  "yojson"       { >= "1.7.0" }
 ]
 
 build: [ [ "dune" "build" "-p" name "-j" jobs ] ]


### PR DESCRIPTION
For a fresh project without the constraints of coq.git, I propose that we depend on the latest available versions of all packages.