### PR TITLE
[lsq_init] `rootPath` is optional, `rootUri` has precedence.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,10 @@
    (@ejgallego, #280)
  - Hypothesis with bodies are now correctly displayed (@ejgallego,
    #296, fixes #293, report by Ali Caglayan)
+ - `coq-lsp` incorrectly required the optional `rootPath`
+   initialization parameter, moreover it ignored `rootUri` if present
+   which goes against the LSP spec (@ejgallego, #295, report by Alex
+   Sanchez-Stern)
 
 # coq-lsp 0.1.4: View
 ---------------------

--- a/controller/lsp_core.ml
+++ b/controller/lsp_core.ml
@@ -270,12 +270,11 @@ let rec lsp_init_loop ic ofmt ~cmdline ~debug : Coq.Workspace.t =
   | LSP.Message.Request { method_ = "initialize"; id; params } ->
     (* At this point logging is allowed per LSP spec *)
     LIO.logMessage ~lvl:3 ~message:"Initializing server";
-    let result = Rq_init.do_initialize ~params |> Result.ok in
-    Rq.answer ~ofmt ~id result;
+    let result, dir = Rq_init.do_initialize ~params in
+    Rq.answer ~ofmt ~id (Result.ok result);
     LIO.logMessage ~lvl:3 ~message:"Server initialized";
     (* Workspace initialization *)
     let debug = debug || !Fleche.Config.v.debug in
-    let dir = string_field "rootPath" params in
     let workspace = Coq.Workspace.guess ~cmdline ~debug ~dir in
     log_workspace workspace;
     workspace

--- a/controller/rq_init.mli
+++ b/controller/rq_init.mli
@@ -1,1 +1,3 @@
-val do_initialize : params:(string * Yojson.Safe.t) list -> Yojson.Safe.t
+(** Returns answer request + workspace root directory *)
+val do_initialize :
+  params:(string * Yojson.Safe.t) list -> Yojson.Safe.t * string


### PR DESCRIPTION
Fixes #294