### PR TITLE
[fleche] Store diagnostics per node, create nodes for unparseable spans

### DIFF
--- a/coq/ast.ml
+++ b/coq/ast.ml
@@ -75,3 +75,17 @@ let grab_definitions f nodes =
 
 let marshal_in ic : t = Marshal.from_channel ic
 let marshal_out oc v = Marshal.to_channel oc v []
+
+let pr_loc ?(print_file = false) loc =
+  let open Loc in
+  let file =
+    if print_file then
+      match loc.fname with
+      | ToplevelInput -> "Toplevel input"
+      | InFile { file; _ } -> "File \"" ^ file ^ "\""
+    else "loc"
+  in
+  Format.asprintf "%s: line: %d, col: %d -- line: %d, col: %d / {%d-%d}" file
+    loc.line_nb (loc.bp - loc.bol_pos) loc.line_nb_last
+    (loc.ep - loc.bol_pos_last)
+    loc.bp loc.ep

--- a/coq/ast.mli
+++ b/coq/ast.mli
@@ -9,3 +9,4 @@ val print : t -> Pp.t
 val grab_definitions : (Loc.t -> Names.Id.t -> 'a) -> t list -> 'a list
 val marshal_in : in_channel -> t
 val marshal_out : out_channel -> t -> unit
+val pr_loc : ?print_file:bool -> Loc.t -> string

--- a/fleche/doc.mli
+++ b/fleche/doc.mli
@@ -19,8 +19,10 @@
 (* [node list] is a very crude form of a meta-data map "loc -> data" , where for
    now [data] is only the goals. *)
 type node =
-  { ast : Coq.Ast.t  (** Ast of node *)
+  { loc : Loc.t
+  ; ast : Coq.Ast.t option  (** Ast of node *)
   ; state : Coq.State.t  (** (Full) State of node *)
+  ; diags : Types.Diagnostic.t list  (** Diagnostics associated to the node *)
   ; memo_info : string
   }
 
@@ -36,7 +38,6 @@ type t = private
   ; contents : string
   ; root : Coq.State.t
   ; nodes : node list
-  ; diags : Types.Diagnostic.t list
   ; diags_dirty : bool
   ; completed : Completion.t
   }

--- a/fleche/info.mli
+++ b/fleche/info.mli
@@ -44,6 +44,7 @@ module type S = sig
 
   type ('a, 'r) query = doc:Doc.t -> point:P.t -> 'a -> 'r option
 
+  val loc : (approx, Loc.t) query
   val ast : (approx, Coq.Ast.t) query
   val goals : (approx, Coq.Goals.reified_pp) query
   val info : (approx, string) query


### PR DESCRIPTION
We rework the document definition so now every span of the document that we process will have a node, even if an Ast can't be produced.

This makes more sense and allows us to store the diagnostics per-node; moreover, unparseable bits have now an associated node, which is important for completion and other use cases such as common prefix handling.