### PR TITLE
[serapi] Bump to version that implements hash / compare for tactics.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,6 @@
 - Location-aware cache for Coq interpretation (@ejgallego)
 
 # coq-lsp 0.0.0.1
--------
+-----------------
 
 - Bootstrap from lambdapi-lsp server (@ejgallego)

--- a/controller/coq_protect.ml
+++ b/controller/coq_protect.ml
@@ -4,6 +4,11 @@ module R = struct
     | Interrupted (* signal sent, eval didn't complete *)
 end
 
+let map_loc ~f = function
+  | R.Completed (Error (loc, msg)) ->
+    R.Completed (Error (Option.map f loc, msg))
+  | res -> res
+
 let eval ~f x =
   try
     let res = f x in

--- a/controller/coq_protect.mli
+++ b/controller/coq_protect.mli
@@ -5,3 +5,7 @@ module R : sig
 end
 
 val eval : f:('i -> 'o) -> 'i -> 'o R.t
+
+(** Update the loc stored in the result, this is used by our cache-aware
+    location *)
+val map_loc : f:(Loc.t -> Loc.t) -> 'a R.t -> 'a R.t


### PR DESCRIPTION
This makes the cache much more efficient, with now almost perfect hit
rate.

However, this also makes obvious the problem we have with our caching
system as indeed located messages (and diagnostics) are unsound
w.r.t. to location-independent caching.

We must implement a proper fix to this strategy before merging this; I
think we can indeed make the cache aware of the location a command was
cached, and thus include the offset when we get a hit, and adjust
the cached messages accordingly. Exciting!