### PR TITLE
[getDocument] Be more resilient on unknown ASTs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,8 @@
    (@ejgallego, @hazardouspeach, #467, #471)
  - Warnings from `_CoqProject` files are now applied (@ejgallego,
    reported by @arthuraa, #500)
+ - Be more resilient when serializing unknowns Asts (@ejgallego, #503,
+   reported by Gijs Pennings)
 
 # coq-lsp 0.1.6: Peek
 ---------------------

--- a/lsp/jCoq.ml
+++ b/lsp/jCoq.ml
@@ -62,6 +62,10 @@ end
 module Ast = struct
   type t = Coq.Ast.t
 
+  (* XXX: Better catch the exception below, but this requires a new SerAPI
+     release *)
+  let () = Serlib.Serlib_base.exn_on_opaque := false
+
   let to_yojson x =
     Serlib.Ser_vernacexpr.vernac_control_to_yojson (Coq.Ast.to_coq x)
 


### PR DESCRIPTION
As seen in
https://coq.zulipchat.com/#narrow/stream/329642-coq-lsp/topic/coq.2FgetDocument.20error we don't want to error when we can't serialize some Ast properly, but instead provide a fallback.

Doing this properly requires `Serlib_base` to expose the exception, we use the hack for now until we can bump the `serlib` dep.