### PR TITLE
[lsp] Implement LSP client-side logging, don't crash on log file creation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
-# coq-lsp 0.1.1: Location
------------------------
+# coq-lsp 0.2.0: Location
+-------------------------
+
+# coq-lsp 0.1.1:
+----------------
+
+ - Don't crash if the log file can't be created (@ejgallego , #87)
+ - Use LSP functions for client-side logging (@ejgallego , #87)
 
 # coq-lsp 0.1.0: Memory
 -----------------------

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ hesitate to stop by.
 
 - Most problems can be resolved by restarting `coq-lsp`, in Visual
   Studio Code, `Ctrl+Shift+P` will give you access to the
-  `coq-lsp.restart` command.
+  `coq-lsp.restart` command. You can also look for messages in the
+  "Output" window in VSCode, "Coq LSP Server Events" channel.
 
 ## Features
 

--- a/editor/code/src/client.ts
+++ b/editor/code/src/client.ts
@@ -1,5 +1,5 @@
 import { window, commands, ExtensionContext, workspace, WebviewPanel, ViewColumn, Uri } from "vscode";
-import { LanguageClient } from "vscode-languageclient/node";
+import { LanguageClient, LanguageClientOptions } from "vscode-languageclient/node";
 import { GoalPanel } from "./goals";
 
 let client : LanguageClient;
@@ -11,6 +11,7 @@ export function panelFactory(context : ExtensionContext) {
     const styleUri = panel.webview.asWebviewUri(Uri.joinPath(context.extensionUri, 'media', 'styles.css'));
     return new GoalPanel(client, panel, styleUri);
 }
+
 export function activate (context : ExtensionContext) : void {
     window.showInformationMessage('Going to activate!');
 
@@ -32,10 +33,12 @@ export function activate (context : ExtensionContext) : void {
             ok_diagnostics: config.ok_diagnostics
         };
 
-        const clientOptions = {
+        const clientOptions : LanguageClientOptions = {
             documentSelector: [
                 {scheme: 'file', language: 'coq'}
             ],
+            outputChannelName: "Coq LSP Server Events",
+            revealOutputChannelOn: 1,
             initializationOptions
         };
         const serverOptions = { command: config.path, args: config.args };

--- a/lsp/base.ml
+++ b/lsp/base.ml
@@ -34,9 +34,12 @@ let _parse_uri str =
 let mk_reply ~id ~result =
   `Assoc [ ("jsonrpc", `String "2.0"); ("id", `Int id); ("result", result) ]
 
-let mk_event m p =
+let mk_notification ~method_ ~params =
   `Assoc
-    [ ("jsonrpc", `String "2.0"); ("method", `String m); ("params", `Assoc p) ]
+    [ ("jsonrpc", `String "2.0")
+    ; ("method", `String method_)
+    ; ("params", `Assoc params)
+    ]
 
 (* let json_of_goal g = let pr_hyp (s,(_,t)) = `Assoc ["hname", `String s;
    "htype", `String (Format.asprintf "%a" Print.pp_term (Bindlib.unbox t))] in
@@ -74,8 +77,9 @@ let mk_diagnostic
     ]
 
 let mk_diagnostics ~uri ~version ld : J.t =
-  mk_event "textDocument/publishDiagnostics"
-  @@ [ ("uri", `String uri)
-     ; ("version", `Int version)
-     ; ("diagnostics", `List List.(map mk_diagnostic ld))
-     ]
+  mk_notification ~method_:"textDocument/publishDiagnostics"
+    ~params:
+      [ ("uri", `String uri)
+      ; ("version", `Int version)
+      ; ("diagnostics", `List List.(map mk_diagnostic ld))
+      ]

--- a/lsp/io.mli
+++ b/lsp/io.mli
@@ -10,25 +10,22 @@
 
 (************************************************************************)
 (* Coq Language Server Protocol                                         *)
-(* Copyright 2019 MINES ParisTech -- LGPL 2.1+                          *)
-(* Copyright 2019-2022 Inria -- LGPL 2.1+                               *)
+(* Copyright 2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2019-2022 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-val mk_range : Fleche.Types.Range.t -> Yojson.Safe.t
+(** Read a JSON-RPC request from channel *)
+val read_request : in_channel -> Yojson.Safe.t
 
-(** Build notification *)
-val mk_notification :
-  method_:string -> params:(string * Yojson.Safe.t) list -> Yojson.Safe.t
+exception ReadError of string
 
-(** Answer to a request *)
-val mk_reply : id:int -> result:Yojson.Safe.t -> Yojson.Safe.t
+(** Send a JSON-RPC request to channel *)
+val send_json : Format.formatter -> Yojson.Safe.t -> unit
 
-(* val mk_diagnostic : Range.t * int * string * unit option -> Yojson.Basic.t *)
-val mk_diagnostics :
-     uri:string
-  -> version:int
-  -> (Fleche.Types.Range.t * int * string * unit option) list
-  -> Yojson.Safe.t
+(** Send a [window/logMessage] notification to the client *)
+val logMessage : Format.formatter -> lvl:int -> message:string -> unit
 
-val std_protocol : bool ref
+(** Send a [$/logTrace] notification to the client *)
+val logTrace :
+  Format.formatter -> message:string -> ?verbose:string -> unit -> unit

--- a/lsp/log.ml
+++ b/lsp/log.ml
@@ -1,0 +1,50 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(************************************************************************)
+(* Coq Language Server Protocol                                         *)
+(* Copyright 2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2019-2022 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
+(* Written by: Emilio J. Gallego Arias                                  *)
+(************************************************************************)
+
+let mut = Mutex.create ()
+let debug_chan = ref None
+
+let start_log ~client_cb file =
+  try
+    let debug_oc = open_out file in
+    debug_chan := Some (debug_oc, Format.formatter_of_out_channel debug_oc);
+    client_cb (Format.asprintf "server log file %s created" file)
+  with _ ->
+    client_cb (Format.asprintf "creation of server log file %s failed" file)
+
+let end_log () =
+  Option.iter
+    (fun (oc, fmt) ->
+      Format.pp_print_flush fmt ();
+      Stdlib.flush oc;
+      close_out oc)
+    !debug_chan;
+  debug_chan := None
+
+let with_log f = Option.iter (fun (_, fmt) -> f fmt) !debug_chan
+
+let log_error hdr msg =
+  with_log (fun fmt ->
+      Mutex.lock mut;
+      Format.fprintf fmt "[%s]: @[%s@]@\n%!" hdr msg;
+      Mutex.unlock mut)
+
+let log_object hdr obj =
+  with_log (fun fmt ->
+      Format.fprintf fmt "[%s]: @[%a@]@\n%!" hdr
+        Yojson.Safe.(pretty_print ~std:false)
+        obj)

--- a/lsp/log.mli
+++ b/lsp/log.mli
@@ -10,25 +10,18 @@
 
 (************************************************************************)
 (* Coq Language Server Protocol                                         *)
-(* Copyright 2019 MINES ParisTech -- LGPL 2.1+                          *)
-(* Copyright 2019-2022 Inria -- LGPL 2.1+                               *)
+(* Copyright 2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2019-2022 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-val mk_range : Fleche.Types.Range.t -> Yojson.Safe.t
+(** Set the error formatter output *)
+val start_log : client_cb:(string -> unit) -> string -> unit
 
-(** Build notification *)
-val mk_notification :
-  method_:string -> params:(string * Yojson.Safe.t) list -> Yojson.Safe.t
+val end_log : unit -> unit
 
-(** Answer to a request *)
-val mk_reply : id:int -> result:Yojson.Safe.t -> Yojson.Safe.t
+(** Log string to server error log *)
+val log_error : string -> string -> unit
 
-(* val mk_diagnostic : Range.t * int * string * unit option -> Yojson.Basic.t *)
-val mk_diagnostics :
-     uri:string
-  -> version:int
-  -> (Fleche.Types.Range.t * int * string * unit option) list
-  -> Yojson.Safe.t
-
-val std_protocol : bool ref
+(** Log JSON object to server error log *)
+val log_object : string -> Yojson.Safe.t -> unit


### PR DESCRIPTION
We implement client-side logging (using LSP protocol), and in particular, we use it to warn the user the heavy-duty log file couldn't be created.

This should solve problems some users were having due to permissions errors.