### PR TITLE
coq/: get rid of submodule; build against opam version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "coq"]
-	path = coq
-	url = git@github.com:ejgallego/coq.git
-	branch = proof+no_global_partial

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,10 @@
-.PHONY: coq_boot build build-all clean opam
+.PHONY: default all clean opam
 
-COQ_BUILD_CONTEXT=../_build/default/coq
+default:
+	dune build $(DUNEOPT) coq-lsp.install
 
-build: coq_boot
-	dune build $(DUNEOPT) coq/coq-core.install coq/coq-stdlib.install coq-lsp.install
-
-build-all: coq_boot
+all:
 	dune build $(DUNEOPT) @all
-
-coq/config/coq_config.ml:
-	cd coq && ./configure -no-ask -prefix $(shell pwd)/_build/install/default/ -native-compiler no
-
-coq_boot: coq/config/coq_config.ml
 
 clean:
 	dune clean
@@ -20,3 +13,4 @@ clean:
 opam:
 	opam pin add coq-lsp . --kind=path -y
 	opam install coq-lsp
+

--- a/controller/coq_doc.ml
+++ b/controller/coq_doc.ml
@@ -102,7 +102,7 @@ let pr_goal (st : Vernacstate.t) : Pp.t option =
   Option.map
     (Vernacstate.LemmaStack.with_top ~f:(fun pstate ->
          let proof = Declare.Proof.get pstate in
-         Printer.pr_open_subgoals ~quiet:false ~diffs:None proof))
+         Printer.pr_open_subgoals ~proof))
     st.Vernacstate.lemmas
 
 (* Simple heuristic for Qed. *)

--- a/controller/dune
+++ b/controller/dune
@@ -1,7 +1,6 @@
 (executable
  (name coq_lsp)
  (public_name coq-lsp)
- (modules lsp_util coq_init coq_doc coq_lsp)
  (link_flags -linkall)
  ; Unfortunate we have to link the STM due to the LTAC plugin
  ; depending on it, we should fix this upstream


### PR DESCRIPTION
It seems to work on bonak, but there seems to be some kind of error at an identifier like this:

`C.(Cubical.Box)` -- where `Cubical` is a class, and `Box` is a projection. I'm taking the projection of `C` with `Cubical.Box`, because the identifier `Box` is already used.