### PR TITLE
[goals] Adapt jsCoq goal printing code to VS Code / React

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,9 @@
    (@ejgallego, #313, fixes #187)
  - Display Coq info and debug messages in info panel (@ejgallego,
    #314, fixes #308)
+ - Goal display handles background goals better, showing preview,
+   goals stack, and focusing information (@ejgallego, #290, fixes
+   #288, based on jsCoq code by Shachar Itzhaky)
 
 # coq-lsp 0.1.4: View
 ---------------------

--- a/editor/code/views/info/CoqPp.tsx
+++ b/editor/code/views/info/CoqPp.tsx
@@ -1,3 +1,5 @@
+import "./media/coqpp.css";
+
 export function CoqPp({
   content,
   inline,
@@ -8,6 +10,6 @@ export function CoqPp({
   if (inline) {
     return <code style={{ whiteSpace: "pre" }}>{content}</code>;
   } else {
-    return <pre>{content}</pre>;
+    return <pre className="coqpp">{content}</pre>;
   }
 }

--- a/editor/code/views/info/Details.tsx
+++ b/editor/code/views/info/Details.tsx
@@ -1,13 +1,14 @@
-import { PropsWithChildren } from "react";
+import { PropsWithChildren, DetailsHTMLAttributes } from "react";
 
-export type DetailsP = PropsWithChildren<{
-  summary: React.ReactNode;
-  open?: boolean;
-}>;
+export type DetailsP = PropsWithChildren<
+  {
+    summary: React.ReactNode;
+  } & DetailsHTMLAttributes<HTMLDetailsElement>
+>;
 
-export function Details({ summary, open, children }: DetailsP) {
+export function Details({ summary, children, open, ...rest }: DetailsP) {
   return (
-    <details style={{ marginBottom: "1ex" }} open={open ?? true}>
+    <details style={{ marginBottom: "1ex" }} open={open ?? true} {...rest}>
       <summary>{summary}</summary>
       <div style={{ marginLeft: "1ex", marginBottom: "1ex" }}>{children}</div>
     </details>

--- a/editor/code/views/info/media/coqpp.css
+++ b/editor/code/views/info/media/coqpp.css
@@ -1,0 +1,3 @@
+pre.coqpp {
+  margin: 0;
+}

--- a/editor/code/views/info/media/goals.css
+++ b/editor/code/views/info/media/goals.css
@@ -1,30 +1,60 @@
-.hname {
-  color: var(--vscode-editorLineNumber-foreground);
+/* previously named .coq-env in jsCoq */
+.coq-goal-env hr {
+  margin: 0.5em 0;
+  border: 1px inset;
 }
 
-.htype {
-  color: var(--vscode-editor-foreground);
+.coq-hypothesis {
+  margin-bottom: 2px;
 }
 
-.numGoal {
-  color: var(--vscode-editorLineNumber-foreground);
+.coq-hypothesis > label {
+  font-weight: normal; /* override bootstrap */
+  margin: 0;
 }
 
-.goal {
-  color: var(--vscode-editor-foreground);
+.coq-hypothesis > label::after {
+  content: ",";
+  margin-right: 0.25em;
 }
 
-.sep,
-hr {
-  color: var(--vscode-editorRuler-foreground);
+.coq-hypothesis > label:last-of-type::after,
+.coq-hypothesis > span.def::after {
+  content: ":";
+  margin: 0 0.5em;
 }
 
-.goalDiv {
-  margin-left: 0.5ex;
-  margin-top: 0.5ex;
+.coq-hypothesis.coq-has-def > label:last-of-type::after {
+  content: ":=";
+  margin: 0 0.5em;
+  color: #777;
 }
 
-.goalsEnv {
-  margin-top: 1ex;
-  margin-bottom: 1ex;
+.coq-hypothesis > label ~ div {
+  display: inline-table; /* this is used to indent hypothesis at their labels */
+  table-layout: fixed;
+}
+
+p.num-goals,
+p.no-goals {
+  margin-top: 0.2em;
+  margin-bottom: 1em;
+  white-space: normal;
+}
+
+div.aside,
+p.aside {
+  white-space: normal;
+  color: #777;
+}
+
+p.num-goals + p.aside {
+  margin-top: -1em;
+  margin-bottom: 1em;
+}
+
+.coq-goal-env {
+  padding-top: 1ex;
+  padding-bottom: 1ex;
+  white-space: pre;
 }

--- a/examples/goals.v
+++ b/examples/goals.v
@@ -1,0 +1,16 @@
+Lemma foo (a b: nat): (1 = 1) /\ (21 = 21 /\ 22 = 22) /\ (3 = 3).
+Proof.
+pose (n := 3).
+split;[|split].
+- now reflexivity.
+- split.
+  + shelve.
+  + now admit.
+- now reflexivity.
+Qed.
+
+Lemma bar : nat.
+Proof.
+pose (a := 3).
+exact a.
+Qed.

--- a/lsp/jFleche.ml
+++ b/lsp/jFleche.ml
@@ -68,7 +68,7 @@ module GoalsAnswer = struct
     ; messages : string list
     ; error : string option
     }
-  [@@deriving yojson]
+  [@@deriving to_yojson]
 end
 
 let mk_goals ~uri ~version ~position ~goals ~messages ~error =

--- a/lsp/jFleche.mli
+++ b/lsp/jFleche.mli
@@ -33,7 +33,7 @@ module GoalsAnswer : sig
     ; messages : string list
     ; error : string option
     }
-  [@@deriving yojson]
+  [@@deriving to_yojson]
 end
 
 val mk_goals :


### PR DESCRIPTION
This is an adaptation to React of the jsCoq goal printing code, but
our current model is a bit different so actually the code is not the
same.

In particular, we display bullets goals, and a bunch of extra
information, including goal preview.

Fixes #288

This is inspired by code originally written by Shachar Itzhaky.
