### PR TITLE
[build] Set libdir explicitly in configure, to workaround configure bug.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,11 @@ watch: coq_boot
 build-all: coq_boot
 	dune build $(DUNEOPT) @all
 
+# We set -libdir due to a Coq bug on win32, see https://github.com/coq/coq/pull/17289
 vendor/coq/config/coq_config.ml:
 	cd vendor/coq \
 	&& ./configure -no-ask -prefix $(shell pwd)/_build/install/default/ \
+	        -libdir $(shell pwd)/_build/install/default/lib/coq \
 		-native-compiler no \
 	&& cp theories/dune.disabled theories/dune \
 	&& cp user-contrib/Ltac2/dune.disabled user-contrib/Ltac2/dune


### PR DESCRIPTION
See https://github.com/coq/coq/pull/17289 for more details.