### PR TITLE
workspace: support unicode filenames

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@
    #281)
  - Fix bug when parsing client option for unicode completion
    (@ejgallego #301)
+ - Support unicode characters in filenames (@artagnon, #302)
 
 # coq-lsp 0.1.4: View
 ---------------------

--- a/coq-lsp.opam
+++ b/coq-lsp.opam
@@ -41,6 +41,7 @@ depends: [
   "ppx_hash"            { >= "v0.13.0"  }
   "ppx_import"          { >= "1.5-3"    }
   "ppx_deriving_yojson" { >= "3.4"      }
+  "uri"                 { >= "4.2.0"    }
 ]
 
 build: [ [ "dune" "build" "-p" name "-j" jobs ] ]

--- a/coq/dune
+++ b/coq/dune
@@ -3,4 +3,4 @@
  (public_name coq-lsp.coq)
  ; Unfortunate we have to link the STM due to the LTAC plugin
  ; depending on it, we should fix this upstream
- (libraries coq-core.vernac coq-core.stm coq-serapi.serlib))
+ (libraries coq-core.vernac coq-core.stm coq-serapi.serlib uri))

--- a/coq/workspace.ml
+++ b/coq/workspace.ml
@@ -113,7 +113,8 @@ let load_objs libs =
   List.(iter rq_file (rev libs))
 
 (* We need to compute this with the right load path *)
-let dirpath_of_file f =
+let dirpath_of_uri ~uri =
+  let f = Uri.pct_decode (Uri.path (Uri.of_string uri)) in
   let ldir0 =
     try
       let lp = Loadpath.find_load_path (Filename.dirname f) in
@@ -127,16 +128,6 @@ let dirpath_of_file f =
   let id = Names.Id.of_string f in
   let ldir = Libnames.add_dirpath_suffix ldir0 id in
   ldir
-
-let dirpath_of_uri ~uri =
-  let file =
-    if String.length uri > 8 then
-      (* Remove "file:///" *)
-      let l = String.length uri - 7 in
-      String.(sub uri 7 l)
-    else uri
-  in
-  dirpath_of_file file
 
 (* NOTE: Use exhaustive match below to avoid bugs by skipping fields *)
 let apply ~uri


### PR DESCRIPTION
Remove ad-hoc handling of uri, and use the Uri module instead. This gives us the benefit of being able to percent-decode, and support unicode filenames.