### PR TITLE
fleche: fix terminator tokens

### DIFF
--- a/fleche/doc.ml
+++ b/fleche/doc.ml
@@ -176,8 +176,7 @@ let parse_to_terminator : unit Pcoq.Entry.t =
   (* type 'a parser_fun = { parser_fun : te LStream.t -> 'a } *)
   let rec dot st =
     match Gramlib.LStream.next st with
-    | Tok.KEYWORD ("." | "..." | "Qed" | "Defined" | "Admitted") | Tok.BULLET _
-      -> ()
+    | Tok.KEYWORD ("." | "..." | "end" | "Qed" | "Defined" | "Admitted") -> ()
     | Tok.EOI -> ()
     | _ -> dot st
   in


### PR DESCRIPTION
Add "end", and remove "..." and BULLET.