### PR TITLE
[esbuild] Properly detect --watch --sourcemap=no and --minify parameters

### DIFF
--- a/editor/code/esbuild.mjs
+++ b/editor/code/esbuild.mjs
@@ -1,16 +1,40 @@
 #!/usr/bin/env node
-
+import process from "process";
 import * as esbuild from "esbuild";
+
+let watchConfig = (entry) => {
+  return {
+    onRebuild(error, result) {
+      console.log(`[watch] build started (rebuild for ${entry})`);
+      if (error) {
+        error.errors.forEach((error) =>
+          console.error(
+            `> ${error.location.file}:${error.location.line}:${error.location.column}: error: ${error.text}`
+          )
+        );
+      } else console.log(`[watch] build finished (rebuild for ${entry}`);
+    },
+  };
+};
+
+let watch = process.argv.includes("--watch") ? watchConfig : (entry) => false;
+let minify = process.argv.includes("--minify");
+let sourcemap = !process.argv.includes("--sourcemap=no");
 
 esbuild
   .build({
     entryPoints: ["./src/client.ts"],
     bundle: true,
-    sourcemap: true,
+    sourcemap: true && sourcemap,
     format: "cjs",
     platform: "node",
     external: ["vscode"],
     outfile: "out/src/client.js",
+    minify,
+    watch: watch("./src/client.ts"),
+  })
+  .then(() => {
+    console.log("[watch] build finished for ./src/client.ts");
   })
   .catch(() => process.exit(1));
 
@@ -18,8 +42,13 @@ esbuild
   .build({
     entryPoints: ["./view/infoview.ts"],
     bundle: true,
-    sourcemap: "inline",
+    sourcemap: "inline" && sourcemap,
     platform: "browser",
-    outfile: "view/out/index.js",
+    outfile: "out/view/index.js",
+    minify,
+    watch: watch("./view/infoview.ts"),
+  })
+  .then(() => {
+    console.log("[watch] build finished for ./view/infoview.ts");
   })
   .catch(() => process.exit(1));

--- a/editor/code/package.json
+++ b/editor/code/package.json
@@ -170,10 +170,10 @@
   },
   "main": "./out/src/client.js",
   "scripts": {
-    "vscode:prepublish": "npm run typecheck && npm run esbuild -- --minify",
+    "vscode:prepublish": "npm run typecheck && npm run esbuild -- --minify --sourcemap=no",
     "esbuild": "node esbuild.mjs",
     "typecheck": "tsc -b",
     "compile": "npm run esbuild",
-    "watch": "npm run esbuild --"
+    "watch": "npm run esbuild -- --watch"
   }
 }

--- a/editor/code/src/client.ts
+++ b/editor/code/src/client.ts
@@ -58,10 +58,10 @@ export function panelFactory(context: ExtensionContext) {
     goalPanel = null;
   });
   const styleUri = panel.webview.asWebviewUri(
-    Uri.joinPath(context.extensionUri, "view", "out", "index.css")
+    Uri.joinPath(context.extensionUri, "out", "view", "index.css")
   );
   const scriptUri = panel.webview.asWebviewUri(
-    Uri.joinPath(context.extensionUri, "view", "out", "index.js")
+    Uri.joinPath(context.extensionUri, "out", "view", "index.js")
   );
   return new GoalPanel(client, panel, styleUri, scriptUri);
 }


### PR DESCRIPTION
Otherwise it doesn't work. We configure our build setup for the esbuild VSCode matcher.

We also consolidate the output directory under `out`.

Fixes #203