### PR TITLE
[doc manager] Remove [yield] from [Doc_manager.check]

### DIFF
--- a/controller/doc_manager.ml
+++ b/controller/doc_manager.ml
@@ -162,7 +162,7 @@ module Check = struct
     | Stopped _ -> false
 
   (* Notification handling; reply is optional / asynchronous *)
-  let check ofmt ~uri =
+  let check ~ofmt ~uri =
     LIO.trace "process_queue" "resuming document checking";
     match Handle.find_opt ~uri with
     | Some handle ->
@@ -177,13 +177,7 @@ module Check = struct
       LIO.trace "Check.check" ("file " ^ uri ^ " not available");
       Int.Set.empty
 
-  let check_or_yield ~ofmt =
-    match !pending with
-    | None ->
-      Thread.delay 0.1;
-      Int.Set.empty
-    | Some uri -> check ofmt ~uri
-
+  let maybe_check ~ofmt = Option.map (fun uri -> check ~ofmt ~uri) !pending
   let schedule ~uri = pending := Some uri
 end
 

--- a/controller/doc_manager.mli
+++ b/controller/doc_manager.mli
@@ -16,10 +16,10 @@
 (************************************************************************)
 
 module Check : sig
-  (** Check a document, or yield if there is none pending; it will send progress
-      and diagnostics notifications to [ofmt]. Will return the list of requests
-      that are ready to execute. *)
-  val check_or_yield : ofmt:Format.formatter -> Int.Set.t
+  (** Check pending documents, return [None] if there is none pending, or
+      [Some rqs] the list of requests ready to execute after the check. Sends
+      progress and diagnostics notifications to [ofmt]. *)
+  val maybe_check : ofmt:Format.formatter -> Int.Set.t option
 end
 
 (** Create a document *)


### PR DESCRIPTION
This will help to make this module independent of the particular event system chosen, that will help with the jsCoq port too.