### PR TITLE
meta: add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ml*             text eol=lf linguist-language=OCaml


### PR DESCRIPTION
This allows GitHub to correctly detect the lanugage for a given file extension. At the time, some .ml files were being classified as standard ml.

Signed-off-by: Ali Caglayan <alizter@gmail.com>

<!-- ps-id: aa5842e0-fb19-4ece-b8a8-d4ea9578b07f -->