### PR TITLE
[stats] Add quick memory stats to sentence information.

### DIFF
--- a/fleche/config.ml
+++ b/fleche/config.ml
@@ -1,5 +1,11 @@
-(* this is very slow, so we disable it *)
+(** [mem_stats] Call [Obj.reachable_words] for every sentence. This is very slow
+    and not very useful, so disabled by default *)
 let mem_stats = false
+
+(** [gc_quick_stats] Show the diff of [Gc.quick_stats] data for each sentence *)
+let gc_quick_stats = true
+
+(** [eager_diagnostics] Send (full) diagnostics after processing each *)
 let eager_diagnostics = true
 
 (** Show diagnostic for OK lines *)

--- a/fleche/stats.mli
+++ b/fleche/stats.mli
@@ -1,3 +1,4 @@
+(** time-based stats *)
 module Kind : sig
   type t =
     | Hashing


### PR DESCRIPTION
Thanks to Pierre-Marie Pédrot for the suggestion.

c.f. https://github.com/coq/coq/issues/11994