### PR TITLE
[fleche] Cache document creation

### DIFF
--- a/controller/cache.ml
+++ b/controller/cache.ml
@@ -22,7 +22,7 @@ let memo_cache_file = ".coq-lsp.cache"
 
 let memo_save_to_disk () =
   try
-    Fleche.Memo.save_to_disk ~file:memo_cache_file;
+    (* Fleche.Memo.save_to_disk ~file:memo_cache_file; *)
     LIO.trace "memo" "cache saved to disk"
   with exn ->
     LIO.trace "memo" (Printexc.to_string exn);
@@ -36,7 +36,7 @@ let memo_read_from_disk () =
   try
     if Sys.file_exists memo_cache_file then (
       LIO.trace "memo" "trying to load cache file";
-      Fleche.Memo.load_from_disk ~file:memo_cache_file;
+      (* Fleche.Memo.load_from_disk ~file:memo_cache_file; *)
       LIO.trace "memo" "cache file loaded")
     else LIO.trace "memo" "cache file not present"
   with exn ->

--- a/coq/interp.ml
+++ b/coq/interp.ml
@@ -15,18 +15,11 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-module Info = struct
-  type 'a t = { res : 'a }
-end
-
-type 'a interp_result = ('a Info.t, Loc.t) Protect.E.t
+type 'a interp_result = ('a, Loc.t) Protect.E.t
 
 let coq_interp ~st cmd =
   let st = State.to_coq st in
   let cmd = Ast.to_coq cmd in
   Vernacinterp.interp ~st cmd |> State.of_coq
 
-let interp ~st cmd =
-  Protect.eval cmd ~f:(fun cmd ->
-      let res = coq_interp ~st cmd in
-      { Info.res })
+let interp ~st cmd = Protect.eval cmd ~f:(coq_interp ~st)

--- a/coq/interp.mli
+++ b/coq/interp.mli
@@ -15,10 +15,6 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-module Info : sig
-  type 'a t = { res : 'a }
-end
-
-type 'a interp_result = ('a Info.t, Loc.t) Protect.E.t
+type 'a interp_result = ('a, Loc.t) Protect.E.t
 
 val interp : st:State.t -> Ast.t -> State.t interp_result

--- a/coq/workspace.ml
+++ b/coq/workspace.ml
@@ -27,6 +27,9 @@ type t =
   ; debug : bool
   }
 
+let hash = Hashtbl.hash
+let compare = Stdlib.compare
+
 (* Lib setup, XXX unify with sysinit *)
 let coq_root = Names.DirPath.make [ Libnames.coq_root ]
 let default_root = Libnames.default_root_prefix

--- a/coq/workspace.mli
+++ b/coq/workspace.mli
@@ -27,6 +27,12 @@ type t = private
   ; debug : bool  (** Enable backtraces *)
   }
 
+(** compare *)
+val compare : t -> t -> int
+
+(** hash *)
+val hash : t -> int
+
 (** user message, debug extra data *)
 val describe : t -> string * string
 

--- a/fleche/doc.ml
+++ b/fleche/doc.ml
@@ -207,9 +207,7 @@ type t =
   ; completed : Completion.t
   }
 
-let mk_doc root_state workspace uri =
-  Coq.Init.doc_init ~root_state ~workspace ~uri
-
+(* Flatten the list of document asts *)
 let asts doc = List.filter_map Node.ast doc.nodes
 
 (* TOC handling *)
@@ -247,6 +245,9 @@ let process_init_feedback ~stats range state messages =
     in
     [ { Node.range; ast = None; state; diags; messages; info } ]
   else []
+
+(* Memoized call to [Coq.Init.doc_init] *)
+let mk_doc root_state workspace uri = Memo.Init.eval (root_state, workspace, uri)
 
 let create ~state ~workspace ~uri ~version ~contents =
   let () = Stats.reset () in

--- a/fleche/doc.ml
+++ b/fleche/doc.ml
@@ -447,9 +447,7 @@ let state_recovery_heuristic doc st v =
   | Vernacexpr.VernacBullet _ | Vernacexpr.VernacEndSubproof ->
     Io.Log.trace "recovery" "bullet";
     Coq.State.admit_goal ~st
-    |> Coq.Protect.E.bind ~f:(fun st ->
-           Coq.Interp.interp ~st v.v
-           |> Coq.Protect.E.map ~f:(fun { Coq.Interp.Info.res } -> res))
+    |> Coq.Protect.E.bind ~f:(fun st -> Coq.Interp.interp ~st v.v)
   | _ -> Coq.Protect.E.ok st
 
 let interp_and_info ~parsing_time ~st ast =
