### PR TITLE
[diagnostics] Don't convert Coq "Info" messages to feedbacks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,5 @@
-# coq-lsp 0.2.0: Location
+# coq-lsp 0.1.1: Location
 -------------------------
-
-# coq-lsp 0.1.1:
-----------------
 
  - Don't crash if the log file can't be created (@ejgallego , #87)
  - Use LSP functions for client-side logging (@ejgallego , #87)
@@ -13,6 +10,9 @@
  - Improved syntax highlighting on VSCode client (@artagnon, #105)
  - Resume document checking from the point it was interrupted
    (@ejgallego, #95, #99)
+ - Don't convert Coq "Info" messages such as "Foo is defined" to
+   feedback by default; users willing to see them can set the
+   corresponding option (@ejgallego, #113)
 
 # coq-lsp 0.1.0: Memory
 -----------------------

--- a/editor/code/package.json
+++ b/editor/code/package.json
@@ -119,6 +119,11 @@
             "type": "boolean",
             "default": false,
             "description": "When showing goals and the cursor is in a tactic, if false, show goals before executing the tactic, if true, show goals after"
+          },
+          "coq-lsp.show_coq_info_messages": {
+            "type": "boolean",
+            "default": false,
+            "description": "Show Coq's Info messages as diagnostics, such as 'foo has been defined.' and miscellaneous operational messages."
           }
         }
       }

--- a/fleche/config.ml
+++ b/fleche/config.ml
@@ -11,6 +11,8 @@ type t =
   ; goal_after_tactic : bool [@default false]
         (** When showing goals and the cursor is in a tactic, if false, show
             goals before executing the tactic, if true, show goals after *)
+  ; show_coq_info_messages : bool [@default false]
+        (** Ignore `msg_info` messages in diagnostics *)
   }
 
 let default =
@@ -19,6 +21,7 @@ let default =
   ; eager_diagnostics = true
   ; ok_diagnostics = false
   ; goal_after_tactic = false
+  ; show_coq_info_messages = false
   }
 
 let v = ref default


### PR DESCRIPTION
We stop displaying messages such as "Foo is defined" as feedback by default; users willing to see them can set the corresponding option.

Closes #108