### PR TITLE
[doc manager] Move postponement logic to document manager.

### DIFF
--- a/controller/lsp_core.ml
+++ b/controller/lsp_core.ml
@@ -32,6 +32,38 @@ let string_field name dict = U.to_string (field name dict)
 module LIO = Lsp.Io
 module LSP = Lsp.Base
 
+module Helpers = struct
+  (* helpers; fix to have better errors on wrong protocol code *)
+  let get_uri params =
+    let document =
+      field "textDocument" params
+      |> Lsp.Doc.TextDocumentIdentifier.of_yojson |> Result.get_ok
+    in
+    let Lsp.Doc.TextDocumentIdentifier.{ uri } = document in
+    uri
+
+  let get_uri_oversion params =
+    let document =
+      field "textDocument" params
+      |> Lsp.Doc.OVersionedTextDocumentIdentifier.of_yojson |> Result.get_ok
+    in
+    let Lsp.Doc.OVersionedTextDocumentIdentifier.{ uri; version } = document in
+    (uri, version)
+
+  let get_uri_version params =
+    let document =
+      field "textDocument" params
+      |> Lsp.Doc.VersionedTextDocumentIdentifier.of_yojson |> Result.get_ok
+    in
+    let Lsp.Doc.VersionedTextDocumentIdentifier.{ uri; version } = document in
+    (uri, version)
+
+  let get_position params =
+    let pos = dict_field "position" params in
+    let line, character = (int_field "line" pos, int_field "character" pos) in
+    (line, character)
+end
+
 (** LSP loop internal state: mainly the data needed to create a new document. In
     particular, we need:
 
@@ -86,61 +118,37 @@ let do_changeWorkspaceFolders ~ofn:_ ~state params =
   let state = List.fold_left State.del_workspace state removed in
   state
 
-module PendingRequest = struct
-  type t =
-    | DocRequest of
-        { uri : Lang.LUri.File.t
-        ; handler : Request.document
-        }
-    | PosRequest of
-        { uri : Lang.LUri.File.t
-        ; point : int * int
-        ; handler : Request.position
-        }
+(* main request module with [answer, postpone, cancel, serve] methods, basically
+   IO + glue with the doc_manager *)
+module Rq : sig
+  module Action : sig
+    type t =
+      | Immediate of Request.R.t
+      | Data of Request.Data.t
 
-  (* Debug printing *)
-  let data fmt = function
-    | DocRequest { uri = _; handler = _ } -> Format.fprintf fmt "{k:doc}"
-    | PosRequest { uri = _; point; handler = _ } ->
-      Format.fprintf fmt "{k:pos | l: %d, c: %d}" (fst point) (snd point)
+    val now : Request.R.t -> t
+    val error : int * string -> t
+  end
 
-  let postpone ~id pr =
-    match pr with
-    | DocRequest { uri; _ } -> Doc_manager.add_on_completion ~uri ~id
-    | PosRequest { uri; point; _ } -> Doc_manager.add_on_point ~uri ~id ~point
+  val serve : ofn:(J.t -> unit) -> id:int -> Action.t -> unit
+  val cancel : ofn:(J.t -> unit) -> code:int -> message:string -> int -> unit
 
-  let cancel ~id pr =
-    match pr with
-    | DocRequest { uri; _ } -> Doc_manager.remove_on_completion ~uri ~id
-    | PosRequest { uri; point; _ } ->
-      Doc_manager.remove_on_point ~uri ~id ~point
-
-  let serve pr =
-    match pr with
-    | DocRequest { uri; handler } ->
-      let doc = Doc_manager.find_doc ~uri in
-      handler ~doc
-    | PosRequest { uri; point; handler } ->
-      let doc = Doc_manager.find_doc ~uri in
-      handler ~point ~doc
-end
-
-(* main module with [answer, postpone, cancel, serve] methods *)
-module Rq = struct
-  (* Answer a request *)
+  val serve_postponed :
+    ofn:(J.t -> unit) -> doc:Fleche.Doc.t -> Int.Set.t -> unit
+end = struct
+  (* Answer a request, private *)
   let answer ~ofn ~id result =
     (match result with
     | Result.Ok result -> LSP.mk_reply ~id ~result
     | Error (code, message) -> LSP.mk_request_error ~id ~code ~message)
     |> ofn
 
-  (* private to the Rq module *)
-  let _rtable : (int, PendingRequest.t) Hashtbl.t = Hashtbl.create 673
+  (* private to the Rq module, just used not to retrigger canceled requests *)
+  let _rtable : (int, Request.Data.t) Hashtbl.t = Hashtbl.create 673
 
-  let postpone ~id (pr : PendingRequest.t) =
+  let postpone ~id (pr : Request.Data.t) =
     if Fleche.Debug.request_delay then
       LIO.trace "request" ("postponing rq : " ^ string_of_int id);
-    PendingRequest.postpone ~id pr;
     Hashtbl.add _rtable id pr
 
   (* Consumes a request, if alive, it answers mandatorily *)
@@ -156,7 +164,10 @@ module Rq = struct
   let cancel ~ofn ~code ~message id : unit =
     (* fail the request, do cleanup first *)
     let f pr =
-      let () = PendingRequest.cancel ~id pr in
+      let () =
+        let request = Request.Data.dm_request pr in
+        Doc_manager.Request.remove { id; request }
+      in
       Error (code, message)
     in
     consume_ ~ofn ~f id
@@ -164,61 +175,46 @@ module Rq = struct
   let debug_serve id pr =
     if Fleche.Debug.request_delay then
       LIO.trace "serving"
-        (Format.asprintf "rq: %d | %a" id PendingRequest.data pr)
+        (Format.asprintf "rq: %d | %a" id Request.Data.data pr)
 
-  let serve ~ofn id =
+  let serve_postponed ~ofn ~doc id =
     let f pr =
       debug_serve id pr;
-      PendingRequest.serve pr
+      Request.Data.serve ~doc pr
     in
     consume_ ~ofn ~f id
+
+  let query ~ofn ~id (pr : Request.Data.t) =
+    let request = Request.Data.dm_request pr in
+    match Doc_manager.Request.add { id; request } with
+    | Cancel ->
+      let code = -32802 in
+      let message = "Document is not ready" in
+      Error (code, message) |> answer ~ofn ~id
+    | Now doc ->
+      debug_serve id pr;
+      Request.Data.serve ~doc pr |> answer ~ofn ~id
+    | Postpone -> postpone ~id pr
+
+  module Action = struct
+    type t =
+      | Immediate of Request.R.t
+      | Data of Request.Data.t
+
+    let now r = Immediate r
+    let error (code, msg) = now (Error (code, msg))
+  end
+
+  let serve ~ofn ~id action =
+    match action with
+    | Action.Immediate r -> answer ~ofn ~id r
+    | Action.Data p -> query ~ofn ~id p
+
+  let serve_postponed ~ofn ~doc rl = Int.Set.iter (serve_postponed ~ofn ~doc) rl
 end
-
-module RAction = struct
-  type t =
-    | ServeNow of Request.R.t
-    | Postpone of PendingRequest.t
-
-  let now r = ServeNow r
-  let error (code, msg) = ServeNow (Error (code, msg))
-end
-
-let action_request ~ofn ~id action =
-  match action with
-  | RAction.ServeNow r -> Rq.answer ~ofn ~id r
-  | RAction.Postpone p -> Rq.postpone ~id p
-
-let serve_postponed_requests ~ofn rl = Int.Set.iter (Rq.serve ~ofn) rl
 
 (***********************************************************************)
-(* Start of protocol handlers *)
-
-(* helpers; fix to have better errors on wrong protocol code *)
-let get_uri params =
-  let document =
-    field "textDocument" params
-    |> Lsp.Doc.TextDocumentIdentifier.of_yojson |> Result.get_ok
-  in
-  let Lsp.Doc.TextDocumentIdentifier.{ uri } = document in
-  uri
-
-let get_uri_oversion params =
-  let document =
-    field "textDocument" params
-    |> Lsp.Doc.OVersionedTextDocumentIdentifier.of_yojson |> Result.get_ok
-  in
-  let Lsp.Doc.OVersionedTextDocumentIdentifier.{ uri; version } = document in
-  (uri, version)
-
-let get_uri_version params =
-  let document =
-    field "textDocument" params
-    |> Lsp.Doc.VersionedTextDocumentIdentifier.of_yojson |> Result.get_ok
-  in
-  let Lsp.Doc.VersionedTextDocumentIdentifier.{ uri; version } = document in
-  (uri, version)
-
-let do_shutdown = RAction.now (Ok `Null)
+(* Start of protocol handlers: document notifications                  *)
 
 let do_open ~ofn ~(state : State.t) params =
   let document =
@@ -230,7 +226,7 @@ let do_open ~ofn ~(state : State.t) params =
   Doc_manager.create ~ofn ~root_state ~workspace ~uri ~raw:text ~version
 
 let do_change ~ofn params =
-  let uri, version = get_uri_version params in
+  let uri, version = Helpers.get_uri_version params in
   let changes = List.map U.to_assoc @@ list_field "contentChanges" params in
   match changes with
   | [] ->
@@ -248,51 +244,25 @@ let do_change ~ofn params =
     Int.Set.iter (Rq.cancel ~ofn ~code ~message) invalid_rq
 
 let do_close ~ofn:_ params =
-  let uri = get_uri params in
+  let uri = Helpers.get_uri params in
   Doc_manager.close ~uri
 
-let get_textDocument params =
-  let uri = get_uri params in
-  let doc = Doc_manager.find_doc ~uri in
-  (uri, doc)
+let do_trace params =
+  let trace = string_field "value" params in
+  match LIO.TraceValue.of_string trace with
+  | Ok t -> LIO.set_trace_value t
+  | Error e -> LIO.trace "trace" ("invalid value: " ^ e)
 
-let get_textOVersionDocument params =
-  let uri, version = get_uri_oversion params in
-  let doc = Doc_manager.find_doc ~uri in
-  (uri, version, doc)
+(***********************************************************************)
+(* Start of protocol handlers: document requests                       *)
 
-let get_position params =
-  let pos = dict_field "position" params in
-  let line, character = (int_field "line" pos, int_field "character" pos) in
-  (line, character)
-
-let request_in_range ~(doc : Fleche.Doc.t) ~version (line, col) =
-  (* EJGA: I'd be nice to better share the code between postponement here and
-     request wake-up in [Doc_manager] (note how both call [Target.reached] *)
-  let in_range =
-    match doc.completed with
-    | Yes _ -> true
-    | Failed range | FailedPermanent range | Stopped range ->
-      Fleche.Doc.Target.reached ~range (line, col)
-  in
-  let in_range =
-    match version with
-    | None -> in_range
-    | Some version -> doc.version >= version && in_range
-  in
-  in_range
+let do_shutdown = Rq.Action.now (Ok `Null)
 
 let do_position_request ~postpone ~params ~handler =
-  let uri, version, doc = get_textOVersionDocument params in
-  let point = get_position params in
-  let in_range = request_in_range ~doc ~version point in
-  match (in_range, postpone) with
-  | true, _ -> RAction.now (handler ~doc ~point)
-  | false, true -> Postpone (PosRequest { uri; point; handler })
-  | false, false ->
-    let code = -32802 in
-    let message = "Document is not ready" in
-    RAction.error (code, message)
+  let uri, version = Helpers.get_uri_oversion params in
+  let point = Helpers.get_position params in
+  Rq.Action.Data
+    (Request.Data.PosRequest { uri; handler; point; version; postpone })
 
 let do_hover = do_position_request ~postpone:false ~handler:Rq_hover.hover
 let do_goals = do_position_request ~postpone:true ~handler:Rq_goals.goals
@@ -305,22 +275,13 @@ let do_completion =
 
 (* Requires the full document to be processed *)
 let do_document_request ~params ~handler =
-  let uri, doc = get_textDocument params in
-  match doc.completed with
-  | Yes _ -> RAction.now (handler ~doc)
-  | Stopped _ | Failed _ | FailedPermanent _ ->
-    Postpone (PendingRequest.DocRequest { uri; handler })
+  let uri = Helpers.get_uri params in
+  Rq.Action.Data (Request.Data.DocRequest { uri; handler })
 
 let do_symbols = do_document_request ~handler:Rq_symbols.symbols
 let do_document = do_document_request ~handler:Rq_document.request
 let do_save_vo = do_document_request ~handler:Rq_save.request
 let do_lens = do_document_request ~handler:Rq_lens.request
-
-let do_trace params =
-  let trace = string_field "value" params in
-  match LIO.TraceValue.of_string trace with
-  | Ok t -> LIO.set_trace_value t
-  | Error e -> LIO.trace "trace" ("invalid value: " ^ e)
 
 let do_cancel ~ofn ~params =
   let id = int_field "id" params in
@@ -363,7 +324,7 @@ let lsp_init_process ~ofn ~cmdline ~debug msg : Init_effect.t =
     in
     LIO.logMessage ~lvl:3 ~message;
     let result, dirs = Rq_init.do_initialize ~params in
-    Rq.answer ~ofn ~id (Result.ok result);
+    Rq.Action.now (Ok result) |> Rq.serve ~ofn ~id;
     LIO.logMessage ~lvl:3 ~message:"Server initialized";
     (* Workspace initialization *)
     let debug = debug || !Fleche.Config.v.debug in
@@ -410,13 +371,13 @@ let dispatch_state_notification ~ofn ~state ~method_ ~params : State.t =
     dispatch_notification ~ofn ~state ~method_ ~params;
     state
 
-let dispatch_request ~method_ ~params : RAction.t =
+let dispatch_request ~method_ ~params : Rq.Action.t =
   match method_ with
   (* Lifecyle *)
   | "initialize" ->
     LIO.trace "dispatch_request" "duplicate initialize request! Rejecting";
     (* XXX what's the error code here *)
-    RAction.error (-32600, "Invalid Request: server already initialized")
+    Rq.Action.error (-32600, "Invalid Request: server already initialized")
   | "shutdown" -> do_shutdown
   (* Symbols and info about the document *)
   | "textDocument/completion" -> do_completion ~params
@@ -433,18 +394,10 @@ let dispatch_request ~method_ ~params : RAction.t =
   (* Generic handler *)
   | msg ->
     LIO.trace "no_handler" msg;
-    RAction.error (-32601, "method not found")
+    Rq.Action.error (-32601, "method not found")
 
 let dispatch_request ~ofn ~id ~method_ ~params =
-  dispatch_request ~method_ ~params |> action_request ~ofn ~id
-
-let dispatch_request ~ofn ~id ~method_ ~params =
-  try dispatch_request ~ofn ~id ~method_ ~params
-  with Doc_manager.AbortRequest ->
-    (* -32603 = internal error *)
-    let code = -32603 in
-    let message = "Internal Document Request Queue Error" in
-    Rq.cancel ~ofn ~code ~message id
+  dispatch_request ~method_ ~params |> Rq.serve ~ofn ~id
 
 let dispatch_message ~ofn ~state (com : LSP.Message.t) : State.t =
   match com with
@@ -470,8 +423,8 @@ type 'a cont =
 let check_or_yield ~ofn ~state =
   match Doc_manager.Check.maybe_check ~ofn with
   | None -> Yield state
-  | Some ready ->
-    let () = serve_postponed_requests ~ofn ready in
+  | Some (ready, doc) ->
+    let () = Rq.serve_postponed ~ofn ~doc ready in
     Cont state
 
 let request_queue = Queue.create ()

--- a/controller/request.ml
+++ b/controller/request.ml
@@ -21,3 +21,40 @@ end
 
 type document = doc:Fleche.Doc.t -> R.t
 type position = doc:Fleche.Doc.t -> point:int * int -> R.t
+
+(** Requests that require data access *)
+module Data = struct
+  type t =
+    | DocRequest of
+        { uri : Lang.LUri.File.t
+        ; handler : document
+        }
+    | PosRequest of
+        { uri : Lang.LUri.File.t
+        ; point : int * int
+        ; version : int option
+        ; postpone : bool
+        ; handler : position
+        }
+
+  (* Debug printing *)
+  let data fmt = function
+    | DocRequest { uri = _; handler = _ } -> Format.fprintf fmt "{k:doc}"
+    | PosRequest { uri = _; point; version; postpone; handler = _ } ->
+      Format.fprintf fmt "{k:pos | l: %d, c: %d v: %a p: %B}" (fst point)
+        (snd point)
+        Format.(pp_print_option pp_print_int)
+        version postpone
+
+  let dm_request pr =
+    match pr with
+    | DocRequest { uri; handler = _ } -> Doc_manager.Request.(FullDoc { uri })
+    | PosRequest { uri; point; version; postpone; handler = _ } ->
+      Doc_manager.Request.(PosInDoc { uri; point; version; postpone })
+
+  let serve ~doc pr =
+    match pr with
+    | DocRequest { uri = _; handler } -> handler ~doc
+    | PosRequest { uri = _; point; version = _; postpone = _; handler } ->
+      handler ~point ~doc
+end

--- a/controller/request.mli
+++ b/controller/request.mli
@@ -21,3 +21,24 @@ end
 
 type document = doc:Fleche.Doc.t -> R.t
 type position = doc:Fleche.Doc.t -> point:int * int -> R.t
+
+(** Requests that require data access *)
+module Data : sig
+  type t =
+    | DocRequest of
+        { uri : Lang.LUri.File.t
+        ; handler : document
+        }
+    | PosRequest of
+        { uri : Lang.LUri.File.t
+        ; point : int * int
+        ; version : int option
+        ; postpone : bool
+        ; handler : position
+        }
+
+  (* Debug printing *)
+  val data : Format.formatter -> t -> unit
+  val dm_request : t -> Doc_manager.Request.request
+  val serve : doc:Fleche.Doc.t -> t -> R.t
+end


### PR DESCRIPTION
Document manager is the current owner of the build state, so it makes sense that it is the component to decide whether a (data) request should be postponed.

This fixes two code todos (`AbortRequest` and duplication of checks) and should open the way for a deeper refactoring of `Doc_manager` towards a true build system for a set of documents.