### PR TITLE
[init] Check that the client and server version do match.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# coq-lsp 0.1.2:
+----------------
+
+ - Send an error to the client if the client and server versions don't
+   match (@ejgallego, #126)
+
 # coq-lsp 0.1.1: Location
 -------------------------
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ to stop by.
 ## Troubleshooting
 
 - Most problems can be resolved by restarting `coq-lsp`, in Visual Studio Code,
-  `Ctrl+Shift+P` will give you access to the `coq-lsp.restart` command. You can
-  also look for messages in the "Output" window in VSCode, "Coq LSP Server
-  Events" channel.
+  `Ctrl+Shift+P` will give you access to the `coq-lsp.restart` command.
+- In VSCode, the "Output" window will have a "Coq LSP Server Events"
+  channel which should contain some important information.
 
 ## Features
 

--- a/editor/code/CHANGELOG.md
+++ b/editor/code/CHANGELOG.md
@@ -1,3 +1,10 @@
+# coq-lsp 0.1.2:
+----------------
+
+- Requires coq-lsp server 0.1.2, see full changelog at
+  https://github.com/ejgallego/coq-lsp/releases/tag/0.1.2
+- Extension will now enforce that server has the correct version
+
 # coq-lsp 0.1.1: Location
 -------------------------
 

--- a/editor/code/src/client.ts
+++ b/editor/code/src/client.ts
@@ -12,7 +12,7 @@ import {
 } from "vscode";
 import * as vscode from "vscode";
 import { Range } from "vscode-languageclient";
-import { 
+import {
     LanguageClient,
     LanguageClientOptions,
     RevealOutputChannelOn,
@@ -26,15 +26,17 @@ enum ShowGoalsOnCursorChange {
     OnMouseAndKeyboard = 2
 };
 
-interface CoqLspConfig {
+interface CoqLspServerConfig {
+    client_version: string,
     eager_diagnostics: boolean,
     ok_diagnostics: boolean,
     goal_after_tactic: boolean,
-    show_coq_info_messages: boolean,
+    show_coq_info_messages: boolean
+}
+interface CoqLspClientConfig {
     show_goals_on : ShowGoalsOnCursorChange
 }
-
-let config : CoqLspConfig;
+let config : CoqLspClientConfig;
 let client: LanguageClient;
 let goalPanel: GoalPanel | null;
 
@@ -69,19 +71,21 @@ export function activate(context: ExtensionContext): void {
         window.showInformationMessage("Coq Language Server: starting");
 
         const wsConfig = workspace.getConfiguration("coq-lsp");
-        config = {
+        config = { show_goals_on: wsConfig.show_goals_on };
+        const initializationOptions : CoqLspServerConfig = {
+            client_version: context.extension.packageJSON.version,
             eager_diagnostics: wsConfig.eager_diagnostics,
             ok_diagnostics: wsConfig.ok_diagnostics,
             goal_after_tactic: wsConfig.goal_after_tactic,
-            show_coq_info_messages: wsConfig.show_coq_info_messages,
-            show_goals_on: wsConfig.show_goals_on
+            show_coq_info_messages: wsConfig.show_coq_info_messages
         };
 
         const clientOptions: LanguageClientOptions = {
             documentSelector: [{ scheme: "file", language: "coq" }],
             outputChannelName: "Coq LSP Server Events",
             revealOutputChannelOn: RevealOutputChannelOn.Info,
-            initializationOptions: config,
+            initializationOptions,
+            markdown: { isTrusted: true, supportHtml: true}
         };
         const serverOptions = { command: wsConfig.path, args: wsConfig.args };
 

--- a/fleche/config.ml
+++ b/fleche/config.ml
@@ -5,6 +5,7 @@ type t =
   ; gc_quick_stats : bool [@default true]
         (** [gc_quick_stats] Show the diff of [Gc.quick_stats] data for each
             sentence *)
+  ; client_version : string [@default "any"]
   ; eager_diagnostics : bool [@default true]
         (** [eager_diagnostics] Send (full) diagnostics after processing each *)
   ; ok_diagnostics : bool [@default false]  (** Show diagnostic for OK lines *)
@@ -18,6 +19,7 @@ type t =
 let default =
   { mem_stats = false
   ; gc_quick_stats = true
+  ; client_version = "any"
   ; eager_diagnostics = true
   ; ok_diagnostics = false
   ; goal_after_tactic = false


### PR DESCRIPTION
For now we don't keep backwards compatibility on the custom protocol stuff and options.