### PR TITLE
Added required support for ViZX Extension

### DIFF
--- a/editor/code/src/goals.ts
+++ b/editor/code/src/goals.ts
@@ -1,4 +1,4 @@
-import { Position, Uri, WebviewPanel, window, ViewColumn } from "vscode";
+import { Position, Uri, WebviewPanel, window, ViewColumn, extensions, commands } from "vscode";
 import {
   BaseLanguageClient,
   RequestType,
@@ -78,6 +78,10 @@ export class InfoPanel {
   // notify the info panel that we have fresh goals to render
   requestDisplay(goals: GoalAnswer<PpString>) {
     this.postMessage("renderGoals", goals);
+    let vizx = extensions.getExtension("inQWIRE.vizx");
+    if (vizx?.isActive) {
+      commands.executeCommand("vizx.lspRender", goals);
+    }
   }
 
   // notify the info panel that we found an error
@@ -89,6 +93,7 @@ export class InfoPanel {
   sendGoalsRequest(client: BaseLanguageClient, params: GoalRequest) {
     this.requestSent(params);
     client.sendRequest(infoReq, params).then(
+      // send message to vyzx here
       (goals) => this.requestDisplay(goals),
       (reason) => this.requestError(reason)
     );

--- a/editor/code/src/goals.ts
+++ b/editor/code/src/goals.ts
@@ -93,7 +93,6 @@ export class InfoPanel {
   sendGoalsRequest(client: BaseLanguageClient, params: GoalRequest) {
     this.requestSent(params);
     client.sendRequest(infoReq, params).then(
-      // send message to vyzx here
       (goals) => this.requestDisplay(goals),
       (reason) => this.requestError(reason)
     );


### PR DESCRIPTION
ViZX can be found [here](https://marketplace.visualstudio.com/items?itemName=inQWIRE.vizx). I just added code to execute a ViZX command when the extension is active; the goal is to enrich some textual goal display with a visualization; this command will simply open a webview with the visualization. ViZX has to be installed and active for the command to be executed; the goals object is the only information passed to ViZX.