### PR TITLE
[init] Be more resilient to input, fix bug on workspace parsing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@
    #262)
  - Preliminary support to display document performance data in panel
    (@ejgallego, #181)
+ - Fix cases when workspace / root URIs are `null`, as per LSP spec,
+   (#453 , reported by orilahav, fixes #283)
 
 # coq-lsp 0.1.6: Peek
 ---------------------

--- a/controller/lsp_core.ml
+++ b/controller/lsp_core.ml
@@ -318,7 +318,9 @@ let do_lens = do_document_request ~handler:Rq_lens.request
 
 let do_trace params =
   let trace = string_field "value" params in
-  LIO.set_trace_value (LIO.TraceValue.of_string trace)
+  match LIO.TraceValue.of_string trace with
+  | Ok t -> LIO.set_trace_value t
+  | Error e -> LIO.trace "trace" ("invalid value: " ^ e)
 
 let do_cancel ~ofn ~params =
   let id = int_field "id" params in
@@ -342,8 +344,8 @@ let version () =
     | None -> "N/A"
     | Some bi -> Build_info.V1.Version.to_string bi
   in
-  Format.asprintf "version %s, dev: %s, Coq version: %s" Version.server
-    dev_version Coq_config.version
+  Format.asprintf "version %s, dev: %s, Coq version: %s, OS: %s" Version.server
+    dev_version Coq_config.version Sys.os_type
 
 module Init_effect = struct
   type t =

--- a/lsp/io.ml
+++ b/lsp/io.ml
@@ -75,10 +75,10 @@ module TraceValue = struct
     | Verbose
 
   let of_string = function
-    | "messages" -> Messages
-    | "verbose" -> Verbose
-    | "off" -> Off
-    | _ -> raise (Invalid_argument "TraceValue.parse")
+    | "messages" -> Ok Messages
+    | "verbose" -> Ok Verbose
+    | "off" -> Ok Off
+    | v -> Error ("TraceValue.parse: " ^ v)
 
   let to_string = function
     | Off -> "off"

--- a/lsp/io.mli
+++ b/lsp/io.mli
@@ -40,7 +40,7 @@ module TraceValue : sig
     | Messages
     | Verbose
 
-  val of_string : string -> t
+  val of_string : string -> (t, string) result
   val to_string : t -> string
 end
 


### PR DESCRIPTION
Workspace parsing must accept `null` as per LSP.

Beware we still require the invariant that at least one workspace is returned by init, we should maybe drop that at some point.

Thanks to orilahav for reporting and debugging this issue.

Fixes #283