### PR TITLE
[fleche] [markdown] Require Coq markdown snippets to use ```coq

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
    (@ejgallego, #271)
  - The goal display now numbers goals starting with 1 instead of 0
    (@artagnon, #277)
+ - Markdown Coq code blocks now must specify "coq" as a language
+   (@ejgallego, #280)
 
 # coq-lsp 0.1.4: View
 ---------------------

--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ panel.
 
 ### Markdown support
 
-Open a markdown file with a `.mv` extension, `coq-lsp` will check the code
-parts! `coq-lsp` places human-friendly documents at the core of its design
-ideas.
+Open a markdown file with a `.mv` extension, `coq-lsp` will check the code parts
+that are enclosed into `coq` language blocks! `coq-lsp` places human-friendly
+documents at the core of its design ideas.
 
 <img alt="Coq + Markdown Editing" height="286px" src="etc/img/lsp-markdown.gif"/>
 

--- a/examples/lists.mv
+++ b/examples/lists.mv
@@ -4,12 +4,12 @@
 - Coq will recognize the code snippets as Coq
 - You will be able to save the document and link to other documents soon
 
-```
+```coq
 From Coq Require Import List.
 Import ListNotations.
 ```
 
-```
+```coq
 Lemma rev_snoc_cons A :
   forall (x : A) (l : list A), rev (l ++ [x]) = x :: rev l.
 Proof.
@@ -20,7 +20,7 @@ Qed.
 ```
 
 Try to update _above_ and **below**:
-```
+```coq
 Theorem rev_rev A : forall (l : list A), rev (rev l) = l.
 Proof.
   induction l.

--- a/fleche/doc.ml
+++ b/fleche/doc.ml
@@ -67,7 +67,9 @@ module Util = struct
     match l with
     | [] -> []
     | l :: ls ->
-      if String.equal "```" l then gen l :: md_map_lines (not coq) ls
+      (* opening vs closing a markdown block *)
+      let code_marker = if coq then "```" else "```coq" in
+      if String.equal code_marker l then gen l :: md_map_lines (not coq) ls
       else (if coq then l else gen l) :: md_map_lines coq ls
 
   let markdown_process text =

--- a/fleche/doc.mli
+++ b/fleche/doc.mli
@@ -42,10 +42,11 @@ end
 
 module Contents : sig
   type t = private
-    { raw : string  (** That's the original, unprocessed document text *)
+    { raw : string
+          (** That's the original, unprocessed document text, including markdown *)
     ; text : string
-          (** That's the text to be sent to the prover, already processed,
-              encoded in UTF-8 *)
+          (** That's the text to be sent to the prover, already processed, and
+              stripped from markdown, encoded in UTF-8 *)
     ; last : Types.Point.t
           (** Last point of [text], you can derive n_lines from here *)
     ; lines : string Array.t  (** [text] split in lines *)


### PR DESCRIPTION
This is needed for some multi-lang documents.