### PR TITLE
vendor Coq-HoTT to demonstrate bugs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,6 @@
 	path = vendor/coq-serapi
 	url = https://github.com/ejgallego/coq-serapi.git
 	branch = v8.17
+[submodule "Coq-HoTT"]
+	path = Coq-HoTT
+	url = https://github.com/HoTT/Coq-HoTT.git


### PR DESCRIPTION
Vendoring Coq-HoTT and building doesn't seem to work with coq-lsp. I observe the following lacking behaviours:

- -noinit is not being passed
- -R/-Q flags are not being passed

This is probably something about _CoqProject not being read correctly.

Also I should note that Coq-HoTT is a Dune project, so ideally we should also be able to read Dune files too.

Signed-off-by: Ali Caglayan <alizter@gmail.com>

<!-- ps-id: 7c5ec9e6-f3d1-4c9a-bd08-cc3a440f54dc -->