### PR TITLE
fleche, editor: strip Ok_diagnostic feature

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
    (@ejgallego, #350)
  - Auto-ignore Coq object files; can be disabled in config
    (@ejgallego, #365)
+ - Remove the Ok diagnostics setting (@artagnon, #129)
 
 # coq-lsp 0.1.5.1: Path
 -----------------------

--- a/editor/code/package.json
+++ b/editor/code/package.json
@@ -112,11 +112,6 @@
             "default": true,
             "description": "Send diagnostics as document is processed; if false, diagnostics are only sent when Coq finishes processing the file"
           },
-          "coq-lsp.ok_diagnostics": {
-            "type": "boolean",
-            "default": false,
-            "description": "Send a diagnostic for sentences that are Ok; this can choke vsCode easily due to too many diagnostics"
-          },
           "coq-lsp.show_coq_info_messages": {
             "type": "boolean",
             "default": false,

--- a/editor/code/src/config.ts
+++ b/editor/code/src/config.ts
@@ -3,7 +3,6 @@ import { ExtensionContext, workspace } from "vscode";
 export interface CoqLspServerConfig {
   client_version: string;
   eager_diagnostics: boolean;
-  ok_diagnostics: boolean;
   goal_after_tactic: boolean;
   show_coq_info_messages: boolean;
   show_notices_as_diagnostics: boolean;
@@ -22,7 +21,6 @@ export namespace CoqLspServerConfig {
     return {
       client_version: client_version,
       eager_diagnostics: wsConfig.eager_diagnostics,
-      ok_diagnostics: wsConfig.ok_diagnostics,
       goal_after_tactic: wsConfig.goal_after_tactic,
       show_coq_info_messages: wsConfig.show_coq_info_messages,
       show_notices_as_diagnostics: wsConfig.show_notices_as_diagnostics,

--- a/fleche/config.ml
+++ b/fleche/config.ml
@@ -16,7 +16,6 @@ type t =
   ; client_version : string [@default "any"]
   ; eager_diagnostics : bool [@default true]
         (** [eager_diagnostics] Send (full) diagnostics after processing each *)
-  ; ok_diagnostics : bool [@default false]  (** Show diagnostic for OK lines *)
   ; goal_after_tactic : bool [@default false]
         (** When showing goals and the cursor is in a tactic, if false, show
             goals before executing the tactic, if true, show goals after *)
@@ -44,7 +43,6 @@ let default =
   ; gc_quick_stats = true
   ; client_version = "any"
   ; eager_diagnostics = true
-  ; ok_diagnostics = false
   ; goal_after_tactic = false
   ; show_coq_info_messages = false
   ; show_notices_as_diagnostics = false

--- a/fleche/doc.ml
+++ b/fleche/doc.ml
@@ -544,12 +544,6 @@ let parsed_node ~range ~ast ~state ~parsing_diags ~parsing_feedback ~diags
   in
   { Node.range; ast = Some ast; diags; messages; state; info }
 
-let maybe_ok_diagnostics ~range =
-  if !Config.v.ok_diagnostics then
-    let ok_diag = Diags.make range 3 (Pp.str "OK") in
-    [ ok_diag ]
-  else []
-
 let strategy_of_coq_err ~node ~state ~last_tok = function
   | Coq.Protect.Error.Anomaly _ -> Stop (Failed last_tok, node)
   | User _ -> Continue { state; last_tok; node }
@@ -566,10 +560,9 @@ let node_of_coq_result ~doc ~range ~ast ~st ~parsing_diags ~parsing_feedback
     ~feedback ~info last_tok res =
   match res with
   | Ok { Coq.Interp.Info.res = state } ->
-    let ok_diags = maybe_ok_diagnostics ~range in
     let node =
-      parsed_node ~range ~ast ~state ~parsing_diags ~parsing_feedback
-        ~diags:ok_diags ~feedback ~info
+      parsed_node ~range ~ast ~state ~parsing_diags ~parsing_feedback ~diags:[]
+        ~feedback ~info
     in
     Continue { state; last_tok; node }
   | Error (Coq.Protect.Error.Anomaly (err_range, msg) as coq_err)


### PR DESCRIPTION
Since the introduction of #106, this feature is redundant, and only serves to choke up notifications in VSCode.