### PR TITLE
[lsp] Remove noop --std argument.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@
  - The info view is now script enabled and does client-side
    rendering. It is also now bundled with esbuild as part of the build
    process (@artagnon, @ejgallego, #171)
+ - The no-op `--std` argument to the `coq-lsp` binary has been
+   removed, beware of your setup in the extension settings
+   (@ejgallego, #208)
 
 # coq-lsp 0.1.3: Event
 ----------------------

--- a/README.md
+++ b/README.md
@@ -204,9 +204,10 @@ Studio Code.
 
 ### Emacs
 
-You can use this mode with [eglot](https://joaotavora.github.io/eglot/) with
-`$path_to_server --std`. Note that `--std` is needed otherwise eglot may choke
-due to extra messages.
+You can use this mode with [eglot](https://joaotavora.github.io/eglot/).
+
+Note that `eglot` used to choke due to extra notifications that `coq-lsp` may
+send, please open an issue if that's the case.
 
 ### Roadmap
 

--- a/editor/code/package.json
+++ b/editor/code/package.json
@@ -99,9 +99,7 @@
             "items": {
               "type": "string"
             },
-            "default": [
-              "--std"
-            ],
+            "default": [],
             "description": "Arguments to the coq-lsp server"
           },
           "coq-lsp.eager_diagnostics": {

--- a/lsp/base.ml
+++ b/lsp/base.ml
@@ -19,10 +19,6 @@
 (* This file contains some coq-specific commands, we should instead
    functorialize it so we can share with other OCaml-specific tools *)
 
-(* Whether to send extended lsp messages *)
-let std_protocol = ref true
-let _mk_extra l = if !std_protocol then [] else l
-
 (* Ad-hoc parsing for file:///foo... *)
 let _parse_uri str =
   let l = String.length str - 7 in

--- a/lsp/base.mli
+++ b/lsp/base.mli
@@ -53,5 +53,3 @@ val mk_diagnostics :
   -> version:int
   -> (Fleche.Types.Range.t * int * string * unit option) list
   -> Yojson.Safe.t
-
-val std_protocol : bool ref


### PR DESCRIPTION
This argument was introduced very long time ago in the Lambdapi implementation as we were not fully LSP compliant, but now we are.

The argument itself has been disabled since a long time, and it misleading now; moreover we put it as default in `package.json`!!!