### PR TITLE
[fleche] Resumption of document checking

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,9 @@
  - Use plugin include paths from `_CoqProject` (@ejgallego, #88)
  - Support OCaml >= 4.12 (@ejgallego, #93)
  - Optimize the number of diagnostics sent in eager mode (@ejgallego, #104)
- - Improved syntax highlighting (@artagnon, #105)
+ - Improved syntax highlighting on VSCode client (@artagnon, #105)
+ - Resume document checking from the point it was interrupted
+   (@ejgallego, #95, #99)
 
 # coq-lsp 0.1.0: Memory
 -----------------------

--- a/coq/state.ml
+++ b/coq/state.ml
@@ -41,7 +41,30 @@ let marshal_in ic : t = Marshal.from_channel ic
 let marshal_out oc st = Marshal.to_channel oc st []
 let of_coq x = x
 let to_coq x = x
-let compare x y = compare x y
+
+(* let compare x y = compare x y *)
+let compare (x : t) (y : t) =
+  let open Vernacstate in
+  let { parsing = p1
+      ; system = s1
+      ; lemmas = l1
+      ; program = g1
+      ; opaques = o1
+      ; shallow = h1
+      } =
+    x
+  in
+  let { parsing = p2
+      ; system = s2
+      ; lemmas = l2
+      ; program = g2
+      ; opaques = o2
+      ; shallow = h2
+      } =
+    y
+  in
+  if p1 == p2 && s1 == s2 && l1 == l2 && g1 == g2 && o1 == o2 && h1 == h2 then 0
+  else 1
 
 let mode ~st =
   Option.map

--- a/fleche/info.ml
+++ b/fleche/info.ml
@@ -113,6 +113,7 @@ module type S = sig
 
   type ('a, 'r) query = doc:Doc.t -> point:P.t -> 'a -> 'r option
 
+  val ast : (approx, Coq.Ast.t) query
   val goals : (approx, Coq.Goals.reified_pp) query
   val info : (approx, string) query
   val completion : (string, string list) query
@@ -166,6 +167,9 @@ module Make (P : Point) : S with module P := P = struct
     in
     let lemmas = Coq.State.lemmas ~st in
     Option.cata (reify_goals ppx) None lemmas
+
+  let ast ~doc ~point approx =
+    find ~doc ~point approx |> Option.map (fun node -> node.Doc.ast)
 
   let goals ~doc ~point approx =
     find ~doc ~point approx

--- a/fleche/info.mli
+++ b/fleche/info.mli
@@ -44,6 +44,7 @@ module type S = sig
 
   type ('a, 'r) query = doc:Doc.t -> point:P.t -> 'a -> 'r option
 
+  val ast : (approx, Coq.Ast.t) query
   val goals : (approx, Coq.Goals.reified_pp) query
   val info : (approx, string) query
   val completion : (string, string list) query


### PR DESCRIPTION
We now resume document checking from the point it was left at. That
required some fixing upstream, see https://github.com/coq/coq/pull/16978 .

It seems to work well and be simple enough.

This does stress `Coq.State.compare`, so I did implement a much weaker
version; unfortunately we don't have a test-suite for checking that
memo is working properly, so we need to keep an eye on it and do some
manual testing.
