### PR TITLE
[hover] Info on memory and time is now disabled by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,6 +51,9 @@
  - Scroll active goal into view (@ejgallego, #410, fixes #381)
  - Server status icon will now react properly to fatal server errors
    (@ejgallego, reported by @Alizter, #411, fixes #399)
+ - Info on memory and time is now disabled by default, new option
+   `coq-lsp.stats_on_hover_option` to re-enable it (@ejgallego, #412,
+   fixes #398).
 
 # coq-lsp 0.1.5.1: Path
 -----------------------

--- a/controller/rq_hover.ml
+++ b/controller/rq_hover.ml
@@ -113,7 +113,8 @@ let hover ~doc ~point =
   in
   let hover_string =
     if show_loc_info then range_string ^ "\n___\n" ^ info_string
-    else info_string
+    else if !Fleche.Config.v.show_stats_on_hover then "\n___\n" ^ info_string
+    else ""
   in
   let hover_string =
     match Rq_common.get_id_at_point ~doc ~point with
@@ -122,7 +123,7 @@ let hover ~doc ~point =
       | None -> hover_string
       | Some typ ->
         let typ = Pp.string_of_ppcmds typ in
-        Format.asprintf "```coq\n%s : %s\n```\n___\n%s" id typ hover_string)
+        Format.asprintf "```coq\n%s : %s\n```%s" id typ hover_string)
     | None -> hover_string
   in
   let contents = { HoverContents.kind = "markdown"; value = hover_string } in

--- a/editor/code/package.json
+++ b/editor/code/package.json
@@ -138,6 +138,11 @@
             "type": "number",
             "default": 150,
             "description": "Maximum number of errors per file, after that, coq-lsp will stop checking the file."
+          },
+          "coq-lsp.show_stats_on_hover": {
+            "type": "boolean",
+            "default": false,
+            "description": "Show timing and memory stats for a sentence on hover."
           }
         }
       },

--- a/editor/code/src/config.ts
+++ b/editor/code/src/config.ts
@@ -11,6 +11,7 @@ export interface CoqLspServerConfig {
   unicode_completion: "off" | "normal" | "extended";
   max_errors: number;
   pp_type: 0 | 1 | 2;
+  show_stats_on_hover: boolean
 }
 
 export namespace CoqLspServerConfig {
@@ -29,6 +30,7 @@ export namespace CoqLspServerConfig {
       unicode_completion: wsConfig.unicode_completion,
       max_errors: wsConfig.max_errors,
       pp_type: wsConfig.pp_type,
+      show_stats_on_hover: wsConfig.show_stats_on_hover
     };
   }
 }

--- a/fleche/config.ml
+++ b/fleche/config.ml
@@ -36,6 +36,7 @@ type t =
   ; pp_type : int [@default 0]
         (** Pretty-printing type in Info Panel Request, 0 = string; 1 = Pp.t; 2
             = Coq Layout Engine *)
+  ; show_stats_on_hover : bool [@default false]
   }
 
 let default =
@@ -51,6 +52,7 @@ let default =
   ; unicode_completion = Normal
   ; max_errors = 150
   ; pp_type = 0
+  ; show_stats_on_hover = false
   }
 
 let v = ref default


### PR DESCRIPTION
Set the new option `coq-lsp.stats_on_hover_option` to re-enable
it.

Fixes #398
