### PR TITLE
doc: Restructure contributing guide (server+client guides)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ Some tips:
 
 [ocamlformat]: https://github.com/ocaml-ppx/ocamlformat
 
-## VS Code Extension guide
+## Cliente guide (VS Code Extension)
 
 The VS Code extension is setup as a standard `npm` Typescript + React package
 using `esbuild` as the bundler. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,24 +85,32 @@ Alternatively, you can also use the regular `dune build @check` etc... targets.
 
 #### Nix
 
-We have a Nix flake that you can use. For development it suffices to run `nix develop`.
+We have a Nix flake that you can use. 
 
-With the following line you can save the configuration in a Nix profile which will prevent the `nix store gc` from deleting the entries:
-```
-nix develop --profile nix/profiles/dev
-```
+1. Dependencies: for development it suffices to run `nix develop` to spawn a shell with the corresponding dependencies.
 
-You can also use the following line to reuse the same profile:
-```
-nix develop nix/profiles/dev
-```
+    With the following line you can save the configuration in a Nix profile which will prevent the `nix store gc` from deleting the entries:
+    ```
+    nix develop --profile nix/profiles/dev
+    ```
 
-In the case of the client, we expose separate shells, e.g client-vscode, would
-be
-```
-nix develop .#client-vscode
-```
-(this can be done on top of the original `nix develop`)
+    You can then use the following line to reuse the previous profile:
+    ```
+    nix develop nix/profiles/dev
+    ```
+
+2. Initialize submodules (as of today the `main` branch uses some submodules, which we plan to get rid of soon)
+  
+    ```sh
+    make submodules-init
+    ```
+
+3. Compile the server (the `coq-lsp` binary can be found in
+`_build/install/default/bin/coq-lsp`).
+
+    ```sh
+    make
+    ```
 
 You can view the list of packages and devShells that are exposed
 by running `nix flake show`.
@@ -152,6 +160,10 @@ The VS Code extension is setup as a standard `npm` Typescript + React package
 using `esbuild` as the bundler. 
 
 ### Setup 
+1. Navigate to the editor folder
+    ```sh
+    cd editor/code
+    ```
 1. Install `esbuild`:
     ```sh
     npm i esbuild
@@ -161,10 +173,10 @@ Then there are two ways to work with the VS Code extension: you can let VS Code
 itself take care of building it (preferred setup), or you can build it manually.
 
 #### Let VS Code handle building the project
-There is nothing to be done, VS Code will build the project automatically. You can skip to launching the extension. 
+There is nothing to be done, VS Code will build the project automatically when launching the extension. You can skip to [launching the extension](#launch-the-extension). 
 
 #### Manual build
-1. Move to the editor folder
+1. Navigate to the editor folder
     ```sh
     cd editor/code
     ```
@@ -196,6 +208,30 @@ Debug" panel in Visual Studio Code, or the F5 keybinding.
 You can of course install the extension in your `~/.vscode/` folder if so you
 desire, although this is not recommended.
 
+### Nix 
+In the case of the client we expose a separate shell, `client-vscode`, which can be spawned with the following line (this can be done on top of the original `nix develop`).
+```
+nix develop .#client-vscode
+```
+
+
+The steps to setup the client are similar to the manual build:
+1. Spawn `develop` shell 
+    ```sh
+    nix develop
+    ```
+2. Inside `develop`, spawn the `client-vscode` shell 
+    ```sh
+    nix develop .#client-vscode
+    ```
+3. Install `esbuild`
+    ```sh
+    npm i esbuild
+    ```
+4. Follow the steps in [manual build](#manual-build)
+
+You are now ready to [launch the extension](#launch-the-extension).
+
 ### Code organization
 The extension is divided into two main folders:
 - `editor/code/src/`: contains the main components,
@@ -224,7 +260,7 @@ right sourcemaps.
 
 `coq-lsp` is released using `dune-release tag` + `dune-release`.
 
-The checklist for the release as of today is:
+The checklist for the release as of today is the following:
 
 ### Client:
 
@@ -249,8 +285,8 @@ You should be able to use `coq-lsp` with
 
 Emacs support is a goal of `coq-lsp`, so if you find any trouble using `eglot` or `lsp-mode` with `coq-lsp`, please don't hesitate to open an issue. 
 
-# VIM
+## VIM
 
-`coq-lsp` should also run on VIM. 
+You should be able to use `coq-lsp` with VIM. 
 
-VIM/NeoVIM support is a goal of `coq-lsp`, so if you find any trouble using `coq-lsp` with VIM/NeoVIM, please don't hesitate to open an issue. 
+VIM support is a goal of `coq-lsp`, so if you find any trouble using `coq-lsp` with VIM, please don't hesitate to open an issue. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,10 +65,10 @@ Dune.
 1. Install the dependencies (the complete updated list of dependencies can be found in `coq-lsp.opam`).
 
     ```sh
-    opam install cmdliner yojson uri dune-build-info menhir ocamlfind zarith sexplib ppx_deriving ppx_sexp_conv ppx_compare ppx_hash ppx_import ppx_deriving_yojson
+    opam install --deps-only .
     ```
 
-2. Initialize submodules (as of today the `main` branch uses some submodules, which we plan to get rid of soon)
+2. Initialize submodules (the `main` branch uses some submodules, which we plan to get rid of soon. Branches `v8.x` can already skip this step.)
   
     ```sh
     make submodules-init
@@ -99,7 +99,7 @@ We have a Nix flake that you can use.
     nix develop nix/profiles/dev
     ```
 
-2. Initialize submodules (as of today the `main` branch uses some submodules, which we plan to get rid of soon)
+2. Initialize submodules (the `main` branch uses some submodules, which we plan to get rid of soon. Branches `v8.x` can already skip this step.)
   
     ```sh
     make submodules-init
@@ -154,6 +154,27 @@ Some tips:
 
 [ocamlformat]: https://github.com/ocaml-ppx/ocamlformat
 
+### Releasing
+
+`coq-lsp` is released using `dune-release tag` + `dune-release`.
+
+The checklist for the release as of today is the following:
+
+### Client:
+
+- update the client changelog at `editor/code/CHANGELOG.md`, commit
+- for the `main` branch: `dune release tag $coq_lsp_version`
+- check with `vsce ls` that the client contents are OK
+- `vsce publish`
+
+### Server:
+
+- sync branches for previous Coq versions, using `git merge`, test and push to CI.
+- `dune release tag` for each `$coq_lsp_version+$coq_version`
+- `dune release` for each version that should to the main opam repos
+- [optional] update pre-release packages to coq-opam-archive
+- [important] bump `version.ml` and `package.json` version string
+
 ## Client guide (VS Code Extension)
 
 The VS Code extension is setup as a standard `npm` Typescript + React package
@@ -164,9 +185,9 @@ using `esbuild` as the bundler.
     ```sh
     cd editor/code
     ```
-1. Install `esbuild`:
+1. Install dependencies:
     ```sh
-    npm i esbuild
+    npm i
     ```
 
 Then there are two ways to work with the VS Code extension: you can let VS Code
@@ -176,13 +197,9 @@ itself take care of building it (preferred setup), or you can build it manually.
 There is nothing to be done, VS Code will build the project automatically when launching the extension. You can skip to [launching the extension](#launch-the-extension). 
 
 #### Manual build
-1. Navigate to the editor folder
+1. Navigate to the editor folder 
     ```sh
     cd editor/code
-    ```
-2. Install dependencies:
-    ```sh
-    npm i
     ```
 
 You can now run `package.json` scripts the usual way:
@@ -224,11 +241,15 @@ The steps to setup the client are similar to the manual build:
     ```sh
     nix develop .#client-vscode
     ```
-3. Install `esbuild`
+1. Navigate to the editor folder
     ```sh
-    npm i esbuild
+    cd editor/code
     ```
-4. Follow the steps in [manual build](#manual-build)
+1. Install dependencies:
+    ```sh
+    npm i
+    ```
+4. Follow the steps in [manual build](#manual-build).
 
 You are now ready to [launch the extension](#launch-the-extension).
 
@@ -255,27 +276,6 @@ that, you want to use the web extension profile in the launch setup.
 
 The default build target will allow you to debug the extension by providing the
 right sourcemaps.
-
-## Releasing
-
-`coq-lsp` is released using `dune-release tag` + `dune-release`.
-
-The checklist for the release as of today is the following:
-
-### Client:
-
-- update the client changelog at `editor/code/CHANGELOG.md`, commit
-- for the `main` branch: `dune release tag $coq_lsp_version`
-- check with `vsce ls` that the client contents are OK
-- `vsce publish`
-
-### Server:
-
-- sync branches for previous Coq versions, using `git merge`, test and push to CI.
-- `dune release tag` for each `$coq_lsp_version+$coq_version`
-- `dune release` for each version that should to the main Coq repos
-- [optional] update pre-release packages to coq-opam-archive
-- [important] bump `version.ml` and `package.json` version string
 
 
 ## Emacs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ Some tips:
 
 [ocamlformat]: https://github.com/ocaml-ppx/ocamlformat
 
-## Cliente guide (VS Code Extension)
+## Client guide (VS Code Extension)
 
 The VS Code extension is setup as a standard `npm` Typescript + React package
 using `esbuild` as the bundler. 


### PR DESCRIPTION
Did a pass on the contributing guide:
- Rewrote the sections on compiling/setting the client as a step-by-step guide (mainly added list of steps)
- Split the Nix sections between the server and client (it was all inside the server guide)
- Added a bit more instructions on setting the client with Nix 
- Moved the `releasing` section outside the server guide