### PR TITLE
[lsp] Only serve request when the document meta-data is up to date.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@
    goal list (@ejgallego, #115, fixes #109)
  - Resume checking from common prefix on document update (@ejgallego,
    #111, fixes #110)
+ - Cancel / reject requests that can be served due to document not
+   being processed sufficiently (@ejgallego, fixes #100)
 
 # coq-lsp 0.1.0: Memory
 -----------------------

--- a/fleche/info.ml
+++ b/fleche/info.ml
@@ -113,6 +113,7 @@ module type S = sig
 
   type ('a, 'r) query = doc:Doc.t -> point:P.t -> 'a -> 'r option
 
+  val node : (approx, Doc.node) query
   val loc : (approx, Loc.t) query
   val ast : (approx, Coq.Ast.t) query
   val goals : (approx, Coq.Goals.reified_pp) query
@@ -141,6 +142,8 @@ module Make (P : Point) : S with module P := P = struct
           else find (Some node) xs)
     in
     find None doc.Doc.nodes
+
+  let node = find
 
   let if_not_empty (pp : Pp.t) =
     if Pp.(repr pp = Ppcmd_empty) then None else Some pp

--- a/fleche/info.mli
+++ b/fleche/info.mli
@@ -44,6 +44,7 @@ module type S = sig
 
   type ('a, 'r) query = doc:Doc.t -> point:P.t -> 'a -> 'r option
 
+  val node : (approx, Doc.node) query
   val loc : (approx, Loc.t) query
   val ast : (approx, Coq.Ast.t) query
   val goals : (approx, Coq.Goals.reified_pp) query

--- a/lsp/base.ml
+++ b/lsp/base.ml
@@ -34,6 +34,13 @@ let _parse_uri str =
 let mk_reply ~id ~result =
   `Assoc [ ("jsonrpc", `String "2.0"); ("id", `Int id); ("result", result) ]
 
+let mk_request_error ~id ~code ~message =
+  `Assoc
+    [ ("jsonrpc", `String "2.0")
+    ; ("id", `Int id)
+    ; ("error", `Assoc [ ("code", `Int code); ("message", `String message) ])
+    ]
+
 let mk_notification ~method_ ~params =
   `Assoc
     [ ("jsonrpc", `String "2.0")

--- a/lsp/base.mli
+++ b/lsp/base.mli
@@ -24,6 +24,9 @@ val mk_notification :
 (** Answer to a request *)
 val mk_reply : id:int -> result:Yojson.Safe.t -> Yojson.Safe.t
 
+(** Fail a request *)
+val mk_request_error : id:int -> code:int -> message:string -> Yojson.Safe.t
+
 (* val mk_diagnostic : Range.t * int * string * unit option -> Yojson.Basic.t *)
 val mk_diagnostics :
      uri:string


### PR DESCRIPTION
In particular, for hover and goals we check we have reached the right position, for `documentSymbol` we wait for the document to be fully checked.

Fixes #100