### PR TITLE
[eager diagnostics] Only send diagnostics when they have changed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
  - Log `_CoqProject` detection settings to client window (@ejgallego, #88)
  - Use plugin include paths from `_CoqProject` (@ejgallego, #88)
  - Support OCaml >= 4.12 (@ejgallego, #93)
+ - Optimize the number of diagnostics sent in eager mode (@ejgallego, #104)
 
 # coq-lsp 0.1.0: Memory
 -----------------------

--- a/fleche/doc.mli
+++ b/fleche/doc.mli
@@ -37,6 +37,7 @@ type t = private
   ; root : Coq.State.t
   ; nodes : node list
   ; diags : Types.Diagnostic.t list
+  ; diags_dirty : bool
   ; completed : Completion.t
   }
 


### PR DESCRIPTION
This makes a lot of difference in the regular mode for large documents. We now go from O(n*d) to O(d^2) where n is the number of sentences and d is the number of diagnostics.