### PR TITLE
[check] Implement `fileProgress` notification for document progress

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@
  - Don't convert Coq "Info" messages such as "Foo is defined" to
    feedback by default; users willing to see them can set the
    corresponding option (@ejgallego, #113)
+ - Send `$/coq/fileProgress` progress notifications from server,
+   similarly to what Lean does; display them in Code's right gutter
+   (@ejgallego, #106, fixes #54)
 
 # coq-lsp 0.1.0: Memory
 -----------------------

--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ Supporting inlays and Lean-style info view.
 
 ### Suggestions / Search panel
 
+## Protocol Notes
+
+`coq-lsp` mostly implements the [LSP Standard](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/), plus some extensions specific to Coq.
+
+Check [the `coq-lsp` protocol documentation](etc/doc/PROTOCOL.md) for more details.
+
 ## Development / Building from sources
 
 ### Server:

--- a/editor/code/package-lock.json
+++ b/editor/code/package-lock.json
@@ -8,10 +8,12 @@
       "name": "coq-lsp",
       "version": "0.1.0",
       "dependencies": {
+        "throttle-debounce": "^5.0.0",
         "vscode-languageclient": "^8.0.2"
       },
       "devDependencies": {
         "@types/node": "^10.14.15",
+        "@types/throttle-debounce": "^5.0.0",
         "@types/vscode": "^1.73.0",
         "esbuild": "^0.15.14",
         "typescript": "^4.8.4"
@@ -56,6 +58,12 @@
       "version": "10.17.60",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
       "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "dev": true
+    },
+    "node_modules/@types/throttle-debounce": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/throttle-debounce/-/throttle-debounce-5.0.0.tgz",
+      "integrity": "sha512-Pb7k35iCGFcGPECoNE4DYp3Oyf2xcTd3FbFQxXUI9hEYKUl6YX+KLf7HrBmgVcD05nl50LIH6i+80js4iYmWbw==",
       "dev": true
     },
     "node_modules/@types/vscode": {
@@ -476,6 +484,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/throttle-debounce": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.0.tgz",
+      "integrity": "sha512-2iQTSgkkc1Zyk0MeVrt/3BvuOXYPl/R8Z0U2xxo9rjwNciaHDG3R+Lm6dh4EeUci49DanvBnuqI6jshoQQRGEg==",
+      "engines": {
+        "node": ">=12.22"
+      }
+    },
     "node_modules/typescript": {
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
@@ -549,6 +565,12 @@
       "version": "10.17.60",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
       "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "dev": true
+    },
+    "@types/throttle-debounce": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/throttle-debounce/-/throttle-debounce-5.0.0.tgz",
+      "integrity": "sha512-Pb7k35iCGFcGPECoNE4DYp3Oyf2xcTd3FbFQxXUI9hEYKUl6YX+KLf7HrBmgVcD05nl50LIH6i+80js4iYmWbw==",
       "dev": true
     },
     "@types/vscode": {
@@ -769,6 +791,11 @@
       "requires": {
         "lru-cache": "^6.0.0"
       }
+    },
+    "throttle-debounce": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.0.tgz",
+      "integrity": "sha512-2iQTSgkkc1Zyk0MeVrt/3BvuOXYPl/R8Z0U2xxo9rjwNciaHDG3R+Lm6dh4EeUci49DanvBnuqI6jshoQQRGEg=="
     },
     "typescript": {
       "version": "4.8.4",

--- a/editor/code/package.json
+++ b/editor/code/package.json
@@ -9,7 +9,6 @@
     "Shachar Itzhaky <shachari@cs.technion.ac.il>",
     "Ramkumar Ramachandra <r@artagnon.com>"
   ],
-
   "publisher": "ejgallego",
   "engines": {
     "vscode": "^1.73.0"
@@ -131,11 +130,13 @@
   },
   "devDependencies": {
     "@types/node": "^10.14.15",
+    "@types/throttle-debounce": "^5.0.0",
     "@types/vscode": "^1.73.0",
     "esbuild": "^0.15.14",
     "typescript": "^4.8.4"
   },
   "dependencies": {
+    "throttle-debounce": "^5.0.0",
     "vscode-languageclient": "^8.0.2"
   },
   "main": "./out/src/client.js",

