### PR TITLE
[error recovery] Allow to admit proofs on failed `Qed`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@
    command. The `show_notices_as_diagnostics` option allows to restore
    old behavior (@ejgallego, #128, fixes #125)
  - Print some more info about Coq workspace configuration (@ejgallego, #151)
+ - Admit failed `Qed` by default; allow users to configure it
+   (@ejgallego, #118, fixes #90)
 
 # coq-lsp 0.1.1: Location
 -------------------------

--- a/coq/state.mli
+++ b/coq/state.mli
@@ -5,10 +5,15 @@ val marshal_out : out_channel -> t -> unit
 val of_coq : Vernacstate.t -> t
 val to_coq : t -> Vernacstate.t
 val compare : t -> t -> int
+val equal : t -> t -> bool
+val hash : t -> int
 val mode : st:t -> Pvernac.proof_mode option
 val parsing : st:t -> Vernacstate.Parser.t
 val lemmas : st:t -> Vernacstate.LemmaStack.t option
 val in_state : st:t -> f:('a -> 'b) -> 'a -> 'b
 
-(* Error recovery *)
+(** Drop the proofs from the state *)
 val drop_proofs : st:t -> t
+
+(** Admit an ongoing proof *)
+val admit : st:t -> t

--- a/editor/code/package.json
+++ b/editor/code/package.json
@@ -143,6 +143,11 @@
               "Show on click",
               "Show on click and on cursor movement"
             ]
+          },
+          "coq-lsp.admit_on_bad_qed": {
+            "type": "boolean",
+            "default": true,
+            "description": "If a `Qed.` command fails, admit the proof automatically."
           }
         }
       }

--- a/editor/code/src/client.ts
+++ b/editor/code/src/client.ts
@@ -8,6 +8,7 @@ import {
   Uri,
   TextEditor,
   OverviewRulerLane,
+  WorkspaceConfiguration,
 } from "vscode";
 import * as vscode from "vscode";
 import { Range } from "vscode-languageclient";
@@ -32,10 +33,14 @@ interface CoqLspServerConfig {
   ok_diagnostics: boolean;
   goal_after_tactic: boolean;
   show_coq_info_messages: boolean;
+  show_notices_as_diagnostics: boolean;
+  admit_on_bad_qed: boolean;
 }
+
 interface CoqLspClientConfig {
   show_goals_on: ShowGoalsOnCursorChange;
 }
+
 let config: CoqLspClientConfig;
 let client: LanguageClient;
 let goalPanel: GoalPanel | null;
@@ -71,6 +76,8 @@ export function activate(context: ExtensionContext): void {
       if (goalPanel) goalPanel.dispose();
     }
 
+    // EJGA: didn't find a way to make CoqLspConfig a subclass of WorkspaceConfiguration
+    // despite that class being open. Would be nice to avoid this copy indeed.
     const wsConfig = workspace.getConfiguration("coq-lsp");
     config = { show_goals_on: wsConfig.show_goals_on };
     const initializationOptions: CoqLspServerConfig = {
@@ -79,6 +86,8 @@ export function activate(context: ExtensionContext): void {
       ok_diagnostics: wsConfig.ok_diagnostics,
       goal_after_tactic: wsConfig.goal_after_tactic,
       show_coq_info_messages: wsConfig.show_coq_info_messages,
+      show_notices_as_diagnostics: wsConfig.show_notices_as_diagnostics,
+      admit_on_bad_qed: wsConfig.admit_on_bad_qed,
     };
 
     const clientOptions: LanguageClientOptions = {

--- a/fleche/config.ml
+++ b/fleche/config.ml
@@ -16,6 +16,11 @@ type t =
         (** Show `msg_info` messages in diagnostics *)
   ; show_notices_as_diagnostics : bool [@default false]
         (** Show `msg_notice` messages in diagnostics *)
+  ; admit_on_bad_qed : bool [@default true]
+        (** [admit_on_bad_qed] There are two possible error recovery strategies
+            when a [Qed] fails: one is not to add the constant to the state, the
+            other one is admit it. We find the second behavior more useful, but
+            YMMV. *)
   }
 
 let default =
@@ -27,6 +32,7 @@ let default =
   ; goal_after_tactic = false
   ; show_coq_info_messages = false
   ; show_notices_as_diagnostics = false
+  ; admit_on_bad_qed = true
   }
 
 let v = ref default

--- a/fleche/memo.ml
+++ b/fleche/memo.ml
@@ -148,6 +148,18 @@ let interp_command ~st ~fb_queue stm : _ Stats.t =
       let time = time_hash +. time_interp in
       Stats.make ~time res)
 
+module AC = Hashtbl.Make (Coq.State)
+
+let admit_cache = AC.create 1000
+
+let interp_admitted ~st =
+  match AC.find_opt admit_cache st with
+  | None ->
+    let admitted_st = Coq.State.admit ~st in
+    AC.add admit_cache st admitted_st;
+    admitted_st
+  | Some admitted_st -> admitted_st
+
 let mem_stats () = Obj.reachable_words (Obj.magic cache)
 
 let _hashtbl_out oc t =

--- a/fleche/memo.mli
+++ b/fleche/memo.mli
@@ -16,6 +16,7 @@ val interp_command :
   -> Coq.Ast.t
   -> Coq.State.t Coq.Interp.interp_result Stats.t
 
+val interp_admitted : st:Coq.State.t -> Coq.State.t
 val mem_stats : unit -> int
 val load_from_disk : file:string -> unit
 val save_to_disk : file:string -> unit


### PR DESCRIPTION
This can be pretty helpful in order to have a better development workflow.

We provide an option so the user can control it.

TODO: We need to better integrate error recovery with the Memo cache, as of now, we re-admit every time so memo won't see the state post-`Qed` is the same.

Fixes #90