### PR TITLE
[info] Improve `documentSymbol` request to return extended info.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,13 @@
    (@ejgallego, #315, fixes #195)
  - Info protocol messages now have location and level
    (@ejgallego, #315)
+ - Warnings are not printed in the info view messages panel
+   (@ejgallego, #, fixes #195)
+ - Improved `documentSymbol` return type for newer `DocumentSymbol[]`
+   hierarchical symbol support. This means that sections and modules
+   will now be properly represented, as well as constructors for
+   inductive types, projections for records, etc...  (@ejgallego,
+   #174, fixes #121, #122)
 
 # coq-lsp 0.1.4: View
 ---------------------

--- a/controller/lsp_core.ml
+++ b/controller/lsp_core.ml
@@ -251,7 +251,7 @@ let do_document_request ~params ~handler =
   | Stopped _ | Failed _ | FailedPermanent _ ->
     Postpone (PendingRequest.DocRequest { uri; handler })
 
-let do_symbols = do_document_request ~handler:Requests.symbols
+let do_symbols = do_document_request ~handler:Rq_symbols.symbols
 
 let do_trace params =
   let trace = string_field "value" params in

--- a/controller/requests.ml
+++ b/controller/requests.ml
@@ -19,20 +19,3 @@ type document_request =
   lines:string Array.t -> doc:Fleche.Doc.t -> Yojson.Safe.t
 
 type position_request = doc:Fleche.Doc.t -> point:int * int -> Yojson.Safe.t
-
-open Lsp.JFleche
-
-let symbols ~lines ~(doc : Fleche.Doc.t) =
-  let uri = doc.uri in
-  let f loc id =
-    let name = Names.Id.to_string id in
-    let kind = 12 in
-    let location =
-      let range = Fleche.Coq_utils.to_range ~lines loc in
-      { Location.uri; range }
-    in
-    SymInfo.(to_yojson { name; kind; location })
-  in
-  let ast = Fleche.Doc.asts doc in
-  let slist = Coq.Ast.grab_definitions f ast in
-  `List slist

--- a/controller/requests.mli
+++ b/controller/requests.mli
@@ -19,5 +19,3 @@ type document_request =
   lines:string Array.t -> doc:Fleche.Doc.t -> Yojson.Safe.t
 
 type position_request = doc:Fleche.Doc.t -> point:int * int -> Yojson.Safe.t
-
-val symbols : document_request

--- a/controller/rq_symbols.ml
+++ b/controller/rq_symbols.ml
@@ -1,0 +1,38 @@
+(************************************************************************)
+(* Coq Language Server Protocol -- Requests                             *)
+(* Copyright 2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2019-2023 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
+(* Written by: Emilio J. Gallego Arias                                  *)
+(************************************************************************)
+
+let rec mk_syminfo ~lines info =
+  let Coq.Ast.Info.{ range; name; kind; detail; children } = info in
+  let range = Fleche.Coq_utils.to_range ~lines range in
+  let { CAst.loc = name_loc; v = name } = name in
+  let selectionRange = Fleche.Coq_utils.to_range ~lines (Option.get name_loc) in
+  let name = Names.Name.print name |> Pp.string_of_ppcmds in
+  let children = Option.map (List.map (mk_syminfo ~lines)) children in
+  Lsp.JFleche.DocumentSymbol.
+    { name
+    ; kind
+    ; detail
+    ; tags = None
+    ; deprecated = None
+    ; range
+    ; selectionRange
+    ; children
+    }
+
+let mk_syminfo ~lines info =
+  mk_syminfo ~lines info |> Lsp.JFleche.DocumentSymbol.to_yojson
+
+let definition_info (ast, st) = Coq.Ast.definition_info ~st ast
+
+let symbols ~lines ~(doc : Fleche.Doc.t) =
+  let definfo =
+    Fleche.Doc.asts_with_st doc
+    |> List.filter_map definition_info
+    |> List.concat
+  in
+  let result = List.map (mk_syminfo ~lines) definfo in
+  `List result

--- a/controller/rq_symbols.mli
+++ b/controller/rq_symbols.mli
@@ -1,0 +1,8 @@
+(************************************************************************)
+(* Coq Language Server Protocol -- Requests                             *)
+(* Copyright 2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2019-2023 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
+(* Written by: Emilio J. Gallego Arias                                  *)
+(************************************************************************)
+
+val symbols : Requests.document_request

--- a/coq/ast.mli
+++ b/coq/ast.mli
@@ -3,7 +3,21 @@ type t
 val loc : t -> Loc.t option
 val hash : t -> int
 val compare : t -> t -> int
-val grab_definitions : (Loc.t -> Names.Id.t -> 'a) -> t list -> 'a list
+
+(** Information about the Ast, to move to lang *)
+module Info : sig
+  type 'l t =
+    { range : 'l
+    ; name : Names.Name.t CAst.t
+    ; kind : int
+    ; detail : string option (* usually the type *)
+    ; children : 'l t list option
+    }
+end
+
+(** [definition_info ~st ast] Compute info about a possible definition in [ast],
+    we need [~st] to compute the type. *)
+val definition_info : st:State.t -> t -> Loc.t Info.t list option
 
 (** Printing *)
 val print : t -> Pp.t

--- a/examples/documentSymbol.v
+++ b/examples/documentSymbol.v
@@ -1,0 +1,45 @@
+Record a := {
+    proj1 : Type
+  ; proj2 : Type
+}.
+
+Inductive foo := A | B : a -> foo.
+
+Inductive eh1 := Ah1 : eh2 -> eh1
+with eh2 := Bh1 : eh1 -> eh2. 
+
+Variable (j : nat).
+
+Axiom test : False.
+
+Fixpoint f1 (n : nat) := match n with O => true | S n => f2 n end
+with f2 (n : nat) := match n with O => true | S n => f1 n end.
+
+Class EqBar := { wit : nat }.
+
+(* Fixme here, Instance is not recognized as a proof opener *)
+Instance foobar : EqBar.
+Admitted.
+
+Section Moo.
+
+    Variable (jj : nat).
+    Hypothesis (umm : Type).
+
+    Definition m1 := 3.
+
+    Theorem m2 : Type. Qed.
+
+End Moo.
+
+Module Bar.
+
+  Variable (u : nat).
+
+  Parameter (v : nat).
+
+  Definition k := 3.
+
+  Theorem not : False. Qed.
+
+End Bar.

--- a/examples/ex0.v
+++ b/examples/ex0.v
@@ -36,7 +36,7 @@ Definition hola := 3.
 
 Inductive event : Type :=
   | R of nat
-  | S of nat. 
+  | S of nat.  
 
 Record pair_emilio := {
   fst : nat;

--- a/fleche/doc.ml
+++ b/fleche/doc.ml
@@ -167,6 +167,7 @@ module Node = struct
   let diags { diags; _ } = diags
   let messages { messages; _ } = messages
   let info { info; _ } = info
+  let with_state f n = Option.map (fun x -> (x, n.state)) (f n)
 end
 
 module Completion = struct
@@ -204,6 +205,7 @@ let mk_doc root_state workspace uri =
   Coq.Init.doc_init ~root_state ~workspace ~uri
 
 let asts doc = List.filter_map Node.ast doc.nodes
+let asts_with_st doc = List.filter_map Node.(with_state ast) doc.nodes
 
 let init_fname ~uri =
   let file = Lang.LUri.File.to_string_file uri in

--- a/fleche/doc.mli
+++ b/fleche/doc.mli
@@ -65,6 +65,8 @@ type t = private
 (** Return the list of all asts in the doc *)
 val asts : t -> Coq.Ast.t list
 
+val asts_with_st : t -> (Coq.Ast.t * Coq.State.t) list
+
 (** Note, [create] calls Coq but it is not cached in the Memo.t table *)
 val create :
      state:Coq.State.t

--- a/lsp/jFleche.ml
+++ b/lsp/jFleche.ml
@@ -79,7 +79,7 @@ module GoalsAnswer = struct
     ; position : Lang.Point.t
     ; goals : string JCoq.Goals.reified_goal JCoq.Goals.goals option
     ; messages : string Message.t list
-    ; error : string option
+    ; error : string option [@default None]
     }
   [@@deriving to_yojson]
 end
@@ -92,6 +92,23 @@ let mk_goals ~uri ~version ~position ~goals ~messages ~error =
   GoalsAnswer.to_yojson
     { textDocument = { uri; version }; position; goals; messages; error }
 
+(** {1} DocumentSymbols *)
+
+module DocumentSymbol = struct
+  type t =
+    { name : string
+    ; detail : string option [@default None]
+    ; kind : int
+    ; tags : int list option [@default None]
+    ; deprecated : bool option [@default None]
+    ; range : Lang.Range.t
+    ; selectionRange : Lang.Range.t
+    ; children : t list option [@default None]
+    }
+  [@@deriving yojson]
+end
+
+(** Not used as of today, superseded by DocumentSymbol *)
 module Location = struct
   type t =
     { uri : Lang.LUri.File.t
@@ -100,6 +117,7 @@ module Location = struct
   [@@deriving yojson]
 end
 
+(** Not used as of today, superseded by DocumentSymbol *)
 module SymInfo = struct
   type t =
     { name : string
@@ -108,6 +126,8 @@ module SymInfo = struct
     }
   [@@deriving yojson]
 end
+
+(** {1} Hover *)
 
 module HoverContents = struct
   type t =
@@ -120,10 +140,12 @@ end
 module HoverInfo = struct
   type t =
     { contents : HoverContents.t
-    ; range : Lang.Range.t option
+    ; range : Lang.Range.t option [@default None]
     }
   [@@deriving yojson]
 end
+
+(** {1} Completion *)
 
 module LabelDetails = struct
   type t = { detail : string } [@@deriving yojson]
@@ -141,10 +163,10 @@ end
 module CompletionData = struct
   type t =
     { label : string
-    ; insertText : string option
-    ; labelDetails : LabelDetails.t option
-    ; textEdit : TextEditReplace.t option
-    ; commitCharacters : string list option
+    ; insertText : string option [@default None]
+    ; labelDetails : LabelDetails.t option [@default None]
+    ; textEdit : TextEditReplace.t option [@default None]
+    ; commitCharacters : string list option [@default None]
     }
   [@@deriving yojson]
 end

--- a/lsp/jFleche.mli
+++ b/lsp/jFleche.mli
@@ -39,7 +39,7 @@ module GoalsAnswer : sig
     ; position : Lang.Point.t
     ; goals : string JCoq.Goals.reified_goal JCoq.Goals.goals option
     ; messages : string Message.t list
-    ; error : string option
+    ; error : string option [@default None]
     }
   [@@deriving to_yojson]
 end
@@ -53,6 +53,23 @@ val mk_goals :
   -> error:Pp.t option
   -> Yojson.Safe.t
 
+(** {1 DocumentSymbols} *)
+
+module DocumentSymbol : sig
+  type t =
+    { name : string
+    ; detail : string option [@default None]
+    ; kind : int
+    ; tags : int list option [@default None]
+    ; deprecated : bool option [@default None]
+    ; range : Lang.Range.t
+    ; selectionRange : Lang.Range.t
+    ; children : t list option [@default None]
+    }
+  [@@deriving yojson]
+end
+
+(** Not used as of today, superseded by DocumentSymbol *)
 module Location : sig
   type t =
     { uri : Lang.LUri.File.t
@@ -61,6 +78,7 @@ module Location : sig
   [@@deriving yojson]
 end
 
+(** Not used as of today, superseded by DocumentSymbol *)
 module SymInfo : sig
   type t =
     { name : string
@@ -69,6 +87,8 @@ module SymInfo : sig
     }
   [@@deriving yojson]
 end
+
+(** {1 Hover} *)
 
 module HoverContents : sig
   type t =
@@ -81,10 +101,12 @@ end
 module HoverInfo : sig
   type t =
     { contents : HoverContents.t
-    ; range : Lang.Range.t option
+    ; range : Lang.Range.t option [@default None]
     }
   [@@deriving yojson]
 end
+
+(** {1 Completion} *)
 
 module LabelDetails : sig
   type t = { detail : string } [@@deriving yojson]
@@ -102,10 +124,10 @@ end
 module CompletionData : sig
   type t =
     { label : string
-    ; insertText : string option
-    ; labelDetails : LabelDetails.t option
-    ; textEdit : TextEditReplace.t option
-    ; commitCharacters : string list option
+    ; insertText : string option [@default None]
+    ; labelDetails : LabelDetails.t option [@default None]
+    ; textEdit : TextEditReplace.t option [@default None]
+    ; commitCharacters : string list option [@default None]
     }
   [@@deriving yojson]
 end


### PR DESCRIPTION
Fixes #121, #122

We improved `documentSymbol` return type for the newer `DocumentSymbol[]` hierarchical symbol support in recent LSP versions.

Sections and modules will now be properly represented, as well as constructors for inductive types, projections for records, etc...