@@ -559,7 +557,7 @@ let recovery_interp ~doc ~st ~ast =
 let node_of_coq_result ~doc ~range ~ast ~st ~parsing_diags ~parsing_feedback
     ~feedback ~info last_tok res =
   match res with
-  | Ok { Coq.Interp.Info.res = state } ->
+  | Ok state ->
     let node =
       parsed_node ~range ~ast ~state ~parsing_diags ~parsing_feedback ~diags:[]
         ~feedback ~info

--- a/fleche/doc.mli
+++ b/fleche/doc.mli
@@ -73,7 +73,7 @@ type t = private
 (** Return the list of all asts in the doc *)
 val asts : t -> Node.Ast.t list
 
-(** Note, [create] calls Coq but it is not cached in the Memo.t table *)
+(** Create a new Coq document, this is cached! *)
 val create :
      state:Coq.State.t
   -> workspace:Coq.Workspace.t

--- a/fleche/memo.ml
+++ b/fleche/memo.ml
@@ -15,18 +15,6 @@ module Stats = struct
     { res; cache_hit; memory; time }
 end
 
-(* This requires a ppx likely as to ignore the CAst location *)
-module VernacInput = struct
-  type t = Coq.Ast.t * Coq.State.t
-
-  let equal (v1, st1) (v2, st2) =
-    if Coq.Ast.compare v1 v2 = 0 then
-      if Coq.State.compare st1 st2 = 0 then true else false
-    else false
-
-  let hash (v, st) = Hashtbl.hash (Coq.Ast.hash v, st)
-end
-
 module CacheStats = struct
   let nhit, ntotal = (ref 0, ref 0)
 
@@ -49,125 +37,113 @@ module CacheStats = struct
       Format.asprintf "cache hit rate: %3.2f" hit_rate
 end
 
-let input_info (v, st) =
-  Format.asprintf "stm: %d | st %d" (Coq.Ast.hash v) (Hashtbl.hash st)
+module Interp = struct
+  (* Loc-independent command evalution and caching. *)
+  module VernacInput = struct
+    type t = Coq.State.t * Coq.Ast.t
 
-module HC = Hashtbl.Make (VernacInput)
+    (* This crutially relies on our ppx to ignore the CAst location *)
+    let equal (st1, v1) (st2, v2) =
+      if Coq.Ast.compare v1 v2 = 0 then
+        if Coq.State.compare st1 st2 = 0 then true else false
+      else false
 
-module Result = struct
-  (* We store the location as to compute an offset for cached results *)
-  type t = Loc.t * Coq.State.t Coq.Interp.interp_result
-end
+    let hash (st, v) = Hashtbl.hash (Coq.Ast.hash v, st)
+  end
 
-type cache = Result.t HC.t
+  type t = VernacInput.t
 
-let cache : cache ref = ref (HC.create 1000)
+  let input_info (st, v) =
+    Format.asprintf "stm: %d | st %d" (Coq.Ast.hash v) (Hashtbl.hash st)
 
-let in_cache st stm =
-  let kind = CS.Kind.Hashing in
-  CS.record ~kind ~f:(HC.find_opt !cache) (stm, st)
+  module HC = Hashtbl.Make (VernacInput)
 
-(* XXX: Move elsewhere *)
-let loc_offset (l1 : Loc.t) (l2 : Loc.t) =
-  let line_offset = l2.line_nb - l1.line_nb in
-  let bol_offset = l2.bol_pos - l1.bol_pos in
-  let line_last_offset = l2.line_nb_last - l1.line_nb_last in
-  let bol_last_offset = l2.bol_pos_last - l1.bol_pos_last in
-  let bp_offset = l2.bp - l1.bp in
-  let ep_offset = l2.ep - l1.ep in
-  ( line_offset
-  , bol_offset
-  , line_last_offset
-  , bol_last_offset
-  , bp_offset
-  , ep_offset )
+  module Result = struct
+    (* We store the location as to compute an offset for cached results *)
+    type t = Loc.t * Coq.State.t Coq.Interp.interp_result
+  end
 
