### PR TITLE
mark vendor/ as vendored_subdir for Dune

### DIFF
--- a/dune
+++ b/dune
@@ -3,3 +3,5 @@
   (flags :standard -rectypes))
  (release
   (flags :standard -rectypes)))
+
+(vendored_dirs vendor)


### PR DESCRIPTION
This stops things like ocamlformat or compiler warnings from being checked in the vendored directories.

Signed-off-by: Ali Caglayan <alizter@gmail.com>

ps-id: 7a8b280a-bc4d-45e2-a966-b28eddb2fde8