### PR TITLE
Reduce thread delay in process queue for a speedup on short commands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# coq-lsp 0.1.8
+---------------
+ - Decrease latency of requests by ~4x by reducing threading timer
+   (fix suggested by @ejgallego, implemented by @hazardouspeach)
+
 # coq-lsp 0.1.7: Just-in-time
 -----------------------------
 

--- a/controller/coq_lsp.ml
+++ b/controller/coq_lsp.ml
@@ -44,7 +44,7 @@ let rec process_queue ~ofn ~state =
        I/O *)
     exit 0
   | Some (Yield state) ->
-    Thread.delay 0.1;
+    Thread.delay 0.01;
     process_queue ~ofn ~state
   | Some (Cont state) -> process_queue ~ofn ~state
 


### PR DESCRIPTION
Instructions to compare performance across branches, as well as timing numbers from a particular machine, are available here: https://pastebin.com/TzBKPj3W. Depending on machine, this seems to lead to 2-4x speedup.