### PR TITLE
[io] Abstract IO functions

### DIFF
--- a/controller/doc_manager.mli
+++ b/controller/doc_manager.mli
@@ -18,13 +18,13 @@
 module Check : sig
   (** Check pending documents, return [None] if there is none pending, or
       [Some rqs] the list of requests ready to execute after the check. Sends
-      progress and diagnostics notifications to [ofmt]. *)
-  val maybe_check : ofmt:Format.formatter -> Int.Set.t option
+      progress and diagnostics notifications using output function [ofn]. *)
+  val maybe_check : ofn:(Yojson.Safe.t -> unit) -> Int.Set.t option
 end
 
 (** Create a document *)
 val create :
-     ofmt:Format.formatter
+     ofn:(Yojson.Safe.t -> unit)
   -> root_state:Coq.State.t
   -> workspace:Coq.Workspace.t
   -> uri:Lang.LUri.File.t
@@ -34,7 +34,7 @@ val create :
 
 (** Update a document, returns the list of not valid requests *)
 val change :
-     ofmt:Format.formatter
+     ofn:(Yojson.Safe.t -> unit)
   -> uri:Lang.LUri.File.t
   -> version:int
   -> raw:string

--- a/controller/lsp_core.ml
+++ b/controller/lsp_core.ml
@@ -76,7 +76,7 @@ module State = struct
     | Some (_, workspace) -> (root_state, workspace)
 end
 
-let do_changeWorkspaceFolders ~ofmt:_ ~state params =
+let do_changeWorkspaceFolders ~ofn:_ ~state params =
   let open Lsp.Workspace in
   let { DidChangeWorkspaceFoldersParams.event } =
     DidChangeWorkspaceFoldersParams.of_yojson (`Assoc params) |> Result.get_ok
@@ -128,11 +128,11 @@ end
 (* main module with [answer, postpone, cancel, serve] methods *)
 module Rq = struct
   (* Answer a request *)
-  let answer ~ofmt ~id result =
+  let answer ~ofn ~id result =
     (match result with
     | Result.Ok result -> LSP.mk_reply ~id ~result
     | Error (code, message) -> LSP.mk_request_error ~id ~code ~message)
-    |> LIO.send_json ofmt
+    |> ofn
 
   (* private to the Rq module *)
   let _rtable : (int, PendingRequest.t) Hashtbl.t = Hashtbl.create 673
@@ -144,34 +144,34 @@ module Rq = struct
     Hashtbl.add _rtable id pr
 
   (* Consumes a request, if alive, it answers mandatorily *)
-  let consume_ ~ofmt ~f id =
+  let consume_ ~ofn ~f id =
     match Hashtbl.find_opt _rtable id with
     | Some pr ->
       Hashtbl.remove _rtable id;
-      f pr |> answer ~ofmt ~id
+      f pr |> answer ~ofn ~id
     | None ->
       LIO.trace "can't consume cancelled request: " (string_of_int id);
       ()
 
-  let cancel ~ofmt ~code ~message id : unit =
+  let cancel ~ofn ~code ~message id : unit =
     (* fail the request, do cleanup first *)
     let f pr =
       let () = PendingRequest.cancel ~id pr in
       Error (code, message)
     in
-    consume_ ~ofmt ~f id
+    consume_ ~ofn ~f id
 
   let debug_serve id pr =
     if Fleche.Debug.request_delay then
       LIO.trace "serving"
         (Format.asprintf "rq: %d | %a" id PendingRequest.data pr)
 
-  let serve ~ofmt id =
+  let serve ~ofn id =
     let f pr =
       debug_serve id pr;
       PendingRequest.serve pr
     in
-    consume_ ~ofmt ~f id
+    consume_ ~ofn ~f id
 end
 
 module RAction = struct
@@ -183,12 +183,12 @@ module RAction = struct
   let error (code, msg) = ServeNow (Error (code, msg))
 end
 
-let action_request ~ofmt ~id action =
+let action_request ~ofn ~id action =
   match action with
-  | RAction.ServeNow r -> Rq.answer ~ofmt ~id r
+  | RAction.ServeNow r -> Rq.answer ~ofn ~id r
   | RAction.Postpone p -> Rq.postpone ~id p
 
-let serve_postponed_requests ~ofmt rl = Int.Set.iter (Rq.serve ~ofmt) rl
+let serve_postponed_requests ~ofn rl = Int.Set.iter (Rq.serve ~ofn) rl
 
 (***********************************************************************)
 (* Start of protocol handlers *)
@@ -220,16 +220,16 @@ let get_uri_version params =
 
 let do_shutdown = RAction.now (Ok `Null)
 