--- a/editor/code/src/goals.ts
+++ b/editor/code/src/goals.ts
@@ -10,6 +10,7 @@ interface Goal {
     ty: string;
     hyps: Hyp[];
 }
+
 interface GoalRequest {}
 
 // returns the HTML code of goals environment

--- a/editor/code/src/progress.ts
+++ b/editor/code/src/progress.ts
@@ -1,0 +1,26 @@
+import { NotificationType, NotificationType1, VersionedTextDocumentIdentifier, Range } from "vscode-languageclient";
+
+enum CoqFileProgressKind {
+    Processing = 1,
+    FatalError = 2
+}
+
+interface CoqFileProgressProcessingInfo {
+    /** Range for which the processing info was reported. */
+    range: Range;
+    /** Kind of progress that was reported. */
+    kind?: CoqFileProgressKind;
+}
+
+export interface CoqFileProgressParams {
+    /** The text document to which this progress notification applies. */
+    textDocument: VersionedTextDocumentIdentifier;
+
+    /**
+     * Array containing the parts of the file which are still being processed.
+     * The array should be empty if and only if the server is finished processing.
+     */
+    processing: CoqFileProgressProcessingInfo[];
+}
+
+export const coqFileProgress = new NotificationType<CoqFileProgressParams>('$/coq/fileProgress');

