### PR TITLE
[lsp] Fix bug on request / notification parsing

### DIFF
--- a/lsp/base.ml
+++ b/lsp/base.ml
@@ -23,7 +23,9 @@ module J = Yojson.Safe
 module U = Yojson.Safe.Util
 
 let string_field name dict = U.to_string List.(assoc name dict)
-let dict_field name dict = U.to_assoc (List.assoc name dict)
+
+let odict_field ~default name dict =
+  Option.cata U.to_assoc default (List.assoc_opt name dict)
 
 module Message = struct
   type t =
@@ -42,7 +44,7 @@ module Message = struct
     try
       let dict = U.to_assoc msg in
       let method_ = string_field "method" dict in
-      let params = dict_field "params" dict in
+      let params = odict_field ~default:[] "params" dict in
       (match List.assoc_opt "id" dict with
       | None -> Notification { method_; params }
       | Some id ->


### PR DESCRIPTION
Problem found by Ramkumar, indeed the `exit` and `shutdown` RPC calls do have `params` missing.