### PR TITLE
[doc] [completion] Improve UTF-8 and position validation

### DIFF
--- a/controller/rq_completion.ml
+++ b/controller/rq_completion.ml
@@ -62,23 +62,23 @@ let unicode_list point : Yojson.Safe.t list =
   (* Coq's CList.map is tail-recursive *)
   CList.map (mk_unicode_completion_item point) ulist
 
-let get_line_at_point ~(doc : Fleche.Doc.t) ~point =
-  (* Guard against bad line number *)
-  let line, _char = point in
-  let line = min line doc.contents.last.line in
-  let line = Array.get doc.contents.lines line in
-  if Fleche.Debug.completion then Lsp.Io.trace "completion" ("line: " ^ line);
-  line
+let validate_line ~(doc : Fleche.Doc.t) ~line =
+  if Array.length doc.contents.lines > line then
+    Some (Array.get doc.contents.lines line)
+  else None
+
+(* This returns a byte-based char offset for the line *)
+let validate_position ~doc ~point =
+  let line, char = point in
+  Option.bind (validate_line ~doc ~line) (fun line ->
+      Option.bind (Fleche.Utf8.index_of_char ~line ~char) (fun index ->
+          Some (String.get line index)))
 
 let get_char_at_point ~(doc : Fleche.Doc.t) ~point =
-  let _line, char = point in
-  if char >= 1 then (
-    let char = char - 1 in
-    let line = get_line_at_point ~doc ~point in
-    let index = Fleche.Utf8.byte_of_char ~line ~char in
-    if Fleche.Debug.completion then
-      Lsp.Io.trace "completion" ("index: " ^ string_of_int index);
-    Some (String.get line index))
+  let line, char = point in
+  if char >= 1 then
+    let point = (line, char - 1) in
+    validate_position ~doc ~point
   else (* Can't get previous char *)
     None
 

--- a/fleche/coq_utils.ml
+++ b/fleche/coq_utils.ml
@@ -14,6 +14,16 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
+(* We convert in case of failure to some default values *)
+
+let char_of_index ~lines ~line ~byte =
+  if line < Array.length lines then
+    let line = Array.get lines line in
+    match Utf8.char_of_index ~line ~byte with
+    | Some char -> char
+    | None -> Utf8.length line
+  else 0
+
 let to_range ~lines (p : Loc.t) : Types.Range.t =
   let Loc.{ line_nb; line_nb_last; bol_pos; bol_pos_last; bp; ep; _ } = p in
 
@@ -24,12 +34,8 @@ let to_range ~lines (p : Loc.t) : Types.Range.t =
   let start_col = bp - bol_pos in
   let end_col = ep - bol_pos_last in
 
-  let start_col =
-    Utf8.char_of_byte ~line:(Array.get lines start_line) ~byte:start_col
-  in
-  let end_col =
-    Utf8.char_of_byte ~line:(Array.get lines end_line) ~byte:end_col
-  in
+  let start_col = char_of_index ~lines ~line:start_line ~byte:start_col in
+  let end_col = char_of_index ~lines ~line:end_line ~byte:end_col in
   Types.Range.
     { start = { line = start_line; character = start_col; offset = bp }
     ; end_ = { line = end_line; character = end_col; offset = ep }

--- a/fleche/utf8.ml
+++ b/fleche/utf8.ml
@@ -48,22 +48,23 @@ let nth s n = nth_aux s 0 n
 
 (* That's a tricky one, if the char we are requesting is out of bounds, then we
    return the last index, 0 in the case line is empty. *)
-let byte_of_char ~line ~char =
-  let ll = length line in
-  if ll <= char then if ll = 0 then 0 else nth line ll - 1 else nth line char
+let index_of_char ~line ~char =
+  if char < length line then Some (nth line char) else None
 
 let find_char line byte =
   let rec f index n_chars =
     let next_index = next line index in
     if next_index > byte then n_chars else f next_index (n_chars + 1)
   in
-  if String.length line <= byte then length line else f 0 0
+  if byte < String.length line then Some (f 0 0) else None
 
-let char_of_byte ~line ~byte =
+let char_of_index ~line ~byte =
   if Debug.unicode then
-    Io.Log.trace "get_last_text"
+    Io.Log.trace "char_of_index"
       (Format.asprintf "str: '%s' | byte: %d" line byte);
-  let res = find_char line byte in
-  if Debug.unicode then
-    Io.Log.trace "get_last_text" (Format.asprintf "char: %d" res);
-  res
+  let char = find_char line byte in
+  (if Debug.unicode then
+   match char with
+   | None -> Io.Log.trace "get_last_text" "failed"
+   | Some char -> Io.Log.trace "get_last_text" (Format.asprintf "char: %d" char));
+  char

--- a/fleche/utf8.mli
+++ b/fleche/utf8.mli
@@ -39,7 +39,10 @@ type char = int
 type index = int
 
 (** Byte index to UTF-8 character position *)
-val char_of_byte : line:string -> byte:index -> char
+val char_of_index : line:string -> byte:index -> char option
 
 (** UTF-8 Char to byte index position *)
-val byte_of_char : line:string -> char:char -> index
+val index_of_char : line:string -> char:char -> index option
+
+(** Lenght in utf-8 chars *)
+val length : string -> char


### PR DESCRIPTION
We are now more strict, and require the [Utf8] clients to take an action when the conversion fails.

Usually clients doing the conversion for the range will want to select the total length (last character) whereas the clients trying to grab a character will want to abort whatever they are doing.

I have reviewed all such uses, and found a couple of errors.

This also fixes the bug with the `fileProgress` range due to the above.

Re Fixes #264