### PR TITLE
[lsp] Improve workspace detection and logging.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
  - Don't crash if the log file can't be created (@ejgallego , #87)
  - Use LSP functions for client-side logging (@ejgallego , #87)
+ - Log `_CoqProject` detection settings to client window (@ejgallego, #88)
+ - Use plugin include paths from `_CoqProject` (@ejgallego, #88)
 
 # coq-lsp 0.1.0: Memory
 -----------------------

--- a/coq/init.ml
+++ b/coq/init.ml
@@ -58,61 +58,40 @@ let coq_init opts =
   in
   Mltop.set_top ser_mltop;
 
+  (* This should go away in Coq itself *)
+  Safe_typing.allow_delayed_constants := true;
+
   (**************************************************************************)
   (* Add root state!!                                                       *)
   (**************************************************************************)
   Vernacstate.freeze_interp_state ~marshallable:false |> State.of_coq
 
-(* End of initialization *)
+(* End of core initialization *)
 
-let loadpath_from_coqproject () : Loadpath.vo_path list =
-  if not (Sys.file_exists "_CoqProject") then []
-  else
-    let (* Io.Log.error "init" "Parsing _CoqProject"; *)
-    open CoqProject_file in
-    let to_vo_loadpath f implicit =
-      let open Loadpath in
-      let unix_path, coq_path = f in
-      (* Lsp.Io.log_error "init"
-       *   (Printf.sprintf "Path from _CoqProject: %s %s" unix_path.path coq_path); *)
-      { implicit
-      ; recursive = true
-      ; has_ml = false
-      ; unix_path = unix_path.path
-      ; coq_path = Libnames.dirpath_of_string coq_path
-      }
-    in
-    let { r_includes; q_includes; _ } =
-      read_project_file ~warning_fn:(fun _ -> ()) "_CoqProject"
-    in
-    let vo_path = List.map (fun f -> to_vo_loadpath f.thing false) q_includes in
-    List.append vo_path
-      (List.map (fun f -> to_vo_loadpath f.thing true) r_includes)
+(**************************************************************************)
+(* Per-document, internal Coq initialization                              *)
+(**************************************************************************)
+
+(* Require a set of libraries *)
+let load_objs libs =
+  let rq_file (dir, from, exp) =
+    let mp = Libnames.qualid_of_string dir in
+    let mfrom = Option.map Libnames.qualid_of_string from in
+    Flags.silently
+      (Vernacentries.vernac_require mfrom exp)
+      [ (mp, Vernacexpr.ImportAll) ]
+  in
+  List.(iter rq_file (rev libs))
 
 (* Inits the context for a document *)
-let doc_init ~root_state ~vo_load_path ~ml_include_path ~libname ~require_libs =
+let doc_init ~root_state ~workspace ~libname ~require_libs =
   (* Lsp.Io.log_error "init" "starting"; *)
   Vernacstate.unfreeze_interp_state (State.to_coq root_state);
 
-  (* This should go away in Coq itself *)
-  Safe_typing.allow_delayed_constants := true;
-  let load_objs libs =
-    let rq_file (dir, from, exp) =
-      let mp = Libnames.qualid_of_string dir in
-      let mfrom = Option.map Libnames.qualid_of_string from in
-      Flags.silently
-        (Vernacentries.vernac_require mfrom exp)
-        [ (mp, Vernacexpr.ImportAll) ]
-    in
-    List.(iter rq_file (rev libs))
-  in
-
-  (* Set load path; important, this has to happen before we declare the library
-     below as [Declaremods/Library] will infer the module name by looking at the
-     load path! *)
-  List.iter Mltop.add_ml_dir ml_include_path;
-  List.iter Loadpath.add_vo_path vo_load_path;
-  List.iter Loadpath.add_vo_path (loadpath_from_coqproject ());
+  (* Set load paths from workspace info. *Important*, this has to happen before
+     we declare the library below as [Declaremods/Library] will infer the module
+     name by looking at the load path! *)
+  Workspace.apply workspace;
   Declaremods.start_library libname;
 
   (* Import initial libraries. *)

--- a/coq/init.mli
+++ b/coq/init.mli
@@ -31,8 +31,7 @@ val coq_init : coq_opts -> State.t
 
 val doc_init :
      root_state:State.t
-  -> vo_load_path:Loadpath.vo_path list
-  -> ml_include_path:string list
+  -> workspace:Workspace.t
   -> libname:Names.DirPath.t
   -> require_libs:
        (string * string option * Vernacexpr.export_with_cats option) list

--- a/coq/workspace.ml
+++ b/coq/workspace.ml
@@ -1,0 +1,104 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(************************************************************************)
+(* Coq Language Server Protocol                                         *)
+(* Copyright 2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2019-2022 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
+(* Written by: Emilio J. Gallego Arias                                  *)
+(************************************************************************)
+
+module Setup = struct
+  type t =
+    { vo_load_path : Loadpath.vo_path list
+    ; ml_include_path : string list
+    ; options : (Goptions.option_name * Coqargs.option_command) list
+          (** This includes warnings *)
+    }
+
+  let append base { vo_load_path; ml_include_path; options } =
+    { vo_load_path = base.vo_load_path @ vo_load_path
+    ; ml_include_path = base.ml_include_path @ ml_include_path
+    ; options = base.options @ options
+    }
+end
+
+type t = Setup.t * string
+(* | CoqProject of Setup.t *)
+(* | Dune *)
+
+let apply ({ Setup.vo_load_path; ml_include_path; options }, _) =
+  List.iter Mltop.add_ml_dir ml_include_path;
+  List.iter Loadpath.add_vo_path vo_load_path;
+  List.iter Coqargs.set_option options;
+  ()
+
+(* TODO, parse _CoqProject extra_args in Coq format *)
+let parse_coq_args _ = []
+
+let loadpath_from_coqproject () : Setup.t =
+  (* Io.Log.error "init" "Parsing _CoqProject"; *)
+  let open CoqProject_file in
+  let to_vo_loadpath f implicit =
+    let open Loadpath in
+    let unix_path, coq_path = f in
+    (* Lsp.Io.log_error "init"
+     *   (Printf.sprintf "Path from _CoqProject: %s %s" unix_path.path coq_path); *)
+    { implicit
+    ; recursive = true
+    ; has_ml = false
+    ; unix_path = unix_path.path
+    ; coq_path = Libnames.dirpath_of_string coq_path
+    }
+  in
+  let { r_includes; q_includes; ml_includes; extra_args; _ } =
+    read_project_file ~warning_fn:(fun _ -> ()) "_CoqProject"
+  in
+  let ml_include_path = List.map (fun f -> f.thing.path) ml_includes in
+  let vo_path = List.map (fun f -> to_vo_loadpath f.thing false) q_includes in
+  let vo_load_path =
+    List.append vo_path
+      (List.map (fun f -> to_vo_loadpath f.thing true) r_includes)
+  in
+  let options = parse_coq_args extra_args in
+  { vo_load_path; ml_include_path; options }
+
+let coq_loadpath_default ~implicit coq_path =
+  let mk_path prefix = coq_path ^ "/" ^ prefix in
+  let mk_lp ~ml ~root ~dir ~implicit =
+    { Loadpath.unix_path = mk_path dir
+    ; coq_path = root
+    ; has_ml = ml
+    ; implicit
+    ; recursive = true
+    }
+  in
+  let coq_root = Names.DirPath.make [ Libnames.coq_root ] in
+  let default_root = Libnames.default_root_prefix in
+  { Setup.vo_load_path =
+      [ mk_lp ~ml:false ~root:coq_root ~implicit ~dir:"theories"
+      ; mk_lp ~ml:true ~root:default_root ~implicit:false ~dir:"user-contrib"
+      ]
+  ; ml_include_path =
+      (let unix_path = Filename.concat coq_path "../coq-core/plugins" in
+       System.all_subdirs ~unix_path |> List.map fst)
+  ; options = []
+  }
+
+(* We append the default loadpath, TODO, support -noinit *)
+let guess ~coqlib ~cmdline =
+  let vo_workspace, origin =
+    if Sys.file_exists "_CoqProject" then
+      ( loadpath_from_coqproject ()
+      , Filename.concat (Sys.getcwd ()) "_CoqProject" )
+    else (cmdline, "Command-line arguments")
+  in
+  ( Setup.append (coq_loadpath_default ~implicit:false coqlib) vo_workspace
+  , origin )

--- a/editor/code/src/client.ts
+++ b/editor/code/src/client.ts
@@ -1,5 +1,5 @@
 import { window, commands, ExtensionContext, workspace, WebviewPanel, ViewColumn, Uri } from "vscode";
-import { LanguageClient, LanguageClientOptions } from "vscode-languageclient/node";
+import { LanguageClient, LanguageClientOptions, RevealOutputChannelOn } from "vscode-languageclient/node";
 import { GoalPanel } from "./goals";
 
 let client : LanguageClient;
@@ -38,7 +38,7 @@ export function activate (context : ExtensionContext) : void {
                 {scheme: 'file', language: 'coq'}
             ],
             outputChannelName: "Coq LSP Server Events",
-            revealOutputChannelOn: 1,
+            revealOutputChannelOn: RevealOutputChannelOn.Info,
             initializationOptions
         };
         const serverOptions = { command: config.path, args: config.args };

--- a/fleche/doc.ml
+++ b/fleche/doc.ml
@@ -37,20 +37,18 @@ type t =
   ; completed : Completion.t
   }
 
-let mk_doc state =
-  let root_state, vo_load_path, ml_include_path, _ = state in
+let mk_doc root_state workspace =
   let libname = Names.(DirPath.make [ Id.of_string "foo" ]) in
   let require_libs = [ ("Coq.Init.Prelude", None, Some (Lib.Import, None)) ] in
-  Coq.Init.doc_init ~root_state ~vo_load_path ~ml_include_path ~libname
-    ~require_libs
+  Coq.Init.doc_init ~root_state ~workspace ~libname ~require_libs
 
 let init_loc ~uri = Loc.initial (InFile { dirpath = None; file = uri })
 
-let create ~state ~uri ~version ~contents =
+let create ~state ~workspace ~uri ~version ~contents =
   { uri
   ; contents
   ; version
-  ; root = mk_doc state
+  ; root = mk_doc state workspace
   ; nodes = []
   ; diags = []
   ; completed = Stopped (init_loc ~uri)

--- a/fleche/doc.mli
+++ b/fleche/doc.mli
@@ -41,7 +41,8 @@ type t = private
   }
 
 val create :
-     state:Coq.State.t * Loadpath.vo_path list * string list * _
+     state:Coq.State.t
+  -> workspace:Coq.Workspace.t
   -> uri:string
   -> version:int
   -> contents:string


### PR DESCRIPTION
We improve our handling of workspaces, preparing the way to setup workspace from `dune` files.

We now log to the user useful workspace detection information, and we read from `_CoqProject` plugin paths, which should likely solve the problems some users were seeing with their plugin-developments not working.