### PR TITLE
editor/code: scope keybinding alt+enter correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 ----------------------
 
  - Support for OCaml 4.11 (@ejgallego, #184)
- - The keybinding alt+enter in VSCode is now correctly scope
+ - The keybinding alt+enter in VSCode is now correctly scoped
    (@artagnon, #188)
 
 # coq-lsp 0.1.3: Event

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 ----------------------
 
  - Support for OCaml 4.11 (@ejgallego, #184)
+ - The keybinding alt+enter in VSCode is now correctly scope
+   (@artagnon, #188)
 
 # coq-lsp 0.1.3: Event
 ----------------------

--- a/editor/code/package.json
+++ b/editor/code/package.json
@@ -70,7 +70,7 @@
         "command": "coq-lsp.goals",
         "key": "alt+enter",
         "mac": "meta+enter",
-        "when": "editorFocus"
+        "when": "editorTextFocus && editorLangId == coq"
       }
     ],
     "configuration": [


### PR DESCRIPTION
The keybinding alt+enter is also used in find-and-replace, when the user wants to replace all instances. Before this change, the keybinding supplied by coq-lsp used to interfere. Moreover, the keybinding should be scoped for just the coq language.