### PR TITLE
[coq] Invalidate vernacstate cache on exception

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,8 @@
  - Hover symbol information: correctly handle identifiers before '.'
    and containing a quote (') themselves (@ejgallego, #393)
  - Add children entries to the table-of-contents (@ejgallego, #394)
+ - Invalidate Coq's imperative cache on error (@ejgallego, @r-muhairi,
+   #395)
 
 # coq-lsp 0.1.5.1: Path
 -----------------------

--- a/coq/protect.ml
+++ b/coq/protect.ml
@@ -38,11 +38,14 @@ let eval_exn ~f x =
     let res = f x in
     R.Completed (Ok res)
   with
-  | Sys.Break -> R.Interrupted
+  | Sys.Break ->
+    Vernacstate.invalidate_cache ();
+    R.Interrupted
   | exn ->
     let e, info = Exninfo.capture exn in
     let loc = Loc.(get_loc info) in
     let msg = CErrors.iprint (e, info) in
+    Vernacstate.invalidate_cache ();
     if CErrors.is_anomaly e then R.Completed (Error (Anomaly (loc, msg)))
     else R.Completed (Error (User (loc, msg)))
 


### PR DESCRIPTION
If an exception is raised after an `unfreeze_interp_state`, the cache will be invalid.

Thanks to @r-muhairi for help in identifying this problem.