### PR TITLE
[nit] Scan also identifiers with doc, Coq's "qualids"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,8 @@
  - Remove the `coq-lsp.ok_diagnostics` setting (@artagnon, #129)
  - Print abbreviations on hover (@ejgallego, #384)
  - Print hover types without parenthesis (@ejgallego, #384)
+ - Parse identifiers with dot for hover and jump to definition
+   (@ejallego, #385)
 
 # coq-lsp 0.1.5.1: Path
 -----------------------

--- a/controller/rq_common.ml
+++ b/controller/rq_common.ml
@@ -10,7 +10,7 @@ let is_id_char x =
   ('a' <= x && x <= 'z')
   || ('A' <= x && x <= 'Z')
   || ('0' <= x && x <= '9')
-  || x = '_'
+  || x = '_' || x = '.'
 
 let rec find_start s c =
   if c <= 0 then 0


### PR DESCRIPTION
Actually we should return a set of candidates, but this provides better results.