### PR TITLE
[code] Fix goals command keybind

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
    (#453 , reported by orilahav, fixes #283)
  - Pass implicit argument information to hover printer (@ejgallego, #453,
    fixes #448)
+ - Fix keybinding for the "Show Goals at Point" command (@4ever2, #460)
 
 # coq-lsp 0.1.6: Peek
 ---------------------

--- a/editor/code/package.json
+++ b/editor/code/package.json
@@ -115,7 +115,7 @@
         "command": "coq-lsp.goals",
         "key": "alt+enter",
         "mac": "meta+enter",
-        "when": "editorTextFocus && (editorLangId == coq || editorLangId == coqmarkdown)"
+        "when": "editorTextFocus && editorLangId == coq || editorTextFocus && editorLangId == coqmarkdown"
       }
     ],
     "viewsContainers": {


### PR DESCRIPTION
The shortcut for the goals command is broken since VS Code doesn't allow parentheses in key binding `when` clauses.