### PR TITLE
[fleche] Stop checking a document when there are too many errors.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,8 @@
    #281)
  - Fix bug when parsing client option for unicode completion
    (@ejgallego #301)
+ - Stop checking documents after a maximum number of errors,
+   user-configurable (by default 150) (@ejgallego, #303)
 
 # coq-lsp 0.1.4: View
 ---------------------

--- a/editor/code/package.json
+++ b/editor/code/package.json
@@ -97,6 +97,11 @@
             "type": "boolean",
             "default": false,
             "description": "Show Coq's \"Notice\" messages as diagnostics, such as `About` and `Search` output."
+          },
+          "coq-lsp.max_errors": {
+            "type": "number",
+            "default": 150,
+            "description": "Maximum number of errors per file, after that, coq-lsp will stop checking the file."
           }
         }
       },

--- a/editor/code/src/config.ts
+++ b/editor/code/src/config.ts
@@ -10,6 +10,7 @@ export interface CoqLspServerConfig {
   admit_on_bad_qed: boolean;
   debug: boolean;
   unicode_completion: "off" | "normal" | "extended";
+  max_errors: number;
 }
 
 export namespace CoqLspServerConfig {
@@ -27,6 +28,7 @@ export namespace CoqLspServerConfig {
       admit_on_bad_qed: wsConfig.admit_on_bad_qed,
       debug: wsConfig.debug,
       unicode_completion: wsConfig.unicode_completion,
+      max_errors: wsConfig.max_errors,
     };
   }
 }

--- a/fleche/config.ml
+++ b/fleche/config.ml
@@ -33,6 +33,7 @@ type t =
         (** Enable debug on Coq side, including backtraces *)
   ; unicode_completion : Unicode_completion.t
         [@default Unicode_completion.Normal]
+  ; max_errors : int [@default 150]
   }
 
 let default =
@@ -47,6 +48,7 @@ let default =
   ; admit_on_bad_qed = true
   ; debug = false
   ; unicode_completion = Normal
+  ; max_errors = 150
   }
 
 let v = ref default

--- a/lang/diagnostic.ml
+++ b/lang/diagnostic.ml
@@ -18,3 +18,5 @@ type t =
   ; message : Pp.t
   ; extra : Extra.t list option
   }
+
+let is_error { severity; _ } = severity >= 1

--- a/lang/diagnostic.mli
+++ b/lang/diagnostic.mli
@@ -18,3 +18,5 @@ type t =
   ; message : Pp.t
   ; extra : Extra.t list option
   }
+
+val is_error : t -> bool


### PR DESCRIPTION
When this happens, it is because usually the Coq install or workspace is in a bad state, or some other fatal problem, so no point in overflowing the clients with diagnostics.

For now I've settled with a default limit of 150 max errors per file.