### PR TITLE
[code] Allow goals to follow selection update by a command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,10 @@
    hardened against them (@ejgallego, #155, #157, #160, fixes #91)
  - `coq-lsp` now follows the LSP specification regarding
    initialization strictly (@ejgallego, #168)
+ - New setting for goals to be updated when the selection changes due
+   to a command; this makes VsCodeVim cursor tracking work; thanks to
+   Cactus (Anton) Golov for detailed bug reporting and testing
+   (@ejgallego, @jesyspa, #170, fixes #163)
 
 # coq-lsp 0.1.2: Message
 ------------------------

--- a/editor/code/package.json
+++ b/editor/code/package.json
@@ -136,12 +136,14 @@
             "enum": [
               0,
               1,
-              2
+              2,
+              3
             ],
             "enumItemLabels": [
               "Don't follow cursor",
               "Show on click",
-              "Show on click and on cursor movement"
+              "Show on click and on cursor movement",
+              "Show on click, cursor, and command movement"
             ]
           },
           "coq-lsp.admit_on_bad_qed": {

--- a/editor/code/src/client.ts
+++ b/editor/code/src/client.ts
@@ -25,6 +25,7 @@ enum ShowGoalsOnCursorChange {
   Never = 0,
   OnMouse = 1,
   OnMouseAndKeyboard = 2,
+  OnMouseKeyboardCommand = 3,
 }
 
 interface CoqLspServerConfig {
@@ -164,13 +165,15 @@ export function activate(context: ExtensionContext): void {
     (evt: vscode.TextEditorSelectionChangeEvent) => {
       if (evt.textEditor.document.languageId != "coq") return;
 
-      const show =
-        (evt.kind == vscode.TextEditorSelectionChangeKind.Keyboard &&
-          config.show_goals_on == ShowGoalsOnCursorChange.OnMouseAndKeyboard) ||
-        (evt.kind == vscode.TextEditorSelectionChangeKind.Mouse &&
-          (config.show_goals_on == ShowGoalsOnCursorChange.OnMouse ||
-            config.show_goals_on ==
-              ShowGoalsOnCursorChange.OnMouseAndKeyboard));
+      const kind =
+        evt.kind == vscode.TextEditorSelectionChangeKind.Mouse
+          ? 1
+          : evt.kind == vscode.TextEditorSelectionChangeKind.Keyboard
+          ? 2
+          : evt.kind
+          ? evt.kind
+          : 1000;
+      const show = kind <= config.show_goals_on;
 
       if (show) {
         goals(evt.textEditor);


### PR DESCRIPTION
Fixes #163

This makes VsCodeVim cursor tracking work; thanks to Cactus (Anton) Golov for detailed bug reporting and testing.