-let do_open ~ofmt ~(state : State.t) params =
+let do_open ~ofn ~(state : State.t) params =
   let document =
     field "textDocument" params
     |> Lsp.Doc.TextDocumentItem.of_yojson |> Result.get_ok
   in
   let Lsp.Doc.TextDocumentItem.{ uri; version; text; _ } = document in
   let root_state, workspace = State.workspace_of_uri ~uri ~state in
-  Doc_manager.create ~ofmt ~root_state ~workspace ~uri ~raw:text ~version
+  Doc_manager.create ~ofn ~root_state ~workspace ~uri ~raw:text ~version
 
-let do_change ~ofmt params =
+let do_change ~ofn params =
   let uri, version = get_uri_version params in
   let changes = List.map U.to_assoc @@ list_field "contentChanges" params in
   match changes with
@@ -242,12 +242,12 @@ let do_change ~ofmt params =
     ()
   | change :: _ ->
     let raw = string_field "text" change in
-    let invalid_rq = Doc_manager.change ~ofmt ~uri ~version ~raw in
+    let invalid_rq = Doc_manager.change ~ofn ~uri ~version ~raw in
     let code = -32802 in
     let message = "Request got old in server" in
-    Int.Set.iter (Rq.cancel ~ofmt ~code ~message) invalid_rq
+    Int.Set.iter (Rq.cancel ~ofn ~code ~message) invalid_rq
 
-let do_close ~ofmt:_ params =
+let do_close ~ofn:_ params =
   let uri = get_uri params in
   Doc_manager.close ~uri
 
@@ -320,11 +320,11 @@ let do_trace params =
   let trace = string_field "value" params in
   LIO.set_trace_value (LIO.TraceValue.of_string trace)
 
-let do_cancel ~ofmt ~params =
+let do_cancel ~ofn ~params =
   let id = int_field "id" params in
   let code = -32800 in
   let message = "Cancelled by client" in
-  Rq.cancel ~ofmt ~code ~message id
+  Rq.cancel ~ofn ~code ~message id
 
 (***********************************************************************)
 
@@ -345,9 +345,9 @@ let version () =
   Format.asprintf "version %s, dev: %s, Coq version: %s" Version.server
     dev_version Coq_config.version
 
-let rec lsp_init_loop ic ofmt ~cmdline ~debug : (string * Coq.Workspace.t) list
-    =
-  match LIO.read_request ic with
+let rec lsp_init_loop ~ifn ~ofn ~cmdline ~debug :
+    (string * Coq.Workspace.t) list =
+  match ifn () with
   | Some (LSP.Message.Request { method_ = "initialize"; id; params }) ->
     (* At this point logging is allowed per LSP spec *)
     let message =
@@ -355,7 +355,7 @@ let rec lsp_init_loop ic ofmt ~cmdline ~debug : (string * Coq.Workspace.t) list
     in
     LIO.logMessage ~lvl:3 ~message;
     let result, dirs = Rq_init.do_initialize ~params in
-    Rq.answer ~ofmt ~id (Result.ok result);
+    Rq.answer ~ofn ~id (Result.ok result);
     LIO.logMessage ~lvl:3 ~message:"Server initialized";
     (* Workspace initialization *)
     let debug = debug || !Fleche.Config.v.debug in
@@ -367,40 +367,40 @@ let rec lsp_init_loop ic ofmt ~cmdline ~debug : (string * Coq.Workspace.t) list
   | Some (LSP.Message.Request { id; _ }) ->
     (* per spec *)
     LSP.mk_request_error ~id ~code:(-32002) ~message:"server not initialized"
