### PR TITLE
[controller] Postpone position requests until doc checking catches up.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,5 @@
-# coq-lsp 0.1.3: View
----------------------
+# coq-lsp 0.1.3: Event
+----------------------
 
  - Much improved handling of Coq fatal errors, the server is now
    hardened against them (@ejgallego, #155, #157, #160, fixes #91)
@@ -17,6 +17,11 @@
    ready, (@ejgallego, #141, #146, fixes #124)
  - Protocol and VS Code interfaces now support shelved and given_up
    goals (@ejgallego, #175)
+ - Allow to postpone requests to wait for data to become available on
+   document points; this is implemented to provide a nicer "show goals
+   while I type" experience. Client default has been changed to "show
+   goals on mouse, click, typing, and cursor movement) (@ejgallego,
+   #177, #179)
 
 # coq-lsp 0.1.2: Message
 ------------------------

--- a/controller/doc_manager.mli
+++ b/controller/doc_manager.mli
@@ -31,8 +31,8 @@ val create :
   -> version:int
   -> unit
 
-(** Update a document *)
-val change : uri:string -> version:int -> contents:string -> unit
+(** Update a document, returns the list of not valid requests *)
+val change : uri:string -> version:int -> contents:string -> Int.Set.t
 
 (** Close a document *)
 val close : uri:string -> unit
@@ -42,5 +42,10 @@ exception AbortRequest
 (** [find_doc ~uri] , raises AbortRequest if [uri] is invalid *)
 val find_doc : uri:string -> Fleche.Doc.t
 
-(** Request support *)
+(** Add a request to be served when the document is completed *)
 val serve_on_completion : uri:string -> id:int -> unit
+
+(** Add a request to be served when the document point data is available, for
+    now, we allow a single request like that. Maybe returns the id of the
+    previous request which should now be cancelled. *)
+val serve_if_point : uri:string -> id:int -> point:int * int -> int option

--- a/controller/requests.ml
+++ b/controller/requests.ml
@@ -15,7 +15,7 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-type document_request = uri:string -> doc:Fleche.Doc.t -> Yojson.Safe.t
+type document_request = doc:Fleche.Doc.t -> Yojson.Safe.t
 type position_request = doc:Fleche.Doc.t -> point:int * int -> Yojson.Safe.t
 
 module Util = struct
@@ -40,7 +40,8 @@ let _kind_of_type _tm = 13
    13 (* Variable *) | Type | Kind | Symb _ | _ when is_undef -> 14 (* Constant
    *) | _ -> 12 (* Function *) *)
 
-let symbols ~uri ~(doc : Fleche.Doc.t) =
+let symbols ~(doc : Fleche.Doc.t) =
+  let uri = doc.uri in
   let f loc id = mk_syminfo uri (Names.Id.to_string id, "", 12, loc) in
   let ast = Util.asts_of_doc doc in
   let slist = Coq.Ast.grab_definitions f ast in

--- a/controller/requests.mli
+++ b/controller/requests.mli
@@ -15,7 +15,7 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-type document_request = uri:string -> doc:Fleche.Doc.t -> Yojson.Safe.t
+type document_request = doc:Fleche.Doc.t -> Yojson.Safe.t
 type position_request = doc:Fleche.Doc.t -> point:int * int -> Yojson.Safe.t
 
 val symbols : document_request

--- a/editor/code/package.json
+++ b/editor/code/package.json
@@ -131,7 +131,7 @@
           },
           "coq-lsp.show_goals_on": {
             "type": "number",
-            "default": 1,
+            "default": 3,
             "description": "When to show goals and information about the current cursor",
             "enum": [
               0,

--- a/editor/code/src/client.ts
+++ b/editor/code/src/client.ts
@@ -155,9 +155,10 @@ export function activate(context: ExtensionContext): void {
   const goals = (editor: TextEditor) => {
     checkPanelAlive();
     let uri = editor.document.uri;
+    let version = editor.document.version;
     let position = editor.selection.active;
     if (goalPanel) {
-      goalPanel.update(uri, position);
+      goalPanel.update(uri, version, position);
     }
   };
 

--- a/editor/code/src/goals.ts
+++ b/editor/code/src/goals.ts
@@ -17,7 +17,7 @@ interface Goal {
 }
 
 interface GoalRequest {
-  textDocument: TextDocumentIdentifier;
+  textDocument: VersionedTextDocumentIdentifier;
   position: Position;
 }
 interface GoalConfig {
@@ -165,8 +165,8 @@ class GoalView {
     this.styleUri = styleUri;
   }
 
-  update(uri: Uri, position: Position) {
-    this.sendGoalsRequest(uri, position);
+  update(uri: Uri, version: number, position: Position) {
+    this.sendGoalsRequest(uri, version, position);
   }
 
   display(goals: GoalAnswer) {
@@ -174,8 +174,8 @@ class GoalView {
   }
 
   // LSP Protocol extension for Goals
-  sendGoalsRequest(uri: Uri, position: Position) {
-    let doc = { uri: uri.toString() };
+  sendGoalsRequest(uri: Uri, version: number, position: Position) {
+    let doc = { uri: uri.toString(), version };
     let cursor: GoalRequest = { textDocument: doc, position: position };
     const req = new RequestType<GoalRequest, GoalAnswer, void>("proof/goals");
     this.client.sendRequest(req, cursor).then(
@@ -195,8 +195,8 @@ export class GoalPanel {
     this.panel = panel;
     this.view = new GoalView(client, panel.webview, styleUri);
   }
-  update(uri: Uri, position: Position) {
-    this.view.update(uri, position);
+  update(uri: Uri, version: number, position: Position) {
+    this.view.update(uri, version, position);
   }
   dispose() {
     this.panel.dispose();

--- a/fleche/debug.ml
+++ b/fleche/debug.ml
@@ -22,3 +22,6 @@ let backtraces = false || all
 
 (* Sched wakeup *)
 let sched_wakeup = false || all
+
+(* Request event queue *)
+let request_delay = true || all

--- a/fleche/doc.mli
+++ b/fleche/doc.mli
@@ -48,7 +48,7 @@ type t = private
   { uri : string
   ; version : int
   ; contents : string
-  ; end_loc : int * int * int
+  ; end_loc : Types.Point.t
   ; root : Coq.State.t
   ; nodes : Node.t list
   ; diags_dirty : bool

--- a/lsp/base.ml
+++ b/lsp/base.ml
@@ -59,7 +59,7 @@ module Message = struct
         Request { id; method_; params })
       |> Result.ok
     with
-    | Not_found -> Error "missing parameter"
+    | Not_found -> Error ("missing parameter: " ^ J.to_string msg)
     | U.Type_error (msg, obj) ->
       Error (Format.asprintf "msg: %s; obj: %s" msg (J.to_string obj))
 


### PR DESCRIPTION
This provides a much nicer typing and navigation experience, basically if some data about the document is not ready, the request is postponed and will be served when such data becames available.

We also switch the default for the client as to show goals on typing / movement of the cursor. With the new delay capability, this gives the user usually what they want in terms of the goal panel being up-to-date.

Some notes:

- For now we only postpone goal requests, we should implement a proper queue (in next PRs). One pending goal request works pretty well for interactive use.

- `Doc.Target.t` can be more refined, as to support `Info.find` `Prev` behavior (but this is a bit complex due to the way both searches interact)