### PR TITLE
[lsp] Cleanup LSP stuff, improve static typing.

### DIFF
--- a/controller/coq_lsp.ml
+++ b/controller/coq_lsp.ml
@@ -421,10 +421,11 @@ let lsp_cb =
     { trace = LIO.trace
     ; send_diagnostics =
         (fun ~ofmt ~uri ~version diags ->
-          Lsp_util.lsp_of_diags ~uri ~version diags |> Lsp.Io.send_json ofmt)
+          Lsp.JFleche.mk_diagnostics ~uri ~version diags
+          |> Lsp.Io.send_json ofmt)
     ; send_fileProgress =
         (fun ~ofmt ~uri ~version progress ->
-          Lsp_util.lsp_of_progress ~uri ~version progress
+          Lsp.JFleche.mk_progress ~uri ~version progress
           |> Lsp.Io.send_json ofmt)
     }
 

--- a/controller/doc_manager.ml
+++ b/controller/doc_manager.ml
@@ -144,7 +144,9 @@ let diags_of_doc doc =
 
 let send_diags ~ofmt ~doc =
   let diags = diags_of_doc doc in
-  let diags = Lsp_util.lsp_of_diags ~uri:doc.uri ~version:doc.version diags in
+  let diags =
+    Lsp.JFleche.mk_diagnostics ~uri:doc.uri ~version:doc.version diags
+  in
   LIO.send_json ofmt @@ diags
 
 module Check = struct

--- a/controller/dune
+++ b/controller/dune
@@ -1,8 +1,6 @@
 (executable
  (name coq_lsp)
- (modules version cache requests rq_init lsp_util doc_manager coq_lsp)
+ (modules version cache requests rq_init doc_manager coq_lsp)
  (public_name coq-lsp)
- (preprocess
-  (staged_pps ppx_import ppx_deriving_yojson))
  (link_flags -linkall)
  (libraries threads coq fleche lsp cmdliner))

--- a/controller/requests.ml
+++ b/controller/requests.ml
@@ -24,13 +24,14 @@ module Util = struct
   let asts_of_doc doc = List.filter_map Fleche.Doc.Node.ast doc.Fleche.Doc.nodes
 end
 
