### PR TITLE
chore: Nix detects .ocamlformat version + CI fmt uses Nix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,33 +47,24 @@ jobs:
       run:
         working-directory: ./editor/code
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: 🔭 Checkout code
+        uses: actions/checkout@v3
+      - name: 🚀 Setup node
+        uses: actions/setup-node@v3
         with:
           node-version: 16
       - run: npm ci
       - run: npm run compile
 
-  lint-fmt:
+  fmt:
+    name: Format
     runs-on: ubuntu-latest
     steps:
       - name: 🔭 Checkout code
         uses: actions/checkout@v3
         with:
           submodules: recursive
-
-      - name: 🐫 Setup OCaml
-        uses: ocaml/setup-ocaml@v2
-        with:
-          ocaml-compiler: 4.14.x
-          dune-cache: true
-
-      # TODO make this faster, use nix?
-
-      - name: 🐫🐪🐫 Get dependencies
-        run: |
-          opam exec -- make opam-deps
-          opam exec -- make opam-dev-deps
-
+      - name: ❄️ Setup Nix
+        uses: cachix/install-nix-action@v18
       - name: 📐 Format
-        run: opam exec -- make fmt
+        run: nix develop .#fmt -c make fmt

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ check: coq_boot
 	dune build $(DUNEOPT) @check
 
 .PHONY: fmt format
-fmt format: coq_boot
+fmt format:
 	dune fmt $(DUNEOPT)
 
 .PHONY: watch


### PR DESCRIPTION
This gives a faster lint job and allow the flake to follow the version of ocamlformat seamlessly.