### PR TITLE
[fleche] Protect Coq document creation

### DIFF
--- a/coq/protect.ml
+++ b/coq/protect.ml
@@ -1,13 +1,25 @@
-module R = struct
-  type 'a t =
-    | Completed of ('a, Loc.t option * Pp.t) result
-    | Interrupted (* signal sent, eval didn't complete *)
+module Error = struct
+  type t = Loc.t option * Pp.t
 end
 
-let map_loc ~f = function
-  | R.Completed (Error (loc, msg)) ->
-    R.Completed (Error (Option.map f loc, msg))
-  | res -> res
+module R = struct
+  type 'a t =
+    | Completed of ('a, Error.t) result
+    | Interrupted (* signal sent, eval didn't complete *)
+
+  let map ~f = function
+    | Completed (Result.Ok r) -> Completed (Result.Ok (f r))
+    | Completed (Result.Error r) -> Completed (Result.Error r)
+    | Interrupted -> Interrupted
+
+  let map_error ~f = function
+    | Completed (Error (loc, msg)) -> Completed (Error (f (loc, msg)))
+    | res -> res
+
+  let map_loc ~f =
+    let f (loc, msg) = (Option.map f loc, msg) in
+    map_error ~f
+end
 
 let eval ~f x =
   try

--- a/coq/protect.mli
+++ b/coq/protect.mli
@@ -1,11 +1,20 @@
-module R : sig
-  type 'a t =
-    | Completed of ('a, Loc.t option * Pp.t) result
-    | Interrupted (* signal sent, eval didn't complete *)
+module Error : sig
+  type t = Loc.t option * Pp.t
 end
 
-val eval : f:('i -> 'o) -> 'i -> 'o R.t
+module R : sig
+  type 'a t =
+    | Completed of ('a, Error.t) result
+    | Interrupted (* signal sent, eval didn't complete *)
 
-(** Update the loc stored in the result, this is used by our cache-aware
-    location *)
-val map_loc : f:(Loc.t -> Loc.t) -> 'a R.t -> 'a R.t
+  val map : f:('a -> 'b) -> 'a t -> 'b t
+  val map_error : f:(Error.t -> Error.t) -> 'a t -> 'a t
+
+  (** Update the loc stored in the result, this is used by our cache-aware
+      location *)
+  val map_loc : f:(Loc.t -> Loc.t) -> 'a t -> 'a t
+end
+
+(** Eval a function and reify the exceptions. Note [f] _must_ be pure, as in
+    case of anomaly [f] may be re-executed with debug options. *)
+val eval : f:('i -> 'o) -> 'i -> 'o R.t

--- a/fleche/doc.mli
+++ b/fleche/doc.mli
@@ -44,13 +44,14 @@ type t = private
   ; completed : Completion.t
   }
 
+(** Note, [create] is not cached in the Memo.t table *)
 val create :
      state:Coq.State.t
   -> workspace:Coq.Workspace.t
   -> uri:string
   -> version:int
   -> contents:string
-  -> t
+  -> t Coq.Protect.R.t
 
 val bump_version : version:int -> contents:string -> t -> t
 

--- a/fleche/memo.ml
+++ b/fleche/memo.ml
@@ -120,7 +120,7 @@ let loc_apply_offset
 let adjust_offset ~stm_loc ~cached_loc res =
   let offset = loc_offset cached_loc stm_loc in
   let f = loc_apply_offset offset in
-  Coq.Protect.map_loc ~f res
+  Coq.Protect.R.map_loc ~f res
 
 let interp_command ~st ~fb_queue stm : _ Stats.t =
   let stm_loc = Coq.Ast.loc stm |> Option.get in


### PR DESCRIPTION
`Coq.Init` will actually often `Require` Coq's prelude and perform arbitrary actions, we now reflect this on the type.

We still have a way to improve here, but for now the code is clear and the server should not crash anymore unless there is a real bug in `coq-lsp`.

Closes #91