-    |> LIO.send_json ofmt;
-    lsp_init_loop ic ofmt ~cmdline ~debug
+    |> ofn;
+    lsp_init_loop ~ifn ~ofn ~cmdline ~debug
   | Some (LSP.Message.Notification { method_ = "exit"; params = _ }) | None ->
     raise Lsp_exit
   | Some (LSP.Message.Notification _) ->
     (* We can't log before getting the initialize message *)
-    lsp_init_loop ic ofmt ~cmdline ~debug
+    lsp_init_loop ~ifn ~ofn ~cmdline ~debug
 
 (** Dispatching *)
-let dispatch_notification ~ofmt ~state ~method_ ~params : unit =
+let dispatch_notification ~ofn ~state ~method_ ~params : unit =
   match method_ with
   (* Lifecycle *)
   | "exit" -> raise Lsp_exit
   (* setTrace *)
   | "$/setTrace" -> do_trace params
   (* Document lifetime *)
-  | "textDocument/didOpen" -> do_open ~ofmt ~state params
-  | "textDocument/didChange" -> do_change ~ofmt params
-  | "textDocument/didClose" -> do_close ~ofmt params
+  | "textDocument/didOpen" -> do_open ~ofn ~state params
+  | "textDocument/didChange" -> do_change ~ofn params
+  | "textDocument/didClose" -> do_close ~ofn params
   | "textDocument/didSave" -> Cache.save_to_disk ()
   (* Cancel Request *)
-  | "$/cancelRequest" -> do_cancel ~ofmt ~params
+  | "$/cancelRequest" -> do_cancel ~ofn ~params
   (* NOOPs *)
   | "initialized" -> ()
   (* Generic handler *)
   | msg -> LIO.trace "no_handler" msg
 
-let dispatch_state_notification ~ofmt ~state ~method_ ~params : State.t =
+let dispatch_state_notification ~ofn ~state ~method_ ~params : State.t =
   match method_ with
   (* Workspace *)
   | "workspace/didChangeWorkspaceFolders" ->
-    do_changeWorkspaceFolders ~ofmt ~state params
+    do_changeWorkspaceFolders ~ofn ~state params
   | _ ->
-    dispatch_notification ~ofmt ~state ~method_ ~params;
+    dispatch_notification ~ofn ~state ~method_ ~params;
     state
 
 let dispatch_request ~method_ ~params : RAction.t =
@@ -428,21 +428,21 @@ let dispatch_request ~method_ ~params : RAction.t =
     LIO.trace "no_handler" msg;
     RAction.error (-32601, "method not found")
 
-let dispatch_request ~ofmt ~id ~method_ ~params =
-  dispatch_request ~method_ ~params |> action_request ~ofmt ~id
+let dispatch_request ~ofn ~id ~method_ ~params =
+  dispatch_request ~method_ ~params |> action_request ~ofn ~id
 
-let dispatch_request ~ofmt ~id ~method_ ~params =
-  try dispatch_request ~ofmt ~id ~method_ ~params
+let dispatch_request ~ofn ~id ~method_ ~params =
+  try dispatch_request ~ofn ~id ~method_ ~params
   with Doc_manager.AbortRequest ->
     (* -32603 = internal error *)
     let code = -32603 in
     let message = "Internal Document Request Queue Error" in
-    Rq.cancel ~ofmt ~code ~message id
+    Rq.cancel ~ofn ~code ~message id
 
-let dispatch_message ~ofmt ~state (com : LSP.Message.t) : State.t =
+let dispatch_message ~ofn ~state (com : LSP.Message.t) : State.t =
   match com with
   | Notification { method_; params } ->
-    dispatch_state_notification ~ofmt ~state ~method_ ~params
+    dispatch_state_notification ~ofn ~state ~method_ ~params
   | Request { id; method_; params } ->
-    dispatch_request ~ofmt ~id ~method_ ~params;
+    dispatch_request ~ofn ~id ~method_ ~params;
     state

--- a/controller/lsp_core.mli
+++ b/controller/lsp_core.mli
@@ -31,15 +31,15 @@ exception Lsp_exit
 
 (** Lsp special init loop *)
 val lsp_init_loop :
-     in_channel
-  -> Format.formatter
+     ifn:(unit -> Lsp.Base.Message.t option)
+  -> ofn:(Yojson.Safe.t -> unit)
   -> cmdline:Coq.Workspace.CmdLine.t
   -> debug:bool
   -> (string * Coq.Workspace.t) list
 
 (** Dispatch an LSP request or notification, requests may be postponed. *)
 val dispatch_message :
-  ofmt:Format.formatter -> state:State.t -> Lsp.Base.Message.t -> State.t
+  ofn:(Yojson.Safe.t -> unit) -> state:State.t -> Lsp.Base.Message.t -> State.t
 
 (** Serve postponed requests in the set, they can be stale *)
-val serve_postponed_requests : ofmt:Format.formatter -> Int.Set.t -> unit
+val serve_postponed_requests : ofn:(Yojson.Safe.t -> unit) -> Int.Set.t -> unit

--- a/fleche/doc.mli
+++ b/fleche/doc.mli
@@ -97,9 +97,10 @@ module Target : sig
   val reached : range:Lang.Range.t -> int * int -> bool
 end
 
-(** [check ~ofmt ~target ~doc ()], [target] will have Flèche stop after the
-    point specified there has been reached. *)
-val check : ofmt:Format.formatter -> target:Target.t -> doc:t -> unit -> t
+(** [check ~ofn ~target ~doc ()], check document [doc], [target] will have
+    Flèche stop after the point specified there has been reached. Output
+    function [ofn] is used to send partial results. *)
+val check : ofn:(Yojson.Safe.t -> unit) -> target:Target.t -> doc:t -> unit -> t
 
 (** [save ~doc] will save [doc] .vo file. It will fail if proofs are open, or if
     the document completion status is not [Yes] *)

--- a/fleche/io.ml
+++ b/fleche/io.ml
@@ -2,13 +2,13 @@ module CallBack = struct
   type t =
     { trace : string -> ?extra:string -> string -> unit
     ; send_diagnostics :
-           ofmt:Format.formatter
+           ofn:(Yojson.Safe.t -> unit)
         -> uri:Lang.LUri.File.t
         -> version:int
         -> Lang.Diagnostic.t list
         -> unit
     ; send_fileProgress :
-           ofmt:Format.formatter
+           ofn:(Yojson.Safe.t -> unit)
         -> uri:Lang.LUri.File.t
         -> version:int
         -> Progress.Info.t list
@@ -17,8 +17,8 @@ module CallBack = struct
 
   let default =
     { trace = (fun _ ?extra:_ _ -> ())
-    ; send_diagnostics = (fun ~ofmt:_ ~uri:_ ~version:_ _ -> ())
-    ; send_fileProgress = (fun ~ofmt:_ ~uri:_ ~version:_ _ -> ())
+    ; send_diagnostics = (fun ~ofn:_ ~uri:_ ~version:_ _ -> ())
+    ; send_fileProgress = (fun ~ofn:_ ~uri:_ ~version:_ _ -> ())
     }
 
   let cb = ref default
@@ -37,9 +37,9 @@ module Log = struct
 end
 
 module Report = struct
-  let diagnostics ~ofmt ~uri ~version d =
-    !CallBack.cb.send_diagnostics ~ofmt ~uri ~version d
+  let diagnostics ~ofn ~uri ~version d =
+    !CallBack.cb.send_diagnostics ~ofn ~uri ~version d
 
-  let fileProgress ~ofmt ~uri ~version d =
-    !CallBack.cb.send_fileProgress ~ofmt ~uri ~version d
+  let fileProgress ~ofn ~uri ~version d =
+    !CallBack.cb.send_fileProgress ~ofn ~uri ~version d
 end

--- a/fleche/io.mli
+++ b/fleche/io.mli
@@ -4,13 +4,13 @@ module CallBack : sig
           (** Send a log message, [extra] may contain information to be shown in
               verbose mode *)
     ; send_diagnostics :
-           ofmt:Format.formatter
+           ofn:(Yojson.Safe.t -> unit)
         -> uri:Lang.LUri.File.t
         -> version:int
         -> Lang.Diagnostic.t list
         -> unit
     ; send_fileProgress :
-           ofmt:Format.formatter
+           ofn:(Yojson.Safe.t -> unit)
         -> uri:Lang.LUri.File.t
         -> version:int
         -> Progress.Info.t list
@@ -29,14 +29,14 @@ end
 
 module Report : sig
   val diagnostics :
-       ofmt:Format.formatter
+       ofn:(Yojson.Safe.t -> unit)
     -> uri:Lang.LUri.File.t
     -> version:int
     -> Lang.Diagnostic.t list
     -> unit
 
   val fileProgress :
-       ofmt:Format.formatter
+       ofn:(Yojson.Safe.t -> unit)
     -> uri:Lang.LUri.File.t
     -> version:int
     -> Progress.Info.t list

--- a/lsp/io.mli
+++ b/lsp/io.mli
@@ -17,6 +17,9 @@
 
 (** JSON-RPC input/output *)
 
+(** Set the log function *)
+val set_log_fn : (Yojson.Safe.t -> unit) -> unit
+
 (** Read a JSON-RPC request from channel *)
 val read_raw_request : in_channel -> Yojson.Safe.t option
 
@@ -43,9 +46,6 @@ end
 
 (** Set the trace value *)
 val set_trace_value : TraceValue.t -> unit
-
-(** Set the log channel *)
-val set_log_channel : Format.formatter -> unit
 
 (** Send a [window/logMessage] notification to the client *)
 val logMessage : lvl:int -> message:string -> unit


### PR DESCRIPTION
Turns out the transport layer for the worker case is directly over JS objects, we thus generalize the IO types accordingly to prepare for the worker version of coq-lsp.