### PR TITLE
[server] [lsp] Fix bug when parsing client option for unicode completion

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,8 @@
  - `coq-lsp` will now reject opening multiple files when the
    underlying Coq version is buggy (@ejgallego, fixes #275, fixes
    #281)
+ - Fix bug when parsing client option for unicode completion
+   (@ejgallego #301)
 
 # coq-lsp 0.1.4: View
 ---------------------

--- a/lsp/jFleche.ml
+++ b/lsp/jFleche.ml
@@ -20,7 +20,24 @@ module Lang = JLang
 
 module Config = struct
   module Unicode_completion = struct
-    type t = [%import: Fleche.Config.Unicode_completion.t] [@@deriving yojson]
+    type t = [%import: Fleche.Config.Unicode_completion.t]
+
+    let to_yojson = function
+      | Off -> `String "off"
+      | Internal_small -> `String "internal"
+      | Normal -> `String "normal"
+      | Extended -> `String "extended"
+
+    let of_yojson (j : Yojson.Safe.t) : (t, string) Result.t =
+      match j with
+      | `String "off" -> Ok Off
+      | `String "internal" -> Ok Internal_small
+      | `String "normal" -> Ok Normal
+      | `String "extended" -> Ok Extended
+      | _ ->
+        Error
+          "Fleche.Config.Unicode_completion.t: expected one of \
+           [off,normal,extended]"
   end
 
   type t = [%import: Fleche.Config.t] [@@deriving yojson]


### PR DESCRIPTION
Yojson ppx doesn't work too well for this kind of enumeration types (they are serialized to a list with a string)

This was broken by #254