### PR TITLE
[build] [code] [ci] Check TS compilation on CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           node-version: 16
       - run: npm ci
-      - run: npm run compile
+      - run: npx --yes vsce ls
 
   fmt-ocamlfmt:
     name: Format with ocamlfmt

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ submodules-deinit:
 # Build the vscode extension
 .PHONY: extension
 extension:
-	cd editor/code && npm i && npm run compile
+	cd editor/code && npm i && npm run vscode:prepublish
 
 # Run prettier
 .PHONY: ts-fmt

--- a/editor/code/src/client.ts
+++ b/editor/code/src/client.ts
@@ -1,6 +1,7 @@
 import {
   window,
   commands,
+  extensions,
   ExtensionContext,
   workspace,
   ViewColumn,
@@ -82,7 +83,7 @@ export function activate(context: ExtensionContext): void {
     context.subscriptions.push(disposable);
   }
   function checkForVSCoq() {
-    let vscoq = vscode.extensions.getExtension("maximedenes.vscoq");
+    let vscoq = extensions.getExtension("maximedenes.vscoq");
     if (vscoq?.isActive) {
       window.showErrorMessage(
         "Coq LSP Extension: VSCoq extension has been detected, you need to deactivate it for coq-lsp to work properly.",


### PR DESCRIPTION
Recent changes to our setup meant that compile is not type checking anymore, thus CI didn't catch a type error that broke the extension.

We now test the release build in CI then, and maybe we could even compare the output of `ls` to a set of files, and add some more checks.

Thus, `make extension` is now really a "release" target.

(I don't want to make CI use `make`, but the default build driver for
 the VSCode marketplace)