-let loc_apply_offset
+  type cache = Result.t HC.t
+
+  let cache : cache ref = ref (HC.create 1000)
+  let stats () = Obj.reachable_words (Obj.magic cache)
+
+  let in_cache st stm =
+    let kind = CS.Kind.Hashing in
+    CS.record ~kind ~f:(HC.find_opt !cache) (st, stm)
+
+  (* XXX: Move elsewhere *)
+  let loc_offset (l1 : Loc.t) (l2 : Loc.t) =
+    let line_offset = l2.line_nb - l1.line_nb in
+    let bol_offset = l2.bol_pos - l1.bol_pos in
+    let line_last_offset = l2.line_nb_last - l1.line_nb_last in
+    let bol_last_offset = l2.bol_pos_last - l1.bol_pos_last in
+    let bp_offset = l2.bp - l1.bp in
+    let ep_offset = l2.ep - l1.ep in
     ( line_offset
     , bol_offset
     , line_last_offset
     , bol_last_offset
     , bp_offset
-    , ep_offset ) (loc : Loc.t) =
-  { loc with
-    line_nb = loc.line_nb + line_offset
-  ; bol_pos = loc.bol_pos + bol_offset
-  ; line_nb_last = loc.line_nb_last + line_last_offset
-  ; bol_pos_last = loc.bol_pos_last + bol_last_offset
-  ; bp = loc.bp + bp_offset
-  ; ep = loc.ep + ep_offset
-  }
+    , ep_offset )
 
-let adjust_offset ~stm_loc ~cached_loc res =
-  let offset = loc_offset cached_loc stm_loc in
-  let f = loc_apply_offset offset in
-  Coq.Protect.E.map_loc ~f res
+  let loc_apply_offset
+      ( line_offset
+      , bol_offset
+      , line_last_offset
+      , bol_last_offset
+      , bp_offset
+      , ep_offset ) (loc : Loc.t) =
+    { loc with
+      line_nb = loc.line_nb + line_offset
+    ; bol_pos = loc.bol_pos + bol_offset
+    ; line_nb_last = loc.line_nb_last + line_last_offset
+    ; bol_pos_last = loc.bol_pos_last + bol_last_offset
+    ; bp = loc.bp + bp_offset
+    ; ep = loc.ep + ep_offset
+    }
 
-let interp_command ~st stm : _ Stats.t =
-  let stm_loc = Coq.Ast.loc stm |> Option.get in
-  match in_cache st stm with
-  | Some (cached_loc, res), time ->
-    if Debug.cache then Io.Log.trace "memo" "cache hit";
-    CacheStats.hit ();
-    let res = adjust_offset ~stm_loc ~cached_loc res in
-    Stats.make ~cache_hit:true ~time res
-  | None, time_hash -> (
-    if Debug.cache then Io.Log.trace "memo" "cache miss";
-    CacheStats.miss ();
-    let kind = CS.Kind.Exec in
-    let res, time_interp = CS.record ~kind ~f:(Coq.Interp.interp ~st) stm in
-    let time = time_hash +. time_interp in
-    match res.r with
-    | Coq.Protect.R.Interrupted ->
-      (* Don't cache interruptions *)
-      Stats.make ~time res
-    | Coq.Protect.R.Completed _ ->
-      let () = HC.add !cache (stm, st) (stm_loc, res) in
+  let adjust_offset ~stm_loc ~cached_loc res =
+    let offset = loc_offset cached_loc stm_loc in
+    let f = loc_apply_offset offset in
+    Coq.Protect.E.map_loc ~f res
+
+  let eval (st, stm) : _ Stats.t =
+    let stm_loc = Coq.Ast.loc stm |> Option.get in
+    match in_cache st stm with
+    | Some (cached_loc, res), time ->
+      if Debug.cache then Io.Log.trace "memo" "cache hit";
+      CacheStats.hit ();
+      let res = adjust_offset ~stm_loc ~cached_loc res in
+      Stats.make ~cache_hit:true ~time res
+    | None, time_hash -> (
+      if Debug.cache then Io.Log.trace "memo" "cache miss";
+      CacheStats.miss ();
+      let kind = CS.Kind.Exec in
+      let res, time_interp = CS.record ~kind ~f:(Coq.Interp.interp ~st) stm in
       let time = time_hash +. time_interp in
-      Stats.make ~time res)
+      match res.r with
+      | Coq.Protect.R.Interrupted ->
+        (* Don't cache interruptions *)
+        Stats.make ~time res
+      | Coq.Protect.R.Completed _ ->
+        let () = HC.add !cache (st, stm) (stm_loc, res) in
+        let time = time_hash +. time_interp in
+        Stats.make ~time res)
+end
 
-module AC = Hashtbl.Make (Coq.State)
+module Admit = struct
+  type t = Coq.State.t
 
-let admit_cache = AC.create 1000
+  module AC = Hashtbl.Make (Coq.State)
 
-let interp_admitted ~st =
-  match AC.find_opt admit_cache st with
-  | None ->
-    let admitted_st = Coq.State.admit ~st in
-    AC.add admit_cache st admitted_st;
-    admitted_st
-  | Some admitted_st -> admitted_st
+  let admit_cache = AC.create 1000
 
-let mem_stats () = Obj.reachable_words (Obj.magic cache)
-
-(* let _hashtbl_out oc t = () *)
-(* Marshal.to_channel oc (HC.length t) []; *)
-(* HC.iter *)
-(*   (fun vi res -> *)
-(*     VernacInput.marshal_out oc vi; *)
-(*     Result.marshal_out oc res) *)
-(*   t *)
-
-(* let _hashtbl_in ic = *)
-(*   let ht = HC.create 1000 in *)
-(*   let count : int = Marshal.from_channel ic in *)
-(*   for _i = 0 to count - 1 do *)
-(*     let vi = VernacInput.marshal_in ic in *)
-(*     let res = Result.marshal_in ic in *)
-(*     HC.add ht vi res *)
-(*   done; *)
-(*   ht *)
-
-let load_from_disk ~file =
-  let ic = open_in_bin file in
-  (* let in_cache : cache = hashtbl_in in_c in *)
-  let in_cache : cache = Marshal.from_channel ic in
-  cache := in_cache;
-  close_in ic
-
-let save_to_disk ~file =
-  let oc = open_out_bin file in
-  let out_cache : cache = !cache in
-  Marshal.to_channel oc out_cache [];
-  (* hashtbl_out out_c out_cache; *)
-  close_out oc
+  let eval st =
+    match AC.find_opt admit_cache st with
+    | None ->
+      let admitted_st = Coq.State.admit ~st in
+      AC.add admit_cache st admitted_st;
+      admitted_st
+    | Some admitted_st -> admitted_st
+end

--- a/fleche/memo.mli
+++ b/fleche/memo.mli
@@ -7,6 +7,12 @@ module Stats : sig
     }
 end
 
+module Init : sig
+  type t = Coq.State.t * Coq.Workspace.t * Lang.LUri.File.t
+
+  val eval : t -> (Coq.State.t, Loc.t) Coq.Protect.E.t
+end
+
 module Interp : sig
   type t = Coq.State.t * Coq.Ast.t
 

--- a/fleche/memo.mli
+++ b/fleche/memo.mli
@@ -7,24 +7,26 @@ module Stats : sig
     }
 end
 