--- a/etc/doc/PROTOCOL.md
+++ b/etc/doc/PROTOCOL.md
@@ -1,0 +1,125 @@
+# coq-lsp protocol documentation
+
+## Introduction and preliminaries
+
+`coq-lsp` should be usable by standard LSP clients, however it
+implements some extensions tailored to improve Coq-specific use.
+
+As of today, this document is written for the 3.17 version of the LSP specification:
+https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification
+
+See also the upstream LSP issue on generic support for Proof
+Assistants
+https://github.com/microsoft/language-server-protocol/issues/1414
+
+## Language server protocol support table
+
+If a feature doesn't appear here it usually means it is not planned in the short term:
+
+| Method                            | Support | Notes                                                      |
+|-----------------------------------|---------|------------------------------------------------------------|
+| `initialize`                      | Partial | We don't obey the advertised client capabilities           |
+| `client/registerCapability`       | No      | Not planned ATM                                            |
+| `$/setTrace`                      | No      | Planned                                                    |
+| `$/logTrace`                      | No      |                                                            |
+| `window/logMessage`               | Yes     |                                                            |
+|-----------------------------------|---------|------------------------------------------------------------|
+| `textDocument/didOpen`            | Yes     | We can't reuse Memo tables yet                             |
+| `textDocument/didChange`          | Yes     | We only support `TextDocumentSyncKind.Full` for now        |
+| `textDocument/didClose`           | Partial | We'd likely want to save a `.vo` file on close if possible |
+| `textDocument/didSave`            | No      |                                                            |
+|-----------------------------------|---------|------------------------------------------------------------|
+| `notebookDocument/didOpen`        | No      | Planned                                                    |
+|-----------------------------------|---------|------------------------------------------------------------|
+| `textDocument/declaration`        | No      | Planned, blocked on upstream issues                        |
+| `textDocument/definition`         | No      | Planned, blocked on upstream issues (#53)                  |
+| `textDocument/references`         | No      | Planned, blocked on upstream issues                        |
+| `textDocument/hover`              | Yes     |                                                            |
+| `textDocument/codeLens`           | No      |                                                            |
+| `textDocument/foldingRange`       | No      |                                                            |
+| `textDocument/documentSymbol`     | Yes     | Needs more work as to provide better results               |
+| `textDocument/semanticTokens`     | No      | Planned                                                    |
+| `textDocument/inlineValue`        | No      | Planned                                                    |
+| `textDocument/inlayHint`          | No      | Planned                                                    |
+| `textDocument/completion`         | Partial | Needs more work locally and upstream (#50)                 |
+| `textDocument/publishDiagnostics` | Yes     |                                                            |
+| `textDocument/diagnostic`         | No      | Planned, issue #49                                         |
+| `textDocument/codeAction`         | No      | Planned                                                    |
+|-----------------------------------|---------|------------------------------------------------------------|
+| `workspace/workspaceFolders`      | No      |                                                            |
+|-----------------------------------|---------|------------------------------------------------------------|
+
+
+## Extensions to the LSP specification
+
+As of today, `coq-lsp` implements two extensions to the LSP spec. Note
+that none of them are stable yet:
+
+### Goal Display
+
+In order to display proof goals, `coq-lsp` supports the `proof/goals` request, parameters are:
+```typescript
+{ textDocument: uri
+, position: Position
+}
+```
+
+Answer to the request is a `Goal[]` object, where
+```typescript
+interface Hyp {
+    names: string;
+    ty: string;
+}
+interface Goal {
+    ty: string;
+    hyps: Hyp[];
+}
+
+interface CoqFileProgressParams {
+
+```
+
+which can be then rendered by the client in way that is desired.
+
+`proof/goals` was first used in the lambdapi-lsp server implementation, and we adapted it.
+
+#### Changelog
+
+- v1: initial version, imported from lambdapi-lsp
+
+### File checking progress
+
+The `$/coq/fileProgress` notification is sent from server to client to
+describe the ranges of the document that have been processed.
+
+It is modelled after `$/lean/fileProgress`, see
+https://github.com/microsoft/language-server-protocol/issues/1414 for more information.
+
+```typescript
+enum CoqFileProgressKind {
+    Processing = 1,
+    FatalError = 2
+}
+
+interface CoqFileProgressProcessingInfo {
+    /** Range for which the processing info was reported. */
+    range: Range;
+    /** Kind of progress that was reported. */
+    kind?: CoqFileProgressKind;
+}
+
+interface CoqFileProgressParams {
+    /** The text document to which this progress notification applies. */
+    textDocument: VersionedTextDocumentIdentifier;
+
+    /**
+     * Array containing the parts of the file which are still being processed.
+     * The array should be empty if and only if the server is finished processing.
+     */
+    processing: CoqFileProgressProcessingInfo[];
+}
+```
+
+#### Changelog
+
+- v1: exact copy from Lean protocol (spec under Apache License)

--- a/fleche/debug.ml
+++ b/fleche/debug.ml
@@ -16,3 +16,6 @@ let parsing = false || all
 
 (* Backtraces *)
 let backtraces = false || all
+
+(* Sched wakeup *)
+let sched_wakeup = false || all

--- a/fleche/doc.mli
+++ b/fleche/doc.mli
@@ -28,14 +28,15 @@ type node =
 
 module Completion : sig
   type t =
-    | Yes
-    | Stopped of Loc.t (* Location of the last valid token *)
+    | Yes of Loc.t  (** Location of the last token in the document *)
+    | Stopped of Loc.t  (** Location of the last valid token *)
 end
 
 type t = private
   { uri : string
   ; version : int
   ; contents : string
+  ; end_loc : int * int * int
   ; root : Coq.State.t
   ; nodes : node list
   ; diags_dirty : bool
@@ -50,7 +51,7 @@ val create :
   -> contents:string
   -> t
 
-val bump_version : version:int -> text:string -> t -> t
+val bump_version : version:int -> contents:string -> t -> t
 
 val check :
   ofmt:Format.formatter -> doc:t -> fb_queue:Coq.Message.t list ref -> t

--- a/fleche/info.ml
+++ b/fleche/info.ml
@@ -56,8 +56,8 @@ module LineCol : Point with type t = int * int = struct
       let r = Types.to_range loc in
       let line1 = r.start.line in
       let col1 = r.start.character in
-      let line2 = r._end.line in
-      let col2 = r._end.character in
+      let line2 = r.end_.line in
+      let col2 = r.end_.character in
       if debug_in_range then
         Io.Log.error "in_range"
           (Format.asprintf "(%d, %d) in (%d,%d)-(%d,%d)" line col line1 col1
@@ -74,8 +74,8 @@ module LineCol : Point with type t = int * int = struct
       let r = Types.to_range loc in
       let line1 = r.start.line in
       let col1 = r.start.character in
-      let line2 = r._end.line in
-      let col2 = r._end.character in
+      let line2 = r.end_.line in
+      let col2 = r.end_.character in
       if debug_in_range then
         Io.Log.error "gt_range"
           (Format.asprintf "(%d, %d) in (%d,%d)-(%d,%d)" line col line1 col1

--- a/fleche/io.ml
+++ b/fleche/io.ml
@@ -3,11 +3,14 @@ module CallBack = struct
     { log_error : string -> string -> unit
     ; send_diagnostics :
         uri:string -> version:int -> Types.Diagnostic.t list -> unit
+    ; send_fileProgress :
+        uri:string -> version:int -> (Types.Range.t * int) list -> unit
     }
 
   let default =
     { log_error = (fun _ _ -> ())
     ; send_diagnostics = (fun ~uri:_ ~version:_ _ -> ())
+    ; send_fileProgress = (fun ~uri:_ ~version:_ _ -> ())
     }
 
   let cb = ref default
@@ -21,4 +24,7 @@ end
 module Report = struct
   let diagnostics ~uri ~version d =
     !CallBack.cb.send_diagnostics ~uri ~version d
+
+  let fileProgress ~uri ~version d =
+    !CallBack.cb.send_fileProgress ~uri ~version d
 end

--- a/fleche/io.mli
+++ b/fleche/io.mli
@@ -3,6 +3,8 @@ module CallBack : sig
     { log_error : string -> string -> unit
     ; send_diagnostics :
         uri:string -> version:int -> Types.Diagnostic.t list -> unit
+    ; send_fileProgress :
+        uri:string -> version:int -> (Types.Range.t * int) list -> unit
     }
 
   val set : t -> unit
@@ -14,4 +16,7 @@ end
 
 module Report : sig
   val diagnostics : uri:string -> version:int -> Types.Diagnostic.t list -> unit
+
+  val fileProgress :
+    uri:string -> version:int -> (Types.Range.t * int) list -> unit
 end

--- a/fleche/types.ml
+++ b/fleche/types.ml
@@ -27,7 +27,7 @@ end
 module Range = struct
   type t =
     { start : Point.t
-    ; _end : Point.t
+    ; end_ : Point.t
     }
 end
 
@@ -56,7 +56,7 @@ let to_range (p : Loc.t) : Range.t =
   let end_col = ep - bol_pos_last in
   Range.
     { start = { line = start_line; character = start_col; offset = bp }
-    ; _end = { line = end_line; character = end_col; offset = ep }
+    ; end_ = { line = end_line; character = end_col; offset = ep }
     }
 
 let to_orange = Option.map to_range

--- a/fleche/types.mli
+++ b/fleche/types.mli
@@ -26,7 +26,7 @@ end
 module Range : sig
   type t =
     { start : Point.t
-    ; _end : Point.t
+    ; end_ : Point.t
     }
 end
 

--- a/lsp/base.ml
+++ b/lsp/base.ml
@@ -50,13 +50,13 @@ let mk_notification ~method_ ~params =
    let json_of_thm thm = let open Proofs in match thm with | None -> `Null |
    Some thm -> `Assoc [ "goals", `List List.(map json_of_goal thm.t_goals) ] *)
 
-let mk_range { Fleche.Types.Range.start; _end } : J.t =
+let mk_range { Fleche.Types.Range.start; end_ } : J.t =
   `Assoc
     [ ( "start"
       , `Assoc
           [ ("line", `Int start.line); ("character", `Int start.character) ] )
     ; ( "end"
-      , `Assoc [ ("line", `Int _end.line); ("character", `Int _end.character) ]
+      , `Assoc [ ("line", `Int end_.line); ("character", `Int end_.character) ]
       )
     ]
 


### PR DESCRIPTION
This is modelled after Lean's `$/lean/fileProgress` notification: a
yellow bar in the right side panel indicates what parts of the
document are still not checked.

Fixes #54

Note that we send on fileProgress per sentence, that's likely too
much; for now, we throttle the decoration update. Could be made into a
user-config.
