### PR TITLE
[goals] Show goals on click (+ configuration options).

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@
  - Send `$/coq/fileProgress` progress notifications from server,
    similarly to what Lean does; display them in Code's right gutter
    (@ejgallego, #106, fixes #54)
+ - Show goals on click by default, allow users to configure the
+   behavior to follow cursor in different ways (@ejgallego, #116,
+   fixes #89)
 
 # coq-lsp 0.1.0: Memory
 -----------------------

--- a/editor/code/package.json
+++ b/editor/code/package.json
@@ -123,6 +123,13 @@
             "type": "boolean",
             "default": false,
             "description": "Show Coq's Info messages as diagnostics, such as 'foo has been defined.' and miscellaneous operational messages."
+          },
+          "coq-lsp.show_goals_on": {
+            "type": "number",
+            "default": 1,
+            "description": "When to show goals and information about the current cursor",
+            "enum": [0,1,2],
+            "enumItemLabels": ["Don't follow cursor", "Show on click", "Show on click and on cursor movement"]
           }
         }
       }

--- a/editor/code/src/goals.ts
+++ b/editor/code/src/goals.ts
@@ -1,5 +1,5 @@
 import { Webview, Position, Uri, WebviewPanel } from "vscode";
-import { RequestType } from "vscode-languageclient";
+import { RequestType, TextDocumentIdentifier, VersionedTextDocumentIdentifier } from "vscode-languageclient";
 import { LanguageClient } from "vscode-languageclient/node";
 
 interface Hyp {
@@ -11,7 +11,10 @@ interface Goal {
     hyps: Hyp[];
 }
 
-interface GoalRequest {}
+interface GoalRequest {
+    textDocument: TextDocumentIdentifier,
+    position: Position
+}
 
 // returns the HTML code of goals environment
 function getGoalsEnvContent(goals: Goal[]) {
@@ -88,7 +91,7 @@ class GoalView {
     // LSP Protocol extension for Goals
     sendGoalsRequest(uri: Uri, position: Position) {
         let doc = { uri: uri.toString() };
-        let cursor = { textDocument: doc, position: position };
+        let cursor : GoalRequest = { textDocument: doc, position: position };
         const req = new RequestType<GoalRequest, Goal[], void>("proof/goals");
         this.client.sendRequest(req, cursor).then(
             (goals) => this.display(goals),


### PR DESCRIPTION
We allow to show goals on click, on cursor movement, or on both. User-configurable.

Fixes #89