-(** Interpret a command, possibly memoizing it *)
-val interp_command :
-  st:Coq.State.t -> Coq.Ast.t -> Coq.State.t Coq.Interp.interp_result Stats.t
+module Interp : sig
+  type t = Coq.State.t * Coq.Ast.t
 
-val interp_admitted : st:Coq.State.t -> (Coq.State.t, Loc.t) Coq.Protect.E.t
+  (** Interpret a command, possibly memoizing it *)
+  val eval : t -> Coq.State.t Coq.Interp.interp_result Stats.t
 
-(** Stats *)
-val mem_stats : unit -> int
+  (** Stats *)
+  val stats : unit -> int
+
+  (** debug *)
+  val input_info : t -> string
+end
+
+module Admit : sig
+  type t = Coq.State.t
+
+  val eval : t -> (Coq.State.t, Loc.t) Coq.Protect.E.t
+end
 
 module CacheStats : sig
   val reset : unit -> unit
   val stats : unit -> string
 end
-
-(** Not working yet *)
-val load_from_disk : file:string -> unit
-
-val save_to_disk : file:string -> unit
-
-(** debug *)
-val input_info : Coq.Ast.t * Coq.State.t -> string

--- a/lang/lUri.ml
+++ b/lang/lUri.ml
@@ -21,4 +21,6 @@ module File = struct
   let to_string_uri { uri; _ } = Uri.to_string uri
   let to_string_file { file; _ } = file
   let extension { file; _ } = Filename.extension file
+  let hash = Hashtbl.hash
+  let compare = Stdlib.compare
 end

--- a/lang/lUri.mli
+++ b/lang/lUri.mli
@@ -27,4 +27,10 @@ module File : sig
 
   (** Filename version, fit for OS functions *)
   val to_string_file : t -> string
+
+  (** compare *)
+  val compare : t -> t -> int
+
+  (** hash *)
+  val hash : t -> int
 end


### PR DESCRIPTION
Some clients, such as Visual Studio Code, may open / close buffers
aggressively when working, this creates some extra load as we don't
cache document creation.

This PR does cache it. In general this has a very low footprint on
memory by itself, as the root state is shared across all buffers, but
of course, the documents themselves could be a big load, but that's
already the case so we don't make things worse.

Fixes #363

[Test suite passes ;)]