+let mk_range = Lsp.JFleche.Types.Range.to_yojson
+
 let mk_syminfo file (name, _path, kind, range) : Yojson.Safe.t =
   `Assoc
     [ ("name", `String name)
     ; ("kind", `Int kind)
     ; (* function *)
-      ( "location"
-      , `Assoc [ ("uri", `String file); ("range", Lsp.Base.mk_range range) ] )
+      ("location", `Assoc [ ("uri", `String file); ("range", mk_range range) ])
     ]
 
 let symbols ~lines ~(doc : Fleche.Doc.t) =
@@ -67,9 +68,7 @@ let hover ~doc ~point =
        , `Assoc
            [ ("kind", `String "markdown"); ("value", `String hover_string) ] )
      ]
-    @ Option.cata
-        (fun range -> [ ("range", Lsp.Base.mk_range range) ])
-        [] range_span)
+    @ Option.cata (fun range -> [ ("range", mk_range range) ]) [] range_span)
 
 (* Replace by ppx when we can print goals properly in the client *)
 let mko f b = Option.cata (fun b -> `String (f b)) `Null b

--- a/controller/rq_init.ml
+++ b/controller/rq_init.ml
@@ -20,14 +20,10 @@ let odict_field name dict =
     []
 
 (* Request Handling: The client expects a reply *)
-module CoqLspOption = struct
-  type t = [%import: Fleche.Config.t] [@@deriving yojson]
-end
-
 let do_client_options coq_lsp_options : unit =
   LIO.trace "init" "custom client options:";
   LIO.trace_object "init" (`Assoc coq_lsp_options);
-  match CoqLspOption.of_yojson (`Assoc coq_lsp_options) with
+  match Lsp.JFleche.Config.of_yojson (`Assoc coq_lsp_options) with
   | Ok v -> Fleche.Config.v := v
   | Error msg -> LIO.trace "CoqLspOption.of_yojson error: " msg
 

--- a/fleche/doc.ml
+++ b/fleche/doc.ml
@@ -14,7 +14,7 @@ module Util = struct
     | [] -> default
     | h :: _ -> h
 
-  let mk_diag ?(extra = []) range severity message =
+  let mk_diag ?extra range severity message =
     let message = Pp.string_of_ppcmds message in
     Types.Diagnostic.{ range; severity; message; extra }
 
@@ -23,8 +23,10 @@ module Util = struct
     match (Coq.Ast.to_coq ast).v with
     | Vernacexpr.{ expr = VernacRequire (prefix, _export, module_refs); _ } ->
       let refs = List.map fst module_refs in
-      let extra = [ Types.Diagnostic.Extra.FailedRequire { prefix; refs } ] in
-      mk_diag ~extra range 1 msg
+      let extra =
+        Some [ Types.Diagnostic.Extra.FailedRequire { prefix; refs } ]
+      in
+      mk_diag ?extra range 1 msg
     | _ -> mk_diag range 1 msg
 
   let feed_to_diag ~drange (range, severity, message) =
@@ -353,7 +355,7 @@ let set_stats ~stats doc = { doc with stats }
 let compute_progress end_ (last_done : Types.Range.t) =
   let start = last_done.end_ in
   let range = Types.Range.{ start; end_ } in
-  (range, 1)
+  { Progress.Info.range; kind = 1 }
 
 let report_progress ~doc (last_tok : Types.Range.t) =
   let progress = compute_progress doc.contents.last last_tok in

--- a/fleche/io.ml
+++ b/fleche/io.ml
@@ -11,7 +11,7 @@ module CallBack = struct
            ofmt:Format.formatter
         -> uri:string
         -> version:int
-        -> (Types.Range.t * int) list
+        -> Progress.Info.t list
         -> unit
     }
 

--- a/fleche/io.mli
+++ b/fleche/io.mli
@@ -13,7 +13,7 @@ module CallBack : sig
            ofmt:Format.formatter
         -> uri:string
         -> version:int
-        -> (Types.Range.t * int) list
+        -> Progress.Info.t list
         -> unit
     }
 
@@ -39,6 +39,6 @@ module Report : sig
        ofmt:Format.formatter
     -> uri:string
     -> version:int
-    -> (Types.Range.t * int) list
+    -> Progress.Info.t list
     -> unit
 end

--- a/fleche/progress.ml
+++ b/fleche/progress.ml
@@ -15,26 +15,10 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-module LSP = Lsp.Base
-
-let lsp_of_diags ~uri ~version diags =
-  List.map
-    (fun { Fleche.Types.Diagnostic.range; severity; message; extra = _ } ->
-      (range, severity, message, None))
-    diags
-  |> Lsp.Base.mk_diagnostics ~uri ~version
-
-let lsp_of_progress ~uri ~version progress =
-  let progress =
-    List.map
-      (fun (range, kind) ->
-        `Assoc [ ("range", LSP.mk_range range); ("kind", `Int kind) ])
-      progress
-  in
-  let params =
-    [ ( "textDocument"
-      , `Assoc [ ("uri", `String uri); ("version", `Int version) ] )
-    ; ("processing", `List progress)
-    ]
-  in
-  LSP.mk_notification ~method_:"$/coq/fileProgress" ~params
+module Info = struct
+  type t =
+    { range : Types.Range.t
+    ; kind : int
+    }
+  [@@deriving yojson]
+end

--- a/fleche/types.ml
+++ b/fleche/types.ml
@@ -52,6 +52,6 @@ module Diagnostic = struct
     { range : Range.t
     ; severity : int
     ; message : string
-    ; extra : Extra.t list
+    ; extra : Extra.t list option
     }
 end

--- a/fleche/types.mli
+++ b/fleche/types.mli
@@ -32,7 +32,7 @@ end
 module Range : sig
   type t =
     { start : Point.t
-    ; end_ : Point.t
+    ; end_ : Point.t [@key "end"]
     }
 
   val pp : Format.formatter -> t -> unit
@@ -52,6 +52,6 @@ module Diagnostic : sig
     { range : Range.t
     ; severity : int
     ; message : string
-    ; extra : Extra.t list
+    ; extra : Extra.t list option
     }
 end

--- a/lsp/base.ml
+++ b/lsp/base.ml
@@ -33,12 +33,12 @@ let dict_field name dict = U.to_assoc (List.assoc name dict)
 module Message = struct
   type t =
     | Notification of
-        { method_ : string
+        { method_ : string [@key "method"]
         ; params : (string * Yojson.Safe.t) list
         }
     | Request of
         { id : int
-        ; method_ : string
+        ; method_ : string [@key "method"]
         ; params : (string * Yojson.Safe.t) list
         }
 
@@ -80,48 +80,13 @@ let mk_notification ~method_ ~params =
   `Assoc
     [ ("jsonrpc", `String "2.0")
     ; ("method", `String method_)
-    ; ("params", `Assoc params)
+    ; ("params", params)
     ]
 
-(* let json_of_goal g = let pr_hyp (s,(_,t)) = `Assoc ["hname", `String s;
-   "htype", `String (Format.asprintf "%a" Print.pp_term (Bindlib.unbox t))] in
-   let open Proofs in let j_env = List.map pr_hyp g.g_hyps in `Assoc [ "gid",
-   `Int g.g_meta.meta_key ; "hyps", `List j_env ; "type", `String
-   (Format.asprintf "%a" Print.pp_term g.g_type)]
-
-   let json_of_thm thm = let open Proofs in match thm with | None -> `Null |
-   Some thm -> `Assoc [ "goals", `List List.(map json_of_goal thm.t_goals) ] *)
-
-let mk_range { Fleche.Types.Range.start; end_ } : J.t =
-  `Assoc
-    [ ( "start"
-      , `Assoc
-          [ ("line", `Int start.line); ("character", `Int start.character) ] )
-    ; ( "end"
-      , `Assoc [ ("line", `Int end_.line); ("character", `Int end_.character) ]
-      )
-    ]
-
-(* let mk_diagnostic ((p : Pos.pos), (lvl : int), (msg : string), (thm :
-   Proofs.theorem option)) : J.json = *)
-let mk_diagnostic
-    ( (r : Fleche.Types.Range.t)
-    , (lvl : int)
-    , (msg : string)
-    , (_thm : unit option) ) : J.t =
-  (* let goal = json_of_thm thm in *)
-  let range = mk_range r in
-  `Assoc
-    [ (* mk_extra ["goal_info", goal] @ *)
-      ("range", range)
-    ; ("severity", `Int lvl)
-    ; ("message", `String msg)
-    ]
-
-let mk_diagnostics ~uri ~version ld : J.t =
-  mk_notification ~method_:"textDocument/publishDiagnostics"
-    ~params:
-      [ ("uri", `String uri)
-      ; ("version", `Int version)
-      ; ("diagnostics", `List List.(map mk_diagnostic ld))
-      ]
+module VersionedTextDocument = struct
+  type t =
+    { uri : string
+    ; version : int
+    }
+  [@@deriving yojson]
+end

--- a/lsp/base.mli
+++ b/lsp/base.mli
@@ -11,7 +11,7 @@
 (************************************************************************)
 (* Coq Language Server Protocol                                         *)
 (* Copyright 2019 MINES ParisTech -- LGPL 2.1+                          *)
-(* Copyright 2019-2022 Inria -- LGPL 2.1+                               *)
+(* Copyright 2019-2023 Inria -- LGPL 2.1+                               *)
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
@@ -35,21 +35,19 @@ module Message : sig
   val params : t -> (string * Yojson.Safe.t) list
 end
 
-val mk_range : Fleche.Types.Range.t -> Yojson.Safe.t
+module VersionedTextDocument : sig
+  type t =
+    { uri : string
+    ; version : int
+    }
+  [@@deriving yojson]
+end
 
 (** Build notification *)
-val mk_notification :
-  method_:string -> params:(string * Yojson.Safe.t) list -> Yojson.Safe.t
+val mk_notification : method_:string -> params:Yojson.Safe.t -> Yojson.Safe.t
 
 (** Answer to a request *)
 val mk_reply : id:int -> result:Yojson.Safe.t -> Yojson.Safe.t
 
 (** Fail a request *)
 val mk_request_error : id:int -> code:int -> message:string -> Yojson.Safe.t
-
-(* val mk_diagnostic : Range.t * int * string * unit option -> Yojson.Basic.t *)
-val mk_diagnostics :
-     uri:string
-  -> version:int
-  -> (Fleche.Types.Range.t * int * string * unit option) list
-  -> Yojson.Safe.t

--- a/lsp/dune
+++ b/lsp/dune
@@ -1,4 +1,6 @@
 (library
  (name lsp)
  (public_name coq-lsp.lsp)
+ (preprocess
+  (staged_pps ppx_import ppx_deriving_yojson))
  (libraries fleche yojson threads))

--- a/lsp/io.ml
+++ b/lsp/io.ml
@@ -90,7 +90,7 @@ let set_trace_value value = trace_value := value
 
 let logMessage ~lvl ~message =
   let method_ = "window/logMessage" in
-  let params = [ ("type", `Int lvl); ("message", `String message) ] in
+  let params = `Assoc [ ("type", `Int lvl); ("message", `String message) ] in
   let msg = Base.mk_notification ~method_ ~params in
   send_json !oc msg
 
@@ -99,8 +99,8 @@ let logTrace ~message ~extra =
   let params =
     match (!trace_value, extra) with
     | Verbose, Some extra ->
-      [ ("message", `String message); ("verbose", `String extra) ]
-    | _, _ -> [ ("message", `String message) ]
+      `Assoc [ ("message", `String message); ("verbose", `String extra) ]
+    | _, _ -> `Assoc [ ("message", `String message) ]
   in
   Base.mk_notification ~method_ ~params |> send_json !oc
 

--- a/lsp/jFleche.ml
+++ b/lsp/jFleche.ml
@@ -1,0 +1,71 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(************************************************************************)
+(* Coq Language Server Protocol                                         *)
+(* Copyright 2019 MINES ParisTech -- LGPL 2.1+                          *)
+(* Copyright 2019-2023 Inria -- LGPL 2.1+                               *)
+(* Written by: Emilio J. Gallego Arias                                  *)
+(************************************************************************)
+
+module Config = struct
+  type t = [%import: Fleche.Config.t] [@@deriving yojson]
+end
+
+module Types = struct
+  module Point = struct
+    type t = [%import: Fleche.Types.Point.t] [@@deriving yojson]
+  end
+
+  module Range = struct
+    type t = [%import: Fleche.Types.Range.t] [@@deriving yojson]
+  end
+
+  module Diagnostic = struct
+    module Libnames = Serlib.Ser_libnames
+
+    module Extra = struct
+      type t = [%import: Fleche.Types.Diagnostic.Extra.t] [@@deriving yojson]
+    end
+
+    type t = [%import: Fleche.Types.Diagnostic.t] [@@deriving yojson]
+  end
+end
+
+module Progress = struct
+  module Info = struct
+    type t =
+      [%import:
+        (Fleche.Progress.Info.t[@with Fleche.Types.Range.t := Types.Range.t])]
+    [@@deriving yojson]
+  end
+
+  type t =
+    { textDocument : Base.VersionedTextDocument.t
+    ; processing : Info.t list
+    }
+  [@@deriving yojson]
+end
+
+let mk_diagnostics ~uri ~version ld : Yojson.Safe.t =
+  let diags = List.map Types.Diagnostic.to_yojson ld in
+  let params =
+    `Assoc
+      [ ("uri", `String uri)
+      ; ("version", `Int version)
+      ; ("diagnostics", `List diags)
+      ]
+  in
+  Base.mk_notification ~method_:"textDocument/publishDiagnostics" ~params
+
+let mk_progress ~uri ~version processing =
+  let textDocument = { Base.VersionedTextDocument.uri; version } in
+  let params = Progress.to_yojson { Progress.textDocument; processing } in
+  Base.mk_notification ~method_:"$/coq/fileProgress" ~params

--- a/lsp/jFleche.mli
+++ b/lsp/jFleche.mli
@@ -10,17 +10,23 @@
 
 (************************************************************************)
 (* Coq Language Server Protocol                                         *)
-(* Copyright 2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
-(* Copyright 2019-2023 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2019 MINES ParisTech -- LGPL 2.1+                          *)
+(* Copyright 2019-2023 Inria -- LGPL 2.1+                               *)
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-module ProgressInfo : sig
-  type t =
-    { range : Lsp.Base.range
-    ; kind : int
-    }
+module Config : sig
+  type t = Fleche.Config.t [@@deriving yojson]
 end
 
-val lsp_of_progress :
-  uri:string -> version:int -> ProgressInfo.t list -> Yojson.Safe.t
+module Types : sig
+  module Range : sig
+    type t = Fleche.Types.Range.t [@@deriving yojson]
+  end
+end
+
+val mk_diagnostics :
+  uri:string -> version:int -> Fleche.Types.Diagnostic.t list -> Yojson.Safe.t
+
+val mk_progress :
+  uri:string -> version:int -> Fleche.Progress.Info.t list -> Yojson.Safe.t


### PR DESCRIPTION
We can do much better, but we will need to introduce the Lang library first. For now, we remove the ppx yojson and import from the controller, and consolidate some types.

Attention to the `extra` stuff in diagnostics, we may need to reintroduce the --std flag.

cc: #2 