### PR TITLE
change displayName to Coq LSP

### DIFF
--- a/editor/code/package.json
+++ b/editor/code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coq-lsp",
-  "displayName": "coq-lsp",
+  "displayName": "Coq LSP",
   "description": "Coq LSP provides native vsCode support for checking Coq proof documents",
   "version": "0.1.4",
   "contributors": [


### PR DESCRIPTION
This changes the settings entry of the extension from "coq-lsp" to "Coq LSP" which is how we describe the extension in vernacular language.