### PR TITLE
[Nix] build without submodules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
         uses: cachix/install-nix-action@v18
 
       - name: 🧱 Build coq-lsp
-        run: nix build .?submodules=1
+        run: nix build
 
   client-compile:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,15 +103,11 @@ nix develop .#client-vscode
 You can view the list of packages and devShells that are exposed
 by running `nix flake show`.
 
-If you wish to do `nix build`, you will need to use the .?submodules=1` trick,
-since we use submodules here for vendoring. For example, building requires:
-
+To build you can do:
 ```
-nix build .?submodules=1
+nix build .
 ```
 
-This currently only applies to building the default package (coq-lsp), which is
-the server. Clients don't have specific submodules as of yet.
 
 #### Releasing
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ don't hesitate to get in touch with us.
    - In nixpkgs: [#213397](https://github.com/NixOS/nixpkgs/pull/213397)
    - In your flake:
    ```nix
-   inputs.coq-lsp = { type = "git"; url = "https://github.com/ejgallego/coq-lsp.git"; submodules = true; };
+   inputs.coq-lsp.url = "github:ejgallego/coq-lsp";
    ...
    coq-lsp.packages.${system}.default
    ```
@@ -189,7 +189,7 @@ don't hesitate to get in touch with us.
 - Open VSX: https://open-vsx.org/extension/ejgallego/coq-lsp
 - Nix:
 ```nix
-inputs.coq-lsp = { type = "git"; url = "https://github.com/ejgallego/coq-lsp.git"; submodules = true; };
+inputs.coq-lsp.url = "github:ejgallego/coq-lsp";
 ...
 programs.vscode = {
   enable = true;

--- a/flake.lock
+++ b/flake.lock
@@ -1,19 +1,36 @@
 {
   "nodes": {
-    "coq-serapi": {
+    "coq": {
       "flake": false,
       "locked": {
-        "lastModified": 1673473454,
-        "narHash": "sha256-ZeKkbEcTfe/5X/pW+Kl4Xjcj3cdZcs06LTg4dZIuHq8=",
+        "lastModified": 1676467671,
+        "narHash": "sha256-3Raldx6C3d8gP0EU6lL9rjf+DGLWtSTLVdnFict07lg=",
         "owner": "ejgallego",
-        "repo": "coq-serapi",
-        "rev": "79880d37705b6ec08108f5e6044fd7a128923753",
+        "repo": "coq",
+        "rev": "8e0314415cc3cd528fc81bf11075d294179f880a",
         "type": "github"
       },
       "original": {
         "owner": "ejgallego",
-        "ref": "v8.17",
+        "repo": "coq",
+        "rev": "8e0314415cc3cd528fc81bf11075d294179f880a",
+        "type": "github"
+      }
+    },
+    "coq-serapi": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1676579089,
+        "narHash": "sha256-4dK0Or4wrdZ8X2OorgNVqRMt4o2bWkOmctUD2B+v9PE=",
+        "owner": "ejgallego",
         "repo": "coq-serapi",
+        "rev": "9c8e91fdad0182675e0cad34bdeba54e63db86cd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ejgallego",
+        "repo": "coq-serapi",
+        "rev": "9c8e91fdad0182675e0cad34bdeba54e63db86cd",
         "type": "github"
       }
     },
@@ -152,6 +169,7 @@
     },
     "root": {
       "inputs": {
+        "coq": "coq",
         "coq-serapi": "coq-serapi",
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,6 @@
         l = lib // builtins;
 
         coqVersion = "8.18";
-        # Builds with ocaml 5, however since ocaml 5 and ocamlPackages_5_0 aren't cached, better to use 4_14
         ocamlPackages = pkgs.ocamlPackages;
 
         mkDunePackage = args @ {
@@ -50,17 +49,8 @@
 
           prefixKey = "-prefix ";
 
-          buildPhase = ''
-            runHook preBuild
+          preBuild = ''
             make dunestrap
-            dune build -p coq-core -j $NIX_BUILD_CORES
-            runHook postBuild
-          '';
-
-          installPhase = ''
-            runHook preInstall
-            dune install --prefix $out --libdir $OCAMLFIND_DESTDIR coq-core
-            runHook postInstall
           '';
 
           propagatedBuildInputs = with ocamlPackages; [zarith findlib];

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,7 @@
           in
             l.attrValues {
               inherit serapi;
-              inherit (ocamlPackages) yojson cmdliner uri dune-build-info;
+              inherit (ocamlPackages) yojson cmdliner uri dune-build-info ocaml findlib;
             };
         };
 
@@ -73,7 +73,7 @@
           packages = l.attrValues {
             inherit (config.treefmt.build) wrapper;
             inherit (pkgs) dune_3 nodejs;
-            inherit (ocamlPackages) ocaml ocaml-lsp;
+            inherit (ocamlPackages) ocaml-lsp;
           };
         };
       };

--- a/flake.nix
+++ b/flake.nix
@@ -103,7 +103,7 @@
     };
 
     coq = {
-      url = "github:ejgallego/coq/8e0314415cc3cd528fc81bf11075d294179f880a";
+      url = "github:ejgallego/coq";
       flake = false;
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -108,7 +108,7 @@
     };
 
     coq-serapi = {
-      url = "github:ejgallego/coq-serapi/9c8e91fdad0182675e0cad34bdeba54e63db86cd";
+      url = "github:ejgallego/coq-serapi";
       flake = false;
     };
   };


### PR DESCRIPTION
This should allow greater composition with existing Coq nix setup.

Importantly we should build coq-lsp with the same version of OCaml and findlib that the Coq derivation is using.

WIP
