### PR TITLE
[lsp] Make sure ranges are serialized to LSP types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
    notification
  - Fix messages panel rendering after the port to React (@ejgallego,
    #272)
+ - Fix non-compliance with LSP range type due to extra `offset` field
+   (@ejgallego, #271)
 
 # coq-lsp 0.1.4: View
 ---------------------


### PR DESCRIPTION
As in diagnostics, LSP ranges don't include Flèche's offset field.

While this is not enforced in VS Code, we fix that to remain within the LSP standard.

This problem was introduced in #254