### PR TITLE
[coq] [workspace] [init] Recognize COQLIB and COQCORELIB

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,8 @@
    #395)
  - Add status bar button to toggle server run status (@ejgallego,
    @Alizter, #378, closes #209)
+ - Support for `COQLIB` and `COQCORELIB` environment variables, added
+   `--coqcorelib` command line argument (@ejgallego, #403)
 
 # coq-lsp 0.1.5.1: Path
 -----------------------

--- a/coq/workspace.mli
+++ b/coq/workspace.mli
@@ -17,6 +17,7 @@
 
 type t = private
   { coqlib : string
+  ; coqcorelib : string
   ; vo_load_path : Loadpath.vo_path list
   ; ml_include_path : string list
   ; require_libs :
@@ -39,6 +40,7 @@ val describe : t -> string * string
 module CmdLine : sig
   type t =
     { coqlib : string
+    ; coqcorelib : string
     ; vo_load_path : Loadpath.vo_path list
     ; ml_include_path : string list
     }


### PR DESCRIPTION
This is in line with upstream Coq; we also add the `--coqcorelib` command line option.

We still don't support the `coq_environment.txt` hack, as it relies in `Sys.executable_name` which seems very very fishy.