### PR TITLE
[controller] Allow to postpone and cancel requests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,9 @@
  - `coq-lsp` will now warn the user when two files have been opened
    simultaneously and the parser may go into a broken state :/
    (@ejgallego #169)
+ - Implement request postponement and cancellation. Thus
+   `documentSymbols` will now be postponed until the document is
+   ready, (@ejgallego #141, #146, fixes #124)
 
 # coq-lsp 0.1.2: Message
 ------------------------

--- a/controller/doc_manager.mli
+++ b/controller/doc_manager.mli
@@ -17,9 +17,10 @@
 
 module Check : sig
   (** Check a document, or yield if there is none pending; it will send progress
-      and diagnostics notifications to [ofmt] *)
+      and diagnostics notifications to [ofmt]. Will return the list of requests
+      that are ready to execute. *)
   val check_or_yield :
-    Format.formatter -> fb_queue:Coq.Message.t list ref -> unit
+    Format.formatter -> fb_queue:Coq.Message.t list ref -> Int.Set.t
 end
 
 (** Create a document *)
@@ -41,3 +42,6 @@ exception AbortRequest
 
 (** [find_doc ~uri] , raises AbortRequest if [uri] is invalid *)
 val find_doc : uri:string -> Fleche.Doc.t
+
+(** Request support *)
+val serve_on_completion : uri:string -> id:int -> unit

--- a/controller/requests.ml
+++ b/controller/requests.ml
@@ -15,9 +15,7 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-type document_request =
-  uri:string -> doc:Fleche.Doc.t -> (Yojson.Safe.t, int * string) Result.t
-
+type document_request = uri:string -> doc:Fleche.Doc.t -> Yojson.Safe.t
 type position_request = doc:Fleche.Doc.t -> point:int * int -> Yojson.Safe.t
 
 module Util = struct
@@ -44,18 +42,10 @@ let _kind_of_type _tm = 13
    *) | _ -> 12 (* Function *) *)
 
 let symbols ~uri ~(doc : Fleche.Doc.t) =
-  match doc.completed with
-  | Yes _ ->
-    let f loc id = mk_syminfo uri (Names.Id.to_string id, "", 12, loc) in
-    let ast = Util.asts_of_doc doc in
-    let slist = Coq.Ast.grab_definitions f ast in
-    let result = `List slist in
-    Ok result
-  | Stopped _ | Failed _ ->
-    (* -32802 = RequestFailed | -32803 = ServerCancelled ; *)
-    let code = -32802 in
-    let message = "Document is not ready" in
-    Error (code, message)
+  let f loc id = mk_syminfo uri (Names.Id.to_string id, "", 12, loc) in
+  let ast = Util.asts_of_doc doc in
+  let slist = Coq.Ast.grab_definitions f ast in
+  `List slist
 
 let hover ~doc ~point =
   let show_loc_info = true in

--- a/controller/requests.mli
+++ b/controller/requests.mli
@@ -15,9 +15,7 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-type document_request =
-  uri:string -> doc:Fleche.Doc.t -> (Yojson.Safe.t, int * string) Result.t
-
+type document_request = uri:string -> doc:Fleche.Doc.t -> Yojson.Safe.t
 type position_request = doc:Fleche.Doc.t -> point:int * int -> Yojson.Safe.t
 
 val symbols : document_request


### PR DESCRIPTION
Some requests need to be delayed until the document is ready, such as
`documentSymbols`. In order to do this, we allow to postpone requests,
and `Doc_manager.check` will now return the list of requests pending
for a given document.

The implementation is lightweight and quite a prototype, but should
serve as a basis for more advanced stuff.

Closes #124.