### PR TITLE
[controller] Reify yield action in the queue controller.

### DIFF
--- a/controller/coq_lsp.ml
+++ b/controller/coq_lsp.ml
@@ -24,68 +24,6 @@ module LSP = Lsp.Base
 open Controller
 open Lsp_core
 
-(***********************************************************************)
-(* The queue strategy is: we keep pending document checks in Doc_manager, they
-   are only resumed when the rest of requests in the queue are served.
-
-   Note that we should add a method to detect stale requests; maybe cancel them
-   when a new edit comes. *)
-
-(** Main event queue *)
-let request_queue = Queue.create ()
-
-type 'a cont =
-  | Cont of 'a
-  | Yield of 'a
-
-let check_or_yield ~ofn ~state =
-  match Doc_manager.Check.maybe_check ~ofn with
-  | None -> Yield state
-  | Some ready ->
-    let () = serve_postponed_requests ~ofn ready in
-    Cont state
-
-let dispatch_or_resume_check ~ofn ~state =
-  match Queue.peek_opt request_queue with
-  | None ->
-    (* This is where we make progress on document checking; kind of IDLE
-       workqueue. *)
-    Control.interrupt := false;
-    check_or_yield ~ofn ~state
-  | Some com ->
-    (* TODO: optimize the queue? EJGA: I've found that VS Code as a client keeps
-       the queue tidy by itself, so this works fine as now *)
-    ignore (Queue.pop request_queue);
-    LIO.trace "process_queue" ("Serving Request: " ^ LSP.Message.method_ com);
-    (* We let Coq work normally now *)
-    Control.interrupt := false;
-    Cont (dispatch_message ~ofn ~state com)
-
-(* Wrapper for the top-level call *)
-let dispatch_or_resume_check ~ofn ~state =
-  try Some (dispatch_or_resume_check ~ofn ~state) with
-  | U.Type_error (msg, obj) ->
-    LIO.trace_object msg obj;
-    Some (Yield state)
-  | Lsp_exit ->
-    (* EJGA: Maybe remove Lsp_exit and have dispatch_or_resume_check return an
-       action? *)
-    None
-  | exn ->
-    (* Note: We should never arrive here from Coq, as every call to Coq should
-       be wrapper in Coq.Protect. So hitting this codepath, is effectively a
-       coq-lsp internal error and should be fixed *)
-    let bt = Printexc.get_backtrace () in
-    let iexn = Exninfo.capture exn in
-    LIO.trace "process_queue"
-      (if Printexc.backtrace_status () then "bt=true" else "bt=false");
-    (* let method_name = LSP.Message.method_ com in *)
-    (* LIO.trace "process_queue" ("exn in method: " ^ method_name); *)
-    LIO.trace "print_exn [OCaml]" (Printexc.to_string exn);
-    LIO.trace "print_exn [Coq  ]" Pp.(string_of_ppcmds CErrors.(iprint iexn));
-    LIO.trace "print_bt  [OCaml]" bt;
-    Some (Yield state)
-
 (* Do cleanup here if necessary *)
 let exit_message () =
   let message = "server exiting" in
@@ -109,14 +47,6 @@ let rec process_queue ~ofn ~state =
     Thread.delay 0.1;
     process_queue ~ofn ~state
   | Some (Cont state) -> process_queue ~ofn ~state
-
-let process_input (com : LSP.Message.t) =
-  if Fleche.Debug.sched_wakeup then
-    LIO.trace "-> enqueue" (Format.asprintf "%.2f" (Unix.gettimeofday ()));
-  (* TODO: this is the place to cancel pending requests that are invalid, and in
-     general, to perform queue optimizations *)
-  Queue.push com request_queue;
-  Control.interrupt := true
 
 (* Main loop *)
 let lsp_cb =
@@ -190,9 +120,9 @@ let lsp_main bt coqcorelib coqlib ocamlpath vo_load_path ml_include_path =
     match ifn () with
     | None ->
       (* EOF, push an exit notication to the queue *)
-      process_input exit_notification
+      enqueue_message exit_notification
     | Some msg ->
-      process_input msg;
+      enqueue_message msg;
       read_loop ()
   in
 

--- a/controller/lsp_core.ml
+++ b/controller/lsp_core.ml
@@ -446,3 +446,74 @@ let dispatch_message ~ofn ~state (com : LSP.Message.t) : State.t =
   | Request { id; method_; params } ->
     dispatch_request ~ofn ~id ~method_ ~params;
     state
+
+(* Queue handling *)
+
+(***********************************************************************)
+(* The queue strategy is: we keep pending document checks in Doc_manager, they
+   are only resumed when the rest of requests in the queue are served.
+
+   Note that we should add a method to detect stale requests; maybe cancel them
+   when a new edit comes. *)
+
+type 'a cont =
+  | Cont of 'a
+  | Yield of 'a
+
+let check_or_yield ~ofn ~state =
+  match Doc_manager.Check.maybe_check ~ofn with
+  | None -> Yield state
+  | Some ready ->
+    let () = serve_postponed_requests ~ofn ready in
+    Cont state
+
+let request_queue = Queue.create ()
+
+let dispatch_or_resume_check ~ofn ~state =
+  match Queue.peek_opt request_queue with
+  | None ->
+    (* This is where we make progress on document checking; kind of IDLE
+       workqueue. *)
+    Control.interrupt := false;
+    check_or_yield ~ofn ~state
+  | Some com ->
+    (* TODO: optimize the queue? EJGA: I've found that VS Code as a client keeps
+       the queue tidy by itself, so this works fine as now *)
+    ignore (Queue.pop request_queue);
+    LIO.trace "process_queue" ("Serving Request: " ^ LSP.Message.method_ com);
+    (* We let Coq work normally now *)
+    Control.interrupt := false;
+    Cont (dispatch_message ~ofn ~state com)
+
+(* Wrapper for the top-level call *)
+let dispatch_or_resume_check ~ofn ~state =
+  try Some (dispatch_or_resume_check ~ofn ~state) with
+  | U.Type_error (msg, obj) ->
+    LIO.trace_object msg obj;
+    Some (Yield state)
+  | Lsp_exit ->
+    (* EJGA: Maybe remove Lsp_exit and have dispatch_or_resume_check return an
+       action? *)
+    None
+  | exn ->
+    (* Note: We should never arrive here from Coq, as every call to Coq should
+       be wrapper in Coq.Protect. So hitting this codepath, is effectively a
+       coq-lsp internal error and should be fixed *)
+    let bt = Printexc.get_backtrace () in
+    let iexn = Exninfo.capture exn in
+    LIO.trace "process_queue"
+      (if Printexc.backtrace_status () then "bt=true" else "bt=false");
+    (* let method_name = LSP.Message.method_ com in *)
+    (* LIO.trace "process_queue" ("exn in method: " ^ method_name); *)
+    LIO.trace "print_exn [OCaml]" (Printexc.to_string exn);
+    LIO.trace "print_exn [Coq  ]" Pp.(string_of_ppcmds CErrors.(iprint iexn));
+    LIO.trace "print_bt  [OCaml]" bt;
+    Some (Yield state)
+
+let enqueue_message (com : LSP.Message.t) =
+  if Fleche.Debug.sched_wakeup then
+    LIO.trace "-> enqueue" (Format.asprintf "%.2f" (Unix.gettimeofday ()));
+  (* TODO: this is the place to cancel pending requests that are invalid, and in
+     general, to perform queue optimizations *)
+  Queue.push com request_queue;
+  Control.interrupt := true

--- a/controller/lsp_core.mli
+++ b/controller/lsp_core.mli
@@ -37,9 +37,15 @@ val lsp_init_loop :
   -> debug:bool
   -> (string * Coq.Workspace.t) list
 
-(** Dispatch an LSP request or notification, requests may be postponed. *)
-val dispatch_message :
-  ofn:(Yojson.Safe.t -> unit) -> state:State.t -> Lsp.Base.Message.t -> State.t
+(** Actions the scheduler requests to callers *)
+type 'a cont =
+  | Cont of 'a
+  | Yield of 'a
 
-(** Serve postponed requests in the set, they can be stale *)
-val serve_postponed_requests : ofn:(Yojson.Safe.t -> unit) -> Int.Set.t -> unit
+(** Core scheduler: dispatch an LSP request or notification, check document and
+    wake up pending requests *)
+val dispatch_or_resume_check :
+  ofn:(Yojson.Safe.t -> unit) -> state:State.t -> State.t cont option
+
+(** Add a message to the queue *)
+val enqueue_message : Lsp.Base.Message.t -> unit


### PR DESCRIPTION
So we can reuse this code in the worker version.

We thus update the interface of Core, all that remains to see if we
can reify the two loops too.

We are basically doing algebraic effects, which can mean we may be going in the right direction for newer OCaml actually, that was not on purpose.
