### PR TITLE
[code] Improve markdown syntax highglighting

### DIFF
--- a/editor/code/CHANGELOG.md
+++ b/editor/code/CHANGELOG.md
@@ -1,3 +1,8 @@
+# coq-lsp 0.1.5: Form
+----------------------
+
+- Improved syntax highligting of coq markdown files
+
 # coq-lsp 0.1.4: View
 ----------------------
 

--- a/editor/code/package.json
+++ b/editor/code/package.json
@@ -46,6 +46,16 @@
           ".mv"
         ],
         "configuration": "./coq.configuration.json"
+      },
+      {
+        "id": "coqmarkdown",
+        "aliases": [
+          "Coq Markdown"
+        ],
+        "extensions": [
+          ".mv"
+        ],
+        "configuration": "./coq.configuration.json"
       }
     ],
     "grammars": [
@@ -53,6 +63,21 @@
         "language": "coq",
         "scopeName": "source.coq",
         "path": "./syntaxes/coq.json"
+      },
+      {
+        "language": "coqmarkdown",
+        "scopeName": "source.coqmarkdown",
+        "path": "./syntaxes/coqmarkdown.json"
+      },
+      {
+        "scopeName": "markdown.coq.codeblock",
+        "path": "./syntaxes/markdown-coq-codeblock.json",
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.coq": "coq"
+        }
       }
     ],
     "commands": [
@@ -70,7 +95,7 @@
         "command": "coq-lsp.goals",
         "key": "alt+enter",
         "mac": "meta+enter",
-        "when": "editorTextFocus && editorLangId == coq"
+        "when": "editorTextFocus && (editorLangId == coq || editorLangId == coqmarkdown"
       }
     ],
     "configuration": [

--- a/editor/code/src/client.ts
+++ b/editor/code/src/client.ts
@@ -68,7 +68,10 @@ export function activate(context: ExtensionContext): void {
     );
 
     const clientOptions: LanguageClientOptions = {
-      documentSelector: [{ scheme: "file", language: "coq" }],
+      documentSelector: [
+        { scheme: "file", language: "coq" },
+        { scheme: "file", language: "coqmarkdown" },
+      ],
       outputChannelName: "Coq LSP Server Events",
       revealOutputChannelOn: RevealOutputChannelOn.Info,
       initializationOptions,
@@ -108,7 +111,11 @@ export function activate(context: ExtensionContext): void {
 
   let goalsHook = window.onDidChangeTextEditorSelection(
     (evt: TextEditorSelectionChangeEvent) => {
-      if (evt.textEditor.document.languageId != "coq") return;
+      if (
+        evt.textEditor.document.languageId != "coq" &&
+        evt.textEditor.document.languageId != "coqmarkdown"
+      )
+        return;
 
       const kind =
         evt.kind == TextEditorSelectionChangeKind.Mouse

--- a/editor/code/src/progress.ts
+++ b/editor/code/src/progress.ts
@@ -63,7 +63,10 @@ export class FileProgressManager {
   });
   private cleanDecos() {
     for (const editor of window.visibleTextEditors) {
-      if (editor.document.languageId === "coq") {
+      if (
+        editor.document.languageId === "coq" ||
+        editor.document.languageId === "coqmarkdown"
+      ) {
         editor.setDecorations(progressDecoration, []);
       }
     }

--- a/editor/code/syntaxes/coqmarkdown.json
+++ b/editor/code/syntaxes/coqmarkdown.json
@@ -1,0 +1,32 @@
+{
+  "fileTypes": ["mv"],
+  "name": "Coq Markdown",
+  "scopeName": "source.coqmarkdown",
+  "patterns": [
+    {
+      "include": "#fenced_code_block_coq"
+    },
+    {
+      "include": "text.html.markdown"
+    }
+  ],
+  "repository": {
+    "fenced_code_block_coq": {
+      "begin": "(^|\\G)(\\s*)(`{3,}|~{3,})\\s*(?i:(coq)((\\s+|:|,|\\{|\\?)[^`]*)?$)",
+      "name": "markup.fenced_code.block.markdown",
+      "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+      "patterns": [
+        {
+          "begin": "(^|\\G)(\\s*)(.*)",
+          "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+          "contentName": "meta.embedded.block.coq",
+          "patterns": [
+            {
+              "include": "source.coq"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/editor/code/syntaxes/markdown-coq-codeblock.json
+++ b/editor/code/syntaxes/markdown-coq-codeblock.json
@@ -1,0 +1,28 @@
+{
+  "fileTypes": [],
+  "scopeName": "markdown.coq.codeblock",
+  "injectionSelector": "L:markup.fenced_code.block.markdown",
+  "patterns": [
+    {
+      "include": "#coq-code-block"
+    }
+  ],
+  "repository": {
+    "coq-code-block": {
+      "begin": "coq(\\s+[^`~]*)?$",
+      "end": "(^|\\G)(?=\\s*[`~]{3,}\\s*$)",
+      "patterns": [
+        {
+          "begin": "(^|\\G)(\\s*)(.*)",
+          "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+          "contentName": "meta.embedded.block.coq",
+          "patterns": [
+            {
+              "include": "source.coq"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Make `.mv` files inherit markdown grammar and inject coq grammar into coq codeblocks in both `.mv` and `.md` files.