### PR TITLE
[coq] [fleche] Unicode Support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,10 @@
-# coq-lsp 0.1.4:
-----------------------
+# coq-lsp 0.1.4: View
+---------------------
 
  - Support for OCaml 4.11 (@ejgallego, #184)
  - The keybinding alt+enter in VSCode is now correctly scoped
    (@artagnon, #188)
+ - Support Unicode files (@ejgallego, #200, fixes #193, fixes #197)
 
 # coq-lsp 0.1.3: Event
 ----------------------

--- a/controller/coq_lsp.ml
+++ b/controller/coq_lsp.ml
@@ -127,7 +127,7 @@ let do_initialize ~params =
     [ ("capabilities", `Assoc capabilities)
     ; ( "serverInfo"
       , `Assoc
-          [ ("name", `String "coq-lsp (C) Inria 2023")
+          [ ("name", `String "coq-lsp (C) Inria 2022-2023")
           ; ("version", `String Version.server)
           ] )
     ]
@@ -231,9 +231,7 @@ let do_position_request ~postpone ~params ~handler =
   let in_range =
     match doc.completed with
     | Yes _ -> true
-    | Failed loc | Stopped loc ->
-      let proc_line = loc.end_.line in
-      line < proc_line || (line = proc_line && col < loc.end_.character)
+    | Failed range | Stopped range -> Fleche.Doc.reached ~range (line, col)
   in
   let in_range =
     match version with

--- a/controller/doc_manager.ml
+++ b/controller/doc_manager.ml
@@ -106,8 +106,8 @@ module Handle = struct
         | None -> (handle, Int.Set.empty)
         | Some (id, (req_line, req_col)) ->
           (* XXX: Same code than in doc.ml *)
-          let stop_line = stop_loc.line_nb_last - 1 in
-          let stop_col = stop_loc.ep - stop_loc.bol_pos_last in
+          let stop_line = stop_loc.end_.line in
+          let stop_col = stop_loc.end_.character in
           if
             stop_line > req_line || (stop_line = req_line && stop_col >= req_col)
           then ({ handle with pt_request = None }, Int.Set.singleton id)

--- a/controller/doc_manager.ml
+++ b/controller/doc_manager.ml
@@ -100,17 +100,13 @@ module Handle = struct
       let pt_request = None in
       let cp_requests = Int.Set.empty in
       ({ handle with cp_requests; pt_request }, wake_up)
-    | Stopped stop_loc ->
+    | Stopped range ->
       let handle, pt_id =
         match handle.pt_request with
         | None -> (handle, Int.Set.empty)
         | Some (id, (req_line, req_col)) ->
-          (* XXX: Same code than in doc.ml *)
-          let stop_line = stop_loc.end_.line in
-          let stop_col = stop_loc.end_.character in
-          if
-            stop_line > req_line || (stop_line = req_line && stop_col >= req_col)
-          then ({ handle with pt_request = None }, Int.Set.singleton id)
+          if Fleche.Doc.reached ~range (req_line, req_col) then
+            ({ handle with pt_request = None }, Int.Set.singleton id)
           else (handle, Int.Set.empty)
       in
       (handle, pt_id)

--- a/coq/ast.ml
+++ b/coq/ast.ml
@@ -76,7 +76,7 @@ let grab_definitions f nodes =
 let marshal_in ic : t = Marshal.from_channel ic
 let marshal_out oc v = Marshal.to_channel oc v []
 
-let pr_loc ?(print_file = false) loc =
+let pp_loc ?(print_file = false) fmt loc =
   let open Loc in
   let file =
     if print_file then
@@ -85,7 +85,10 @@ let pr_loc ?(print_file = false) loc =
       | InFile { file; _ } -> "File \"" ^ file ^ "\""
     else "loc"
   in
-  Format.asprintf "%s: line: %d, col: %d -- line: %d, col: %d / {%d-%d}" file
+  Format.fprintf fmt "%s: line: %d, col: %d -- line: %d, col: %d / {%d-%d}" file
     (loc.line_nb - 1) (loc.bp - loc.bol_pos) (loc.line_nb_last - 1)
     (loc.ep - loc.bol_pos_last)
     loc.bp loc.ep
+
+let loc_to_string ?print_file loc =
+  Format.asprintf "%a" (pp_loc ?print_file) loc

--- a/coq/ast.mli
+++ b/coq/ast.mli
@@ -3,10 +3,20 @@ type t
 val loc : t -> Loc.t option
 val hash : t -> int
 val compare : t -> t -> int
-val to_coq : t -> Vernacexpr.vernac_control
-val of_coq : Vernacexpr.vernac_control -> t
-val print : t -> Pp.t
 val grab_definitions : (Loc.t -> Names.Id.t -> 'a) -> t list -> 'a list
+
+(** Printing *)
+val print : t -> Pp.t
+
+val pp_loc : ?print_file:bool -> Format.formatter -> Loc.t -> unit
+val loc_to_string : ?print_file:bool -> Loc.t -> string
+
+(** Unused for now *)
 val marshal_in : in_channel -> t
+
 val marshal_out : out_channel -> t -> unit
-val pr_loc : ?print_file:bool -> Loc.t -> string
+
+(** Internal, will go away once the [Lang.t] interface is ready *)
+val to_coq : t -> Vernacexpr.vernac_control
+
+val of_coq : Vernacexpr.vernac_control -> t

--- a/coq/init.mli
+++ b/coq/init.mli
@@ -33,4 +33,4 @@ val doc_init :
      root_state:State.t
   -> workspace:Workspace.t
   -> libname:Names.DirPath.t
-  -> State.t Protect.E.t
+  -> (State.t, Loc.t) Protect.E.t

--- a/coq/interp.ml
+++ b/coq/interp.ml
@@ -19,7 +19,7 @@ module Info = struct
   type 'a t = { res : 'a }
 end
 
-type 'a interp_result = 'a Info.t Protect.E.t
+type 'a interp_result = ('a Info.t, Loc.t) Protect.E.t
 
 let coq_interp ~st cmd =
   let st = State.to_coq st in

--- a/coq/interp.mli
+++ b/coq/interp.mli
@@ -19,6 +19,6 @@ module Info : sig
   type 'a t = { res : 'a }
 end
 
-type 'a interp_result = 'a Info.t Protect.E.t
+type 'a interp_result = ('a Info.t, Loc.t) Protect.E.t
 
 val interp : st:State.t -> Ast.t -> State.t interp_result

--- a/coq/message.ml
+++ b/coq/message.ml
@@ -1,4 +1,4 @@
 (** Messages from Coq *)
-type t = Loc.t option * int * Pp.t
+type 'l t = 'l option * int * Pp.t
 
 type coq = Feedback.feedback

--- a/coq/message.mli
+++ b/coq/message.mli
@@ -1,4 +1,4 @@
 (** Messages from Coq *)
-type t = Loc.t option * int * Pp.t
+type 'l t = 'l option * int * Pp.t
 
 type coq = Feedback.feedback

--- a/coq/parsing.mli
+++ b/coq/parsing.mli
@@ -5,5 +5,5 @@ module Parsable : sig
   val loc : t -> Loc.t
 end
 
-val parse : st:State.t -> Parsable.t -> Ast.t option Protect.E.t
+val parse : st:State.t -> Parsable.t -> (Ast.t option, Loc.t) Protect.E.t
 val discard_to_dot : Parsable.t -> unit

--- a/coq/print.mli
+++ b/coq/print.mli
@@ -3,4 +3,4 @@ val pr_letype_env :
   -> Environ.env
   -> Evd.evar_map
   -> EConstr.t
-  -> Pp.t Protect.E.t
+  -> (Pp.t, Loc.t) Protect.E.t

--- a/coq/state.mli
+++ b/coq/state.mli
@@ -17,7 +17,7 @@ val lemmas : st:t -> Proof.t option
 
 (** Execute a command in state [st]. Unfortunately this can produce anomalies as
     Coq state setting is imperative, so we need to wrap it in protect. *)
-val in_state : st:t -> f:('a -> 'b) -> 'a -> 'b Protect.E.t
+val in_state : st:t -> f:('a -> 'b) -> 'a -> ('b, Loc.t) Protect.E.t
 
 (** Drop the proofs from the state *)
 val drop_proofs : st:t -> t
@@ -25,8 +25,9 @@ val drop_proofs : st:t -> t
 (** Admit an ongoing proof *)
 val admit : st:t -> t
 
-(* Extra *)
+(** Extra / interanl *)
 val marshal_in : in_channel -> t
+
 val marshal_out : out_channel -> t -> unit
 val of_coq : Vernacstate.t -> t
 val to_coq : t -> Vernacstate.t

--- a/examples/unicode1.v
+++ b/examples/unicode1.v
@@ -1,0 +1,9 @@
+Axiom P : nat -> Prop.
+Axiom foo : forall {n}, P (S n) -> P n.
+Ltac foo := apply foo.
+Infix "⊆" := lt (at level 10).
+
+Goal forall Γ Δ, Γ ⊆ Δ -> P Γ.
+(* check goal is updated after the intros here properly *)
+intros Γ Δ s.
+foo.

--- a/fleche/coq_utils.ml
+++ b/fleche/coq_utils.ml
@@ -10,17 +10,29 @@
 
 (************************************************************************)
 (* Coq Language Server Protocol                                         *)
-(* Copyright 2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
-(* Copyright 2019-2023 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2022-2023 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-type document_request =
-  lines:string Array.t -> doc:Fleche.Doc.t -> Yojson.Safe.t
+let to_range ~lines (p : Loc.t) : Types.Range.t =
+  let Loc.{ line_nb; line_nb_last; bol_pos; bol_pos_last; bp; ep; _ } = p in
 
-type position_request = doc:Fleche.Doc.t -> point:int * int -> Yojson.Safe.t
+  let start_line = line_nb - 1 in
+  let end_line = line_nb_last - 1 in
 
-val symbols : document_request
-val hover : position_request
-val goals : position_request
-val completion : position_request
+  (* cols *)
+  let start_col = bp - bol_pos in
+  let end_col = ep - bol_pos_last in
+
+  let start_col =
+    Utf8.char_of_byte ~line:(Array.get lines start_line) ~byte:start_col
+  in
+  let end_col =
+    Utf8.char_of_byte ~line:(Array.get lines end_line) ~byte:end_col
+  in
+  Types.Range.
+    { start = { line = start_line; character = start_col; offset = bp }
+    ; end_ = { line = end_line; character = end_col; offset = ep }
+    }
+
+let to_orange ~lines = Option.map (to_range ~lines)

--- a/fleche/coq_utils.mli
+++ b/fleche/coq_utils.mli
@@ -10,17 +10,11 @@
 
 (************************************************************************)
 (* Coq Language Server Protocol                                         *)
-(* Copyright 2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
-(* Copyright 2019-2023 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2022-2023 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-type document_request =
-  lines:string Array.t -> doc:Fleche.Doc.t -> Yojson.Safe.t
+(** Specific to Coq *)
+val to_range : lines:string array -> Loc.t -> Types.Range.t
 
-type position_request = doc:Fleche.Doc.t -> point:int * int -> Yojson.Safe.t
-
-val symbols : document_request
-val hover : position_request
-val goals : position_request
-val completion : position_request
+val to_orange : lines:string array -> Loc.t option -> Types.Range.t option

--- a/fleche/debug.ml
+++ b/fleche/debug.ml
@@ -10,6 +10,7 @@ let cache = false || all
 (* LSP messages: Send and receive *)
 let send = false || all || lsp
 let read = false || all || lsp
+let lsp_init = false || all || lsp
 
 (* Parsing (this is a bit expensive as it will call the printer *)
 let parsing = false || all
@@ -19,6 +20,9 @@ let scan = false || all
 
 (* Backtraces *)
 let backtraces = false || all
+
+(* Unicode conversion *)
+let unicode = false || all
 
 (* Sched wakeup *)
 let sched_wakeup = false || all

--- a/fleche/doc.ml
+++ b/fleche/doc.ml
@@ -243,8 +243,7 @@ let process_init_feedback range state messages =
 let create ~state ~workspace ~uri ~version ~contents =
   let { Coq.Protect.E.r; feedback } = mk_doc state workspace in
   Coq.Protect.R.map r ~f:(fun root ->
-      Stats.reset ();
-      let stats = Stats.dump () in
+      let stats = Stats.zero () in
       let init_loc = init_loc ~uri in
       let contents = Contents.make ~uri ~raw:contents in
       let lines = contents.lines in

--- a/fleche/doc.ml
+++ b/fleche/doc.ml
@@ -562,17 +562,15 @@ module Target = struct
     | Position of int * int
 end
 
-let beyond_target (pos : Types.Range.t) target =
+let reached ~(range : Types.Range.t) (line, col) =
+  let reached_line = range.end_.line in
+  let reached_col = range.end_.character in
+  line < reached_line || (line = reached_line && col <= reached_col)
+
+let beyond_target (range : Types.Range.t) target =
   match target with
   | Target.End -> false
-  | Position (cut_line, cut_col) ->
-    (* This needs careful thinking as to help with the show goals postponement
-       case. *)
-    (* let pos_line = pos.line_nb_last - 1 in *)
-    (* let pos_col = pos.ep - pos.bol_pos_last in *)
-    let pos_line = pos.end_.line in
-    let pos_col = pos.end_.character in
-    pos_line > cut_line || (pos_line = cut_line && pos_col > cut_col)
+  | Position (cut_line, cut_col) -> reached ~range (cut_line, cut_col)
 
 let pr_target = function
   | Target.End -> "end"

--- a/fleche/doc.ml
+++ b/fleche/doc.ml
@@ -56,8 +56,8 @@ module Util = struct
     Io.Log.trace "cache" (Stats.to_string ());
     Io.Log.trace "cache" (Memo.CacheStats.stats ());
     (* this requires patches to Coq *)
-    (* Io.Log.error "coq parsing" (Cstats.dump ()); *)
-    (* Cstats.reset (); *)
+    (* Io.Log.error "coq parsing" (CoqParsingStats.dump ()); *)
+    (* CoqParsingStats.reset (); *)
     Memo.CacheStats.reset ();
     Stats.reset ()
 
@@ -122,8 +122,6 @@ module Node = struct
 
     let make ?(cache_hit = false) ~parsing_time ?time ~mw_prev ~mw_after () =
       { cache_hit; parsing_time; time; mw_prev; mw_after }
-
-    (* let { Gc.major_words = mw_after; _ } = Gc.quick_stat () in *)
 
     let pp_time fmt = function
       | None -> Format.fprintf fmt "N/A"

--- a/fleche/doc.ml
+++ b/fleche/doc.ml
@@ -15,31 +15,30 @@ module Util = struct
     | h :: _ -> h
 
   let mk_diag ?(extra = []) range severity message =
-    let range = Types.to_range range in
     let message = Pp.string_of_ppcmds message in
     Types.Diagnostic.{ range; severity; message; extra }
 
   (* ast-dependent error diagnostic generation *)
-  let mk_error_diagnostic ~loc ~msg ~ast =
+  let mk_error_diagnostic ~range ~msg ~ast =
     match (Coq.Ast.to_coq ast).v with
     | Vernacexpr.{ expr = VernacRequire (prefix, _export, module_refs); _ } ->
       let refs = List.map fst module_refs in
       let extra = [ Types.Diagnostic.Extra.FailedRequire { prefix; refs } ] in
-      mk_diag ~extra loc 1 msg
-    | _ -> mk_diag loc 1 msg
+      mk_diag ~extra range 1 msg
+    | _ -> mk_diag range 1 msg
 
-  let feed_to_diag ~loc (range, severity, message) =
-    let range = Option.default loc range in
+  let feed_to_diag ~drange (range, severity, message) =
+    let range = Option.default drange range in
     mk_diag range severity message
 
-  let diags_of_feedback ~loc fbs =
+  let diags_of_messages ~drange fbs =
     let diags, messages = List.partition (fun (_, lvl, _) -> lvl < 3) fbs in
     let diags =
       if !Config.v.show_notices_as_diagnostics then
         diags @ List.filter (fun (_, lvl, _) -> lvl = 3) fbs
       else diags
     in
-    (List.map (feed_to_diag ~loc) diags, messages)
+    (List.map (feed_to_diag ~drange) diags, messages)
 
   let build_span start_loc end_loc =
     Loc.
@@ -102,11 +101,11 @@ module DDebug = struct
     Io.Log.trace "coq"
       ("parsed sentence: " ^ line ^ Pp.string_of_ppcmds (Coq.Ast.print ast))
 
-  let resume last_tok version =
+  let resume (last_tok : Types.Range.t) version =
     Io.Log.trace "check"
       Format.(
-        asprintf "resuming [v: %d], from: %d l: %d" version last_tok.Loc.ep
-          (last_tok.Loc.line_nb_last - 1))
+        asprintf "resuming [v: %d], from: %d l: %d" version last_tok.end_.offset
+          last_tok.end_.line)
 end
 
 (* [node list] is a very crude form of a meta-data map "loc -> data" , where for
@@ -145,16 +144,23 @@ module Node = struct
       memo_info ^ "\n___\n" ^ mem_info
   end
 
+  module Message = struct
+    type t = Types.Range.t option * int * Pp.t
+
+    let feedback_to_message ~lines (loc, lvl, msg) =
+      (Coq_utils.to_orange ~lines loc, lvl, msg)
+  end
+
   type t =
-    { loc : Loc.t
+    { range : Types.Range.t
     ; ast : Coq.Ast.t option  (** Ast of node *)
     ; state : Coq.State.t  (** (Full) State of node *)
     ; diags : Types.Diagnostic.t list
-    ; messages : Coq.Message.t list
+    ; messages : Message.t list
     ; info : Info.t
     }
 
-  let loc { loc; _ } = loc
+  let range { range; _ } = range
   let ast { ast; _ } = ast
   let state { state; _ } = state
   let diags { diags; _ } = diags
@@ -174,18 +180,13 @@ module Contents = struct
     }
 
   let get_last_text text =
+    let offset = String.length text in
     let lines = CString.split_on_char '\n' text |> Array.of_list in
     let n_lines = Array.length lines in
     let last_line = if n_lines < 1 then "" else Array.get lines (n_lines - 1) in
-    (* let character = Types.char_of_byte ~line:last_line ~byte:(String.length
-       last_line) in *)
-    let character = String.length last_line in
-    ( Types.Point.
-        { line = Array.length lines - 1
-        ; character
-        ; offset = String.length text
-        }
-    , lines )
+    let last_line_col = String.length last_line in
+    let character = Utf8.char_of_byte ~line:last_line ~byte:last_line_col in
+    (Types.Point.{ line = n_lines - 1; character; offset }, lines)
 
   let make ~uri ~raw =
     let text = Util.process_contents ~uri ~contents:raw in
@@ -195,12 +196,17 @@ end
 
 module Completion = struct
   type t =
-    | Yes of Loc.t  (** Location of the last token in the document *)
-    | Stopped of Loc.t  (** Location of the last valid token *)
-    | Failed of Loc.t  (** Critical failure, like an anomaly *)
+    | Yes of Types.Range.t  (** Location of the last token in the document *)
+    | Stopped of Types.Range.t  (** Location of the last valid token *)
+    | Failed of Types.Range.t  (** Critical failure, like an anomaly *)
 
-  let loc = function
-    | Yes loc | Stopped loc | Failed loc -> loc
+  let range = function
+    | Yes range | Stopped range | Failed range -> range
+
+  let to_string = function
+    | Yes _ -> "fully checked"
+    | Stopped _ -> "stopped"
+    | Failed _ -> "failed"
 end
 
 (* Private. A doc is a list of nodes for now. The first element in the list is
@@ -222,15 +228,16 @@ let mk_doc root_state workspace =
   let libname = Names.(DirPath.make [ Id.of_string "foo" ]) in
   Coq.Init.doc_init ~root_state ~workspace ~libname
 
-let init_loc ~uri = Loc.initial (InFile { dirpath = None; file = uri })
+let init_fname ~uri = Loc.InFile { dirpath = None; file = uri }
+let init_loc ~uri = Loc.initial (init_fname ~uri)
 
-let process_init_feedback loc state feedback =
-  if not (CList.is_empty feedback) then
-    let diags, messages = Util.diags_of_feedback ~loc feedback in
+let process_init_feedback range state messages =
+  if not (CList.is_empty messages) then
+    let diags, messages = Util.diags_of_messages ~drange:range messages in
     let parsing_time = 0.0 in
     let { Gc.major_words = mw_prev; _ } = Gc.quick_stat () in
     let info = Node.Info.make ~parsing_time ~mw_prev ~mw_after:mw_prev () in
-    [ { Node.loc; ast = None; state; diags; messages; info } ]
+    [ { Node.range; ast = None; state; diags; messages; info } ]
   else []
 
 let create ~state ~workspace ~uri ~version ~contents =
@@ -239,36 +246,40 @@ let create ~state ~workspace ~uri ~version ~contents =
       Stats.reset ();
       let stats = Stats.dump () in
       let init_loc = init_loc ~uri in
-      let nodes = process_init_feedback init_loc root feedback in
-      let diags_dirty = not (CList.is_empty nodes) in
       let contents = Contents.make ~uri ~raw:contents in
+      let lines = contents.lines in
+      let init_range = Coq_utils.to_range ~lines init_loc in
+      let feedback =
+        List.map (Node.Message.feedback_to_message ~lines) feedback
+      in
+      let nodes = process_init_feedback init_range root feedback in
+      let diags_dirty = not (CList.is_empty nodes) in
       { uri
       ; contents
       ; version
       ; root
       ; nodes
       ; diags_dirty
-      ; completed = Stopped init_loc
+      ; completed = Stopped init_range
       ; stats
       })
 
-let recover_up_to_offset doc offset =
+let recover_up_to_offset ~init_range doc offset =
   Io.Log.trace "prefix"
     (Format.asprintf "common prefix offset found at %d" offset);
-  let rec find acc_nodes acc_loc nodes =
+  let rec find acc_nodes acc_range nodes =
     match nodes with
-    | [] -> (List.rev acc_nodes, acc_loc)
+    | [] -> (List.rev acc_nodes, acc_range)
     | n :: ns ->
       if Debug.scan then
         Io.Log.trace "scan"
-          (Format.asprintf "consider node at %s" (Coq.Ast.pr_loc n.Node.loc));
-      if n.loc.Loc.ep >= offset then (List.rev acc_nodes, acc_loc)
-      else find (n :: acc_nodes) n.loc ns
+          (Format.asprintf "consider node at %a" Types.Range.pp n.Node.range);
+      if n.range.end_.offset >= offset then (List.rev acc_nodes, acc_range)
+      else find (n :: acc_nodes) n.range ns
   in
-  let loc = init_loc ~uri:doc.uri in
-  find [] loc doc.nodes
+  find [] init_range doc.nodes
 
-let compute_common_prefix ~contents (prev : t) =
+let compute_common_prefix ~init_range ~contents (prev : t) =
   let s1 = prev.contents.raw in
   let l1 = prev.contents.last.offset in
   let s2 = contents.Contents.raw in
@@ -279,25 +290,30 @@ let compute_common_prefix ~contents (prev : t) =
     else i
   in
   let common_idx = match_or_stop 0 in
-  let nodes, loc = recover_up_to_offset prev common_idx in
-  Io.Log.trace "prefix" ("resuming from " ^ Coq.Ast.pr_loc loc);
-  let completed = Completion.Stopped loc in
+  let nodes, range = recover_up_to_offset ~init_range prev common_idx in
+  Io.Log.trace "prefix" ("resuming from " ^ Types.Range.to_string range);
+  let completed = Completion.Stopped range in
   (nodes, completed)
 
-let bump_version ~version ~contents doc =
+let bump_version ~init_range ~version ~contents doc =
   (* When a new document, we resume checking from a common prefix *)
-  let nodes, completed = compute_common_prefix ~contents doc in
-  (* uri, root, and stats remain the same, maybe stats should not *)
+  let nodes, completed = compute_common_prefix ~init_range ~contents doc in
+  (* uri, root_state, and stats remain the same, stats should not! *)
+  (* XXX: make the stats structure incremental *)
+  let stats = doc.stats in
   { doc with
     version
   ; nodes
   ; contents
   ; diags_dirty = true (* EJGA: Is it worth to optimize this? *)
   ; completed
+  ; stats
   }
 
 let bump_version ~version ~contents doc =
   let contents = Contents.make ~uri:doc.uri ~raw:contents in
+  let init_loc = init_loc ~uri:doc.uri in
+  let init_range = Coq_utils.to_range ~lines:contents.lines init_loc in
   match doc.completed with
   (* We can do better, but we need to handle the case where the anomaly is when
      restoring / executing the first sentence *)
@@ -307,9 +323,9 @@ let bump_version ~version ~contents doc =
     ; nodes = []
     ; contents
     ; diags_dirty = true
-    ; completed = Stopped (init_loc ~uri:doc.uri)
+    ; completed = Stopped init_range
     }
-  | Stopped _ | Yes _ -> bump_version ~version ~contents doc
+  | Stopped _ | Yes _ -> bump_version ~init_range ~version ~contents doc
 
 let add_node ~node doc =
   let diags_dirty = if node.Node.diags <> [] then true else doc.diags_dirty in
@@ -337,17 +353,12 @@ let set_stats ~stats doc = { doc with stats }
    As we are quite dynamic (for now) in terms of what we observe of the document
    (basically we observe it linearly), we must compute the final position with a
    bit of a hack. *)
-let compute_progress end_ last_done =
-  let start =
-    { Types.Point.line = last_done.Loc.line_nb_last - 1
-    ; character = last_done.ep - last_done.bol_pos_last
-    ; offset = last_done.ep
-    }
-  in
+let compute_progress end_ (last_done : Types.Range.t) =
+  let start = last_done.end_ in
   let range = Types.Range.{ start; end_ } in
   (range, 1)
 
-let report_progress ~doc last_tok =
+let report_progress ~doc (last_tok : Types.Range.t) =
   let progress = compute_progress doc.contents.last last_tok in
   Io.Report.fileProgress ~uri:doc.uri ~version:doc.version [ progress ]
 
@@ -362,16 +373,16 @@ let rec find_recovery_for_failed_qed ~default nodes =
   match nodes with
   | [] -> (default, None)
   | { Node.ast = None; _ } :: ns -> find_recovery_for_failed_qed ~default ns
-  | { ast = Some ast; state; loc; _ } :: ns -> (
+  | { ast = Some ast; state; range; _ } :: ns -> (
     match (Coq.Ast.to_coq ast).CAst.v.Vernacexpr.expr with
     | Vernacexpr.VernacStartTheoremProof _ -> (
       if !Config.v.admit_on_bad_qed then
         let state = Memo.interp_admitted ~st:state in
-        (state, Some loc)
+        (state, Some range)
       else
         match ns with
         | [] -> (default, None)
-        | n :: _ -> (n.state, Some n.loc))
+        | n :: _ -> (n.state, Some n.range))
     | _ -> find_recovery_for_failed_qed ~default ns)
 
 (* Simple heuristic for Qed. *)
@@ -379,8 +390,8 @@ let state_recovery_heuristic doc st v =
   match (Coq.Ast.to_coq v).CAst.v.Vernacexpr.expr with
   (* Drop the top proof state if we reach a faulty Qed. *)
   | Vernacexpr.VernacEndProof _ ->
-    let st, loc = find_recovery_for_failed_qed ~default:st doc.nodes in
-    let loc_msg = Option.cata Coq.Ast.pr_loc "no loc" loc in
+    let st, range = find_recovery_for_failed_qed ~default:st doc.nodes in
+    let loc_msg = Option.cata Types.Range.to_string "no loc" range in
     Io.Log.trace "recovery" (loc_msg ^ " " ^ Memo.input_info (v, st));
     st
   | _ -> st
@@ -399,13 +410,17 @@ let interp_and_info ~parsing_time ~st ast =
 
 type parse_action =
   | EOF of Completion.t (* completed *)
-  | Skip of Loc.t * Loc.t (* span of the skipped sentence + last valid token *)
+  | Skip of
+      Types.Range.t
+      * Types.Range.t (* span of the skipped sentence + last valid token *)
   | Process of Coq.Ast.t (* success! *)
 
 (* Returns parse_action, diags, parsing_time *)
-let parse_action ~st last_tok doc_handle =
+let parse_action ~lines ~st last_tok doc_handle =
   let start_loc = Coq.Parsing.Parsable.loc doc_handle |> CLexer.after in
-  let { Coq.Protect.E.r; feedback }, time = parse_stm ~st doc_handle in
+  let parse_res, time = parse_stm ~st doc_handle in
+  let f = Coq_utils.to_range ~lines in
+  let { Coq.Protect.E.r; feedback } = Coq.Protect.E.map_loc ~f parse_res in
   match r with
   | Coq.Protect.R.Interrupted -> (EOF (Stopped last_tok), [], feedback, time)
   | Coq.Protect.R.Completed res -> (
@@ -415,6 +430,7 @@ let parse_action ~st last_tok doc_handle =
          EOF, the below trick doesn't work. That will involved updating the type
          of `main_entry` *)
       let last_tok = Coq.Parsing.Parsable.loc doc_handle in
+      let last_tok = Coq_utils.to_range ~lines last_tok in
       (EOF (Yes last_tok), [], feedback, time)
     | Ok (Some ast) ->
       let () = if Debug.parsing then DDebug.parsed_sentence ~ast in
@@ -422,53 +438,57 @@ let parse_action ~st last_tok doc_handle =
     | Error (Anomaly (_, msg)) | Error (User (None, msg)) ->
       (* We don't have a better altenative :(, usually missing error loc here
          means an anomaly, so we stop *)
-      let err_loc = last_tok in
-      let parse_diags = [ Util.mk_diag err_loc 1 msg ] in
+      let err_range = last_tok in
+      let parse_diags = [ Util.mk_diag err_range 1 msg ] in
       (EOF (Failed last_tok), parse_diags, feedback, time)
-    | Error (User (Some err_loc, msg)) ->
-      let parse_diags = [ Util.mk_diag err_loc 1 msg ] in
+    | Error (User (Some err_range, msg)) ->
+      let parse_diags = [ Util.mk_diag err_range 1 msg ] in
       Coq.Parsing.discard_to_dot doc_handle;
       let last_tok = Coq.Parsing.Parsable.loc doc_handle in
+      let last_tok_range = Coq_utils.to_range ~lines last_tok in
       let span_loc = Util.build_span start_loc last_tok in
-      (Skip (span_loc, last_tok), parse_diags, feedback, time))
+      let span_range = Coq_utils.to_range ~lines span_loc in
+      (Skip (span_range, last_tok_range), parse_diags, feedback, time))
 
 (* Result of node-building action *)
 type document_action =
   | Stop of Completion.t * Node.t
   | Continue of
       { state : Coq.State.t
-      ; last_tok : Loc.t
+      ; last_tok : Types.Range.t
       ; node : Node.t
       }
-  | Interrupted of Loc.t
+  | Interrupted of Types.Range.t
 
-let unparseable_node ~loc ~parsing_diags ~parsing_feedback ~state ~parsing_time
-    =
-  let fb_diags, messages = Util.diags_of_feedback ~loc parsing_feedback in
+let unparseable_node ~range ~parsing_diags ~parsing_feedback ~state
+    ~parsing_time =
+  let fb_diags, messages =
+    Util.diags_of_messages ~drange:range parsing_feedback
+  in
   let diags = fb_diags @ parsing_diags in
   let { Gc.major_words = mw_prev; _ } = Gc.quick_stat () in
   let info = Node.Info.make ~parsing_time ~mw_prev ~mw_after:mw_prev () in
-  { Node.loc; ast = None; diags; messages; state; info }
+  { Node.range; ast = None; diags; messages; state; info }
 
-let assemble_diags ~loc ~parsing_diags ~parsing_feedback ~diags ~feedback =
+let assemble_diags ~range ~parsing_diags ~parsing_feedback ~diags ~feedback =
   let parsing_fb_diags, parsing_messages =
-    Util.diags_of_feedback ~loc parsing_feedback
+    Util.diags_of_messages ~drange:range parsing_feedback
   in
-  let fb_diags, fb_messages = Util.diags_of_feedback ~loc feedback in
+  let fb_diags, fb_messages = Util.diags_of_messages ~drange:range feedback in
   let diags = parsing_diags @ parsing_fb_diags @ fb_diags @ diags in
   let messages = parsing_messages @ fb_messages in
   (diags, messages)
 
-let parsed_node ~loc ~ast ~state ~parsing_diags ~parsing_feedback ~diags
+let parsed_node ~range ~ast ~state ~parsing_diags ~parsing_feedback ~diags
     ~feedback ~info =
   let diags, messages =
-    assemble_diags ~loc ~parsing_diags ~parsing_feedback ~diags ~feedback
+    assemble_diags ~range ~parsing_diags ~parsing_feedback ~diags ~feedback
   in
-  { Node.loc; ast = Some ast; diags; messages; state; info }
+  { Node.range; ast = Some ast; diags; messages; state; info }
 
-let maybe_ok_diagnostics ~loc =
+let maybe_ok_diagnostics ~range =
   if !Config.v.ok_diagnostics then
-    let ok_diag = Util.mk_diag loc 3 (Pp.str "OK") in
+    let ok_diag = Util.mk_diag range 3 (Pp.str "OK") in
     [ ok_diag ]
   else []
 
@@ -476,24 +496,23 @@ let strategy_of_coq_err ~node ~state ~last_tok = function
   | Coq.Protect.Error.Anomaly _ -> Stop (Failed last_tok, node)
   | User _ -> Continue { state; last_tok; node }
 
-let node_of_coq_result ~doc ~parsing_diags ~parsing_feedback ~ast ~st ~feedback
-    ~info last_tok res =
-  let ast_loc = Coq.Ast.loc ast |> Option.get in
+let node_of_coq_result ~doc ~range ~ast ~st ~parsing_diags ~parsing_feedback
+    ~feedback ~info last_tok res =
   match res with
   | Ok { Coq.Interp.Info.res = state } ->
-    let ok_diags = maybe_ok_diagnostics ~loc:ast_loc in
+    let ok_diags = maybe_ok_diagnostics ~range in
     let node =
-      parsed_node ~loc:ast_loc ~ast ~state ~parsing_diags ~parsing_feedback
+      parsed_node ~range ~ast ~state ~parsing_diags ~parsing_feedback
         ~diags:ok_diags ~feedback ~info
     in
     Continue { state; last_tok; node }
-  | Error (Coq.Protect.Error.Anomaly (err_loc, msg) as coq_err)
-  | Error (User (err_loc, msg) as coq_err) ->
-    let err_loc = Option.default ast_loc err_loc in
-    let err_diags = [ Util.mk_error_diagnostic ~loc:err_loc ~msg ~ast ] in
+  | Error (Coq.Protect.Error.Anomaly (err_range, msg) as coq_err)
+  | Error (User (err_range, msg) as coq_err) ->
+    let err_range = Option.default range err_range in
+    let err_diags = [ Util.mk_error_diagnostic ~range:err_range ~msg ~ast ] in
     let recovery_st = state_recovery_heuristic doc st ast in
     let node =
-      parsed_node ~loc:ast_loc ~ast ~state:recovery_st ~parsing_diags
+      parsed_node ~range ~ast ~state:recovery_st ~parsing_diags
         ~parsing_feedback ~diags:err_diags ~feedback ~info
     in
     strategy_of_coq_err ~node ~state:recovery_st ~last_tok coq_err
@@ -504,34 +523,38 @@ let document_action ~st ~parsing_diags ~parsing_feedback ~parsing_time ~doc
   match action with
   (* End of file *)
   | EOF completed ->
-    let loc = Completion.loc completed in
+    let range = Completion.range completed in
     let node =
-      unparseable_node ~loc ~parsing_diags ~parsing_feedback ~state:st
+      unparseable_node ~range ~parsing_diags ~parsing_feedback ~state:st
         ~parsing_time
     in
     Stop (completed, node)
   (* Parsing error *)
-  | Skip (span_loc, last_tok) ->
+  | Skip (span_range, last_tok) ->
     let node =
-      unparseable_node ~loc:span_loc ~parsing_diags ~parsing_feedback ~state:st
-        ~parsing_time
+      unparseable_node ~range:span_range ~parsing_diags ~parsing_feedback
+        ~state:st ~parsing_time
     in
     Continue { state = st; last_tok; node }
   (* We can interpret the command now *)
   | Process ast -> (
-    let { Coq.Protect.E.r; feedback }, info =
-      interp_and_info ~parsing_time ~st ast
-    in
+    let lines = doc.contents.lines in
+    let process_res, info = interp_and_info ~parsing_time ~st ast in
+    let f = Coq_utils.to_range ~lines in
+    let { Coq.Protect.E.r; feedback } = Coq.Protect.E.map_loc ~f process_res in
     match r with
     | Coq.Protect.R.Interrupted ->
       (* Exit *)
       Interrupted last_tok
     | Coq.Protect.R.Completed res ->
+      let ast_loc = Coq.Ast.loc ast |> Option.get in
+      let ast_range = Coq_utils.to_range ~lines ast_loc in
       (* The evaluation by Coq fully completed, then we can resume checking from
          this point then, hence the new last valid token last_tok_new *)
       let last_tok_new = Coq.Parsing.Parsable.loc doc_handle in
-      node_of_coq_result ~doc ~ast ~st ~parsing_diags ~parsing_feedback
-        ~feedback ~info last_tok_new res)
+      let last_tok_new = Coq_utils.to_range ~lines last_tok_new in
+      node_of_coq_result ~doc ~range:ast_range ~ast ~st ~parsing_diags
+        ~parsing_feedback ~feedback ~info last_tok_new res)
 
 module Target = struct
   type t =
@@ -539,14 +562,16 @@ module Target = struct
     | Position of int * int
 end
 
-let beyond_target pos target =
+let beyond_target (pos : Types.Range.t) target =
   match target with
   | Target.End -> false
   | Position (cut_line, cut_col) ->
     (* This needs careful thinking as to help with the show goals postponement
        case. *)
-    let pos_line = pos.Loc.line_nb_last - 1 in
-    let pos_col = Loc.(pos.ep - pos.bol_pos_last) in
+    (* let pos_line = pos.line_nb_last - 1 in *)
+    (* let pos_col = pos.ep - pos.bol_pos_last in *)
+    let pos_line = pos.end_.line in
+    let pos_col = pos.end_.character in
     pos_line > cut_line || (pos_line = cut_line && pos_col > cut_col)
 
 let pr_target = function
@@ -554,12 +579,13 @@ let pr_target = function
   | Target.Position (l, c) -> Format.asprintf "{cutpoint l: %02d | c: %02d" l c
 
 let log_beyond_target last_tok target =
-  Io.Log.trace "beyond_target" ("target reached " ^ Coq.Ast.pr_loc last_tok);
+  Io.Log.trace "beyond_target"
+    ("target reached " ^ Types.Range.to_string last_tok);
   Io.Log.trace "beyond_target" ("target is " ^ pr_target target)
 
 (* main interpretation loop *)
 let process_and_parse ~ofmt ~target ~uri ~version doc last_tok doc_handle =
-  let rec stm doc st last_tok =
+  let rec stm doc st (last_tok : Types.Range.t) =
     (* Reporting of progress and diagnostics (if dirty) *)
     let doc = send_eager_diagnostics ~ofmt ~uri ~version ~doc in
     report_progress ~ofmt ~doc last_tok;
@@ -568,15 +594,16 @@ let process_and_parse ~ofmt ~target ~uri ~version doc last_tok doc_handle =
       let () = log_beyond_target last_tok target in
       (* We set to Completed.Yes when we have reached the EOI *)
       let completed =
-        if last_tok.Loc.ep >= doc.contents.last.offset then
+        if last_tok.end_.offset >= doc.contents.last.offset then
           Completion.Yes last_tok
         else Completion.Stopped last_tok
       in
       set_completion ~completed doc
     else
       (* Parsing *)
+      let lines = doc.contents.lines in
       let action, parsing_diags, parsing_feedback, parsing_time =
-        parse_action ~st last_tok doc_handle
+        parse_action ~lines ~st last_tok doc_handle
       in
       (* Execution *)
       let action =
@@ -598,7 +625,8 @@ let process_and_parse ~ofmt ~target ~uri ~version doc last_tok doc_handle =
   (* Note that nodes and diags in reversed order here *)
   (match doc.nodes with
   | [] -> ()
-  | n :: _ -> Io.Log.trace "resume" ("last node :" ^ Coq.Ast.pr_loc n.loc));
+  | n :: _ ->
+    Io.Log.trace "resume" ("last node :" ^ Types.Range.to_string n.range));
   let st =
     Util.hd_opt ~default:doc.root
       (List.map (fun { Node.state; _ } -> state) doc.nodes)
@@ -613,21 +641,41 @@ let process_and_parse ~ofmt ~target ~uri ~version doc last_tok doc_handle =
 
 let log_doc_completion (completed : Completion.t) =
   let timestamp = Unix.gettimeofday () in
-  let loc, status =
-    match completed with
-    | Yes loc -> (loc, "fully checked")
-    | Stopped loc -> (loc, "stopped")
-    | Failed loc -> (loc, "failed")
-  in
-  Format.asprintf "done [%.2f]: document %s with pos %s" timestamp status
-    (Coq.Ast.pr_loc loc)
+  let range = Completion.range completed in
+  let status = Completion.to_string completed in
+  Format.asprintf "done [%.2f]: document %s with pos %a" timestamp status
+    Types.Range.pp range
   |> Io.Log.trace "check"
 
-let resume_check ~ofmt ~last_tok ~doc ~target =
+(* Rebuild a Coq loc from a range, this used to be done using [CLexer.after] but
+   due to Fleche now being 100% based on unicode locations we implement our
+   own *)
+let loc_after ~lines ~uri (r : Types.Range.t) =
+  let line_nb_last = r.end_.line + 1 in
+  let end_index =
+    let line = Array.get lines r.end_.line in
+    if Debug.unicode then
+      Io.Log.trace "loc_after"
+        (Format.asprintf "str: '%s' | char: %d" line r.end_.character);
+    Utf8.byte_of_char ~line ~char:r.end_.character
+  in
+  let bol_pos_last = r.end_.offset - end_index in
+  { Loc.fname = init_fname ~uri
+  ; line_nb = line_nb_last
+  ; bol_pos = bol_pos_last
+  ; line_nb_last
+  ; bol_pos_last
+  ; bp = r.end_.offset
+  ; ep = r.end_.offset
+  }
+
+(** Setup parser and call the main routine *)
+let resume_check ~ofmt ~(last_tok : Types.Range.t) ~doc ~target =
   let uri, version, contents = (doc.uri, doc.version, doc.contents) in
   (* Compute resume point, basically [CLexer.after] + stream setup *)
-  let resume_loc = CLexer.after last_tok in
-  let offset = resume_loc.bp in
+  let lines = doc.contents.lines in
+  let resume_loc = loc_after ~lines ~uri last_tok in
+  let offset = resume_loc.Loc.bp in
   let pcontent_len = contents.last.offset in
   match Util.safe_sub contents.text offset (pcontent_len - offset) with
   | None ->
@@ -641,6 +689,7 @@ let resume_check ~ofmt ~last_tok ~doc ~target =
     in
     process_and_parse ~ofmt ~target ~uri ~version doc last_tok handle
 
+(** Check a document, if it was not completed already *)
 let check ~ofmt ~target ~doc () =
   match doc.completed with
   | Yes _ ->

--- a/fleche/doc.mli
+++ b/fleche/doc.mli
@@ -106,3 +106,6 @@ end
 (** [check ofmt ~fb_queue ?cutpoint ~doc] if set, [cutpoint] will have Flèche
     stop after the point specified there has been reached. *)
 val check : ofmt:Format.formatter -> target:Target.t -> doc:t -> unit -> t
+
+(** Helper used to determine wakeup / postponement condictions wrt targets *)
+val reached : range:Types.Range.t -> int * int -> bool

--- a/fleche/doc.mli
+++ b/fleche/doc.mli
@@ -29,20 +29,24 @@ module Node : sig
     val print : stats:Stats.t -> t -> string
   end
 
+  module Message : sig
+    type t = Types.Range.t option * int * Pp.t
+  end
+
   type t = private
-    { loc : Loc.t
+    { range : Types.Range.t
     ; ast : Coq.Ast.t option  (** Ast of node *)
     ; state : Coq.State.t  (** (Full) State of node *)
     ; diags : Types.Diagnostic.t list  (** Diagnostics associated to the node *)
-    ; messages : Coq.Message.t list
+    ; messages : Message.t list
     ; info : Info.t
     }
 
-  val loc : t -> Loc.t
+  val range : t -> Types.Range.t
   val ast : t -> Coq.Ast.t option
   val state : t -> Coq.State.t
   val diags : t -> Types.Diagnostic.t list
-  val messages : t -> Coq.Message.t list
+  val messages : t -> Message.t list
   val info : t -> Info.t
 end
 
@@ -60,9 +64,9 @@ end
 
 module Completion : sig
   type t = private
-    | Yes of Loc.t  (** Location of the last token in the document *)
-    | Stopped of Loc.t  (** Location of the last valid token *)
-    | Failed of Loc.t  (** Critical failure, like an anomaly *)
+    | Yes of Types.Range.t  (** Location of the last token in the document *)
+    | Stopped of Types.Range.t  (** Location of the last valid token *)
+    | Failed of Types.Range.t  (** Critical failure, like an anomaly *)
 end
 
 (** A Flèche document is basically a [node list], which is a crude form of a
@@ -86,7 +90,7 @@ val create :
   -> uri:string
   -> version:int
   -> contents:string
-  -> t Coq.Protect.R.t
+  -> (t, Loc.t) Coq.Protect.R.t
 
 (** Update the contents of a document, updating the right structures for
     incremental checking. *)

--- a/fleche/info.ml
+++ b/fleche/info.ml
@@ -18,8 +18,8 @@
 module type Point = sig
   type t
 
-  val in_range : ?loc:Loc.t -> t -> bool
-  val gt_range : ?loc:Loc.t -> t -> bool
+  val in_range : ?range:Types.Range.t -> t -> bool
+  val gt_range : ?range:Types.Range.t -> t -> bool
 
   type offset_table = string
 
@@ -48,13 +48,12 @@ module LineCol : Point with type t = int * int = struct
   let to_string (l, c) = "(" ^ string_of_int l ^ "," ^ string_of_int c ^ ")"
   let debug_in_range = false
 
-  let in_range ?loc (line, col) =
+  let in_range ?range (line, col) =
     (* Coq starts at 1, lsp at 0 *)
-    match loc with
+    match range with
     | None -> false
-    | Some loc ->
-      let r = Types.to_range loc in
-      let line1 = r.start.line in
+    | Some r ->
+      let line1 = r.Types.Range.start.line in
       let col1 = r.start.character in
       let line2 = r.end_.line in
       let col2 = r.end_.character in
@@ -67,12 +66,11 @@ module LineCol : Point with type t = int * int = struct
       if line1 = line && line2 = line then col1 <= col && col < col2
       else (line1 = line && col1 <= col) || (line2 = line && col < col2)
 
-  let gt_range ?loc (line, col) =
-    match loc with
+  let gt_range ?range (line, col) =
+    match range with
     | None -> false
-    | Some loc ->
-      let r = Types.to_range loc in
-      let line1 = r.start.line in
+    | Some r ->
+      let line1 = r.Types.Range.start.line in
       let col1 = r.start.character in
       let line2 = r.end_.line in
       let col2 = r.end_.character in
@@ -87,15 +85,17 @@ module Offset : Point with type t = int = struct
   type t = int
   type offset_table = string
 
-  let in_range ?loc point =
-    match loc with
+  let in_range ?range point =
+    match range with
     | None -> false
-    | Some loc -> loc.Loc.bp <= point && point < loc.ep
+    | Some range ->
+      range.Types.Range.start.offset <= point
+      && point < range.Types.Range.end_.offset
 
-  let gt_range ?loc point =
-    match loc with
+  let gt_range ?range point =
+    match range with
     | None -> false
-    | Some loc -> point < loc.Loc.bp
+    | Some range -> point < range.Types.Range.start.offset
 
   let to_offset off _ = off
   let to_string off = string_of_int off
@@ -114,10 +114,10 @@ module type S = sig
   type ('a, 'r) query = doc:Doc.t -> point:P.t -> 'a -> 'r option
 
   val node : (approx, Doc.Node.t) query
-  val loc : (approx, Loc.t) query
+  val range : (approx, Types.Range.t) query
   val ast : (approx, Coq.Ast.t) query
   val goals : (approx, Coq.Goals.reified_pp) query
-  val messages : (approx, Coq.Message.t list) query
+  val messages : (approx, Doc.Node.Message.t list) query
   val info : (approx, Doc.Node.Info.t) query
   val completion : (string, string list) query
 end
@@ -133,13 +133,13 @@ module Make (P : Point) : S with module P := P = struct
       match l with
       | [] -> prev
       | node :: xs -> (
-        let loc = node.Doc.Node.loc in
+        let range = node.Doc.Node.range in
         match approx with
-        | Exact -> if P.in_range ~loc point then Some node else find None xs
+        | Exact -> if P.in_range ~range point then Some node else find None xs
         | PrevIfEmpty ->
-          if P.gt_range ~loc point then prev else find (Some node) xs
+          if P.gt_range ~range point then prev else find (Some node) xs
         | Prev ->
-          if P.gt_range ~loc point || P.in_range ~loc point then prev
+          if P.gt_range ~range point || P.in_range ~range point then prev
           else find (Some node) xs)
     in
     find None doc.Doc.nodes
@@ -160,9 +160,9 @@ module Make (P : Point) : S with module P := P = struct
     let lemmas = Coq.State.lemmas ~st in
     Option.map (Coq.Goals.reify ~ppx) lemmas
 
-  let loc ~doc ~point approx =
+  let range ~doc ~point approx =
     let node = find ~doc ~point approx in
-    Option.map Doc.Node.loc node
+    Option.map Doc.Node.range node
 
   let ast ~doc ~point approx =
     let node = find ~doc ~point approx in

--- a/fleche/info.ml
+++ b/fleche/info.ml
@@ -48,6 +48,12 @@ module LineCol : Point with type t = int * int = struct
   let to_string (l, c) = "(" ^ string_of_int l ^ "," ^ string_of_int c ^ ")"
   let debug_in_range = false
 
+  let debug_in_range hdr line col line1 col1 line2 col2 =
+    if debug_in_range then
+      Io.Log.trace hdr
+        (Format.asprintf "(%d, %d) in (%d,%d)-(%d,%d)" line col line1 col1 line2
+           col2)
+
   let in_range ?range (line, col) =
     (* Coq starts at 1, lsp at 0 *)
     match range with
@@ -57,10 +63,7 @@ module LineCol : Point with type t = int * int = struct
       let col1 = r.start.character in
       let line2 = r.end_.line in
       let col2 = r.end_.character in
-      if debug_in_range then
-        Io.Log.trace "in_range"
-          (Format.asprintf "(%d, %d) in (%d,%d)-(%d,%d)" line col line1 col1
-             line2 col2);
+      debug_in_range "in_range" line col line1 col1 line2 col2;
       (line1 < line && line < line2)
       ||
       if line1 = line && line2 = line then col1 <= col && col < col2
@@ -74,10 +77,7 @@ module LineCol : Point with type t = int * int = struct
       let col1 = r.start.character in
       let line2 = r.end_.line in
       let col2 = r.end_.character in
-      if debug_in_range then
-        Io.Log.trace "gt_range"
-          (Format.asprintf "(%d, %d) in (%d,%d)-(%d,%d)" line col line1 col1
-             line2 col2);
+      debug_in_range "gt_range" line col line1 col1 line2 col2;
       line < line1 || (line = line1 && col < col1)
 end
 

--- a/fleche/info.mli
+++ b/fleche/info.mli
@@ -19,8 +19,8 @@
 module type Point = sig
   type t
 
-  val in_range : ?loc:Loc.t -> t -> bool
-  val gt_range : ?loc:Loc.t -> t -> bool
+  val in_range : ?range:Types.Range.t -> t -> bool
+  val gt_range : ?range:Types.Range.t -> t -> bool
 
   (** [to_offset] will help to resolve a position from for example (line,col) to
       an offset, but in some case requires a lookup method. *)
@@ -45,10 +45,10 @@ module type S = sig
   type ('a, 'r) query = doc:Doc.t -> point:P.t -> 'a -> 'r option
 
   val node : (approx, Doc.Node.t) query
-  val loc : (approx, Loc.t) query
+  val range : (approx, Types.Range.t) query
   val ast : (approx, Coq.Ast.t) query
   val goals : (approx, Coq.Goals.reified_pp) query
-  val messages : (approx, Coq.Message.t list) query
+  val messages : (approx, Doc.Node.Message.t list) query
   val info : (approx, Doc.Node.Info.t) query
   val completion : (string, string list) query
 end

--- a/fleche/io.mli
+++ b/fleche/io.mli
@@ -24,7 +24,7 @@ module Log : sig
   val trace : string -> ?extra:string -> string -> unit
 
   (** For unexpected feedback *)
-  val feedback : Coq.Message.t list -> unit
+  val feedback : Loc.t Coq.Message.t list -> unit
 end
 
 module Report : sig

--- a/fleche/stats.ml
+++ b/fleche/stats.ml
@@ -19,6 +19,7 @@ let find kind = Hashtbl.find_opt stats kind |> Option.default 0.0
 
 type t = float * float * float
 
+let zero () = (0.0, 0.0, 0.0)
 let dump () = (find Kind.Hashing, find Kind.Parsing, find Kind.Exec)
 
 let restore (h, p, e) =

--- a/fleche/stats.mli
+++ b/fleche/stats.mli
@@ -13,6 +13,7 @@ val reset : unit -> unit
 
 type t
 
+val zero : unit -> t
 val dump : unit -> t
 val restore : t -> unit
 val get_f : t -> kind:Kind.t -> float

--- a/fleche/types.ml
+++ b/fleche/types.ml
@@ -22,6 +22,9 @@ module Point = struct
     ; character : int
     ; offset : int
     }
+
+  let pp fmt { line; character; offset } =
+    Format.fprintf fmt "{ l: %d, c: %d | o: %d }" line character offset
 end
 
 module Range = struct
@@ -29,6 +32,11 @@ module Range = struct
     { start : Point.t
     ; end_ : Point.t
     }
+
+  let pp fmt { start; end_ } =
+    Format.fprintf fmt "(@[%a@]--@[%a@])" Point.pp start Point.pp end_
+
+  let to_string r = Format.asprintf "%a" pp r
 end
 
 module Diagnostic = struct
@@ -47,16 +55,3 @@ module Diagnostic = struct
     ; extra : Extra.t list
     }
 end
-
-let to_range (p : Loc.t) : Range.t =
-  let Loc.{ line_nb; line_nb_last; bol_pos; bol_pos_last; bp; ep; _ } = p in
-  let start_line = line_nb - 1 in
-  let start_col = bp - bol_pos in
-  let end_line = line_nb_last - 1 in
-  let end_col = ep - bol_pos_last in
-  Range.
-    { start = { line = start_line; character = start_col; offset = bp }
-    ; end_ = { line = end_line; character = end_col; offset = ep }
-    }
-
-let to_orange = Option.map to_range

--- a/fleche/types.mli
+++ b/fleche/types.mli
@@ -25,6 +25,8 @@ module Point : sig
     ; character : int
     ; offset : int
     }
+
+  val pp : Format.formatter -> t -> unit
 end
 
 module Range : sig
@@ -32,6 +34,9 @@ module Range : sig
     { start : Point.t
     ; end_ : Point.t
     }
+
+  val pp : Format.formatter -> t -> unit
+  val to_string : t -> string
 end
 
 module Diagnostic : sig
@@ -50,8 +55,3 @@ module Diagnostic : sig
     ; extra : Extra.t list
     }
 end
-
-(** XXX specific to Coq *)
-val to_range : Loc.t -> Range.t
-
-val to_orange : Loc.t option -> Range.t option

--- a/fleche/utf8.ml
+++ b/fleche/utf8.ml
@@ -1,0 +1,64 @@
+(* utf8 utils, both Coq and Camomile have similar implementations, at some point
+   we should remove this but for now we keep it internal. For now we use the
+   Camomille functions *)
+
+type char = int
+type index = int
+
+(* Taken from camomille *)
+(* Copyright (C) 2002, 2003 Yamagata Yoriyuki.  *)
+let rec search_head s i =
+  if i >= String.length s then i
+  else
+    let n = Char.code (String.unsafe_get s i) in
+    if n < 0x80 || n >= 0xc2 then i else search_head s (i + 1)
+
+let next s i =
+  let n = Char.code s.[i] in
+  if n < 0x80 then i + 1
+  else if n < 0xc0 then search_head s (i + 1)
+  else if n <= 0xdf then i + 2
+  else if n <= 0xef then i + 3
+  else if n <= 0xf7 then i + 4
+  else if n <= 0xfb then i + 5
+  else if n <= 0xfd then i + 6
+  else invalid_arg "UTF8.next"
+
+let rec length_aux s c i =
+  if i >= String.length s then c
+  else
+    let n = Char.code (String.unsafe_get s i) in
+    let k =
+      if n < 0x80 then 1
+      else if n < 0xc0 then invalid_arg "UTF8.length"
+      else if n < 0xe0 then 2
+      else if n < 0xf0 then 3
+      else if n < 0xf8 then 4
+      else if n < 0xfc then 5
+      else if n < 0xfe then 6
+      else invalid_arg "UTF8.length"
+    in
+    length_aux s (c + 1) (i + k)
+
+let length s = length_aux s 0 0
+let rec nth_aux s i n = if n = 0 then i else nth_aux s (next s i) (n - 1)
+let nth s n = nth_aux s 0 n
+
+(* end of camomille *)
+let byte_of_char ~line ~char = nth line char
+
+let find_char line byte =
+  let rec f index n_chars =
+    let next_index = next line index in
+    if next_index > byte then n_chars else f next_index (n_chars + 1)
+  in
+  if String.length line <= byte then length line else f 0 0
+
+let char_of_byte ~line ~byte =
+  if Debug.unicode then
+    Io.Log.trace "get_last_text"
+      (Format.asprintf "str: '%s' | byte: %d" line byte);
+  let res = find_char line byte in
+  if Debug.unicode then
+    Io.Log.trace "get_last_text" (Format.asprintf "char: %d" res);
+  res

--- a/fleche/utf8.mli
+++ b/fleche/utf8.mli
@@ -1,0 +1,44 @@
+(* Copyright (C) 2002, 2003 Yamagata Yoriyuki. *)
+
+(* This library is free software; you can redistribute it and/or *)
+(* modify it under the terms of the GNU Lesser General Public License *)
+(* as published by the Free Software Foundation; either version 2 of *)
+(* the License, or (at your option) any later version. *)
+
+(* As a special exception to the GNU Library General Public License, you *)
+(* may link, statically or dynamically, a "work that uses this library" *)
+(* with a publicly distributed version of this library to produce an *)
+(* executable file containing portions of this library, and distribute *)
+(* that executable file under terms of your choice, without any of the *)
+(* additional requirements listed in clause 6 of the GNU Library General *)
+(* Public License. By "a publicly distributed version of this library", *)
+(* we mean either the unmodified Library as distributed by the authors, *)
+(* or a modified version of this library that is distributed under the *)
+(* conditions defined in clause 3 of the GNU Library General Public *)
+(* License. This exception does not however invalidate any other reasons *)
+(* why the executable file might be covered by the GNU Library General *)
+(* Public License . *)
+
+(* This library is distributed in the hope that it will be useful, *)
+(* but WITHOUT ANY WARRANTY; without even the implied warranty of *)
+(* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU *)
+(* Lesser General Public License for more details. *)
+
+(* You should have received a copy of the GNU Lesser General Public *)
+(* License along with this library; if not, write to the Free Software *)
+(* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 *)
+(* USA *)
+
+(* Taken from camomille *)
+
+(* utf8 utils, both Coq and Camomile have similar implementations, at some point
+   we should remove this but for now we keep it internal. For now we use the
+   Camomille functions *)
+
+type char = int
+type index = int
+
+(** Byte index to UTF-8 character position *)
+val char_of_byte : line:string -> byte:index -> char
+
+val byte_of_char : line:string -> char:char -> index


### PR DESCRIPTION
We enforce a stricter separation between `Range.t` and `Loc.t`, with
Flèche not using `Loc.t` anymore, and `Range.t` being in unicode
character positions.

To achieve this we need to convert all the positions coming from Coq;
we do this in a principled way, but the whole business is often
delicate.

As we keep a position per sentence, this implies a `O(n)` number of
conversions in total, where `n is the number of sentences; we could
optimize that to be lazy, but it is unlikely to show in profiles as
that is a pretty reasonably `O(.)` factor.

Fixes #193 , fixes #197 .
