### PR TITLE
[interp] Cache goals and feedbacks in the interpretation cache.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,9 @@
-0.0.0.1
+# coq-lsp 0.1.0: Memory
+-----------------------
+
+- Location-aware cache for Coq interpretation (@ejgallego)
+
+# coq-lsp 0.0.0.1
 -------
 
 - Bootstrap from lambdapi-lsp server (@ejgallego)

--- a/controller/coq_doc.mli
+++ b/controller/coq_doc.mli
@@ -18,7 +18,6 @@
 
 type node =
   { ast : Coq_ast.t
-  ; exec : bool
   ; goal : Pp.t option
   }
 
@@ -40,5 +39,5 @@ val create :
 val check :
      ofmt:Format.formatter
   -> doc:t
-  -> coq_queue:string Queue.t
+  -> fb_queue:Pp.t list ref
   -> t * Coq_state.t * Yojson.Basic.t

--- a/controller/coq_interp.ml
+++ b/controller/coq_interp.ml
@@ -1,9 +1,23 @@
 module Info = struct
   type 'a t =
     { res : 'a
-    ; warnings : unit
+    ; goal : Pp.t option
+    ; feedback : Pp.t list
     }
 end
+
+let get_feedback fb_queue =
+  let res = !fb_queue in
+  fb_queue := [];
+  res
+
+let pr_goal (st : Coq_state.t) : Pp.t option =
+  let st = Coq_state.to_coq st in
+  Option.map
+    (Vernacstate.LemmaStack.with_top ~f:(fun pstate ->
+         let proof = Declare.Proof.get pstate in
+         Printer.pr_open_subgoals ~quiet:false ~diffs:None proof))
+    st.Vernacstate.lemmas
 
 type 'a interp_result = 'a Info.t Coq_protect.R.t
 
@@ -12,10 +26,14 @@ let coq_interp ~st cmd =
   let cmd = Coq_ast.to_coq cmd in
   Vernacinterp.interp ~st cmd |> Coq_state.of_coq
 
-let interp ~st cmd =
+let interp ~st ~fb_queue cmd =
   Coq_protect.eval cmd ~f:(fun cmd ->
       let res = coq_interp ~st cmd in
-      { Info.res; warnings = () })
+      (* It is safe to call the printer here as the state is guaranteed to be
+         the right one after `coq_interp`, but beware! *)
+      let goal = pr_goal res in
+      let feedback = List.rev @@ get_feedback fb_queue in
+      { Info.res; goal; feedback })
 
 let marshal_out f oc res =
   match res with
@@ -35,7 +53,7 @@ let marshal_in f ic =
   let tag : int = Marshal.from_channel ic in
   if tag = 0 then
     let res = f ic in
-    Coq_protect.R.Completed (Ok { Info.res; warnings = () })
+    Coq_protect.R.Completed (Ok { Info.res; goal = None; feedback = [] })
   else
     let loc : Loc.t option = Marshal.from_channel ic in
     let msg : Pp.t = Marshal.from_channel ic in

--- a/controller/coq_interp.mli
+++ b/controller/coq_interp.mli
@@ -1,13 +1,19 @@
 module Info : sig
   type 'a t =
     { res : 'a
-    ; warnings : unit
+    ; goal : Pp.t option
+    ; feedback : Pp.t list
     }
 end
 
 type 'a interp_result = 'a Info.t Coq_protect.R.t
 
-val interp : st:Coq_state.t -> Coq_ast.t -> Coq_state.t interp_result
+val interp :
+     st:Coq_state.t
+  -> fb_queue:Pp.t list ref
+  -> Coq_ast.t
+  -> Coq_state.t interp_result
+
 val marshal_in : (in_channel -> 'a) -> in_channel -> 'a interp_result
 
 val marshal_out :

--- a/controller/coq_lsp.ml
+++ b/controller/coq_lsp.ml
@@ -80,8 +80,8 @@ let completed_table : (string, Coq_doc.t * Coq_state.t) Hashtbl.t =
 
 (* Notification handling; reply is optional / asynchronous *)
 let do_check_text ofmt ~state ~doc =
-  let _, _, _, coq_queue = state in
-  let doc, final_st, diags = Coq_doc.check ~ofmt ~doc ~coq_queue in
+  let _, _, _, fb_queue = state in
+  let doc, final_st, diags = Coq_doc.check ~ofmt ~doc ~fb_queue in
   Hashtbl.replace completed_table doc.uri (doc, final_st);
   LIO.send_json ofmt @@ diags
 
@@ -338,11 +338,11 @@ let lsp_main log_file std vo_load_path ml_include_path =
    * Console.err_fmt := lp_fmt; *)
   (* Console.verbose := 4; *)
   let fb_handler, fb_queue =
-    let q = Queue.create () in
+    let q = ref [] in
     ( (fun Feedback.{ contents; _ } ->
         Format.fprintf lp_fmt "%s@\n%!" "fb received";
         match contents with
-        | Message (_lvl, _loc, msg) -> Queue.push Pp.(string_of_ppcmds msg) q
+        | Message (_lvl, _loc, msg) -> q := msg :: !q
         | _ -> ())
     , q )
   in

--- a/controller/memo.mli
+++ b/controller/memo.mli
@@ -11,7 +11,10 @@ end
 val input_info : Coq_ast.t * Coq_state.t -> string
 
 val interp_command :
-  st:Coq_state.t -> Coq_ast.t -> Coq_state.t Coq_interp.interp_result Stats.t
+     st:Coq_state.t
+  -> fb_queue:Pp.t list ref
+  -> Coq_ast.t
+  -> Coq_state.t Coq_interp.interp_result Stats.t
 
 val mem_stats : unit -> int
 val load_from_disk : file:string -> unit


### PR DESCRIPTION
Goal printing is dependent on the state, thus it makes sense to cache
it, as otherwise we'd have to restore the state to print them, which
would kind of defeat the purpose of caching.

This fixes a bug when we'd print goals in the wrong state as `Memo`
wouldn't set the state correctly.

Feedbacks are not, per-se, dependent on the state, but we cache them
too as it makes sense to modularize the code that way.