### PR TITLE
[hover] Pass implicit information to printer.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@
    (@ejgallego, #181)
  - Fix cases when workspace / root URIs are `null`, as per LSP spec,
    (#453 , reported by orilahav, fixes #283)
+ - Pass implicit argument information to hover printer (@ejgallego, #453,
+   fixes #448)
 
 # coq-lsp 0.1.6: Peek
 ---------------------


### PR DESCRIPTION
This follows what Coq's `About` does upstream.

Note that still the printing is not very satisfactory in some cases, but in this case it seems Coq's `About` has the same problem.

So I'd suggest to close #448 and open an issue upstream about general implicit argument printing, WDYT @Alizter ?

Fixes #448.