### PR TITLE
[coq] Support for token-based interruption

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ recommend that if you are installing via opam, you use the following branches
 that have some fixes backported:
 
 - For 8.20: No known problems
-- For 8.19: No known problems
+- For 8.19: `opam pin add coq-core https://github.com/ejgallego/coq.git#v8.19+lsp`
 - For 8.18: `opam pin add coq-core https://github.com/ejgallego/coq.git#v8.18+lsp`
 - For 8.17: `opam pin add coq-core https://github.com/ejgallego/coq.git#v8.17+lsp`
 - For 8.16: `opam pin add coq      https://github.com/ejgallego/coq.git#v8.16+lsp`

--- a/coq/limits.ml
+++ b/coq/limits.ml
@@ -57,8 +57,16 @@ let select = function
   | Coq -> backend := (module Coq)
   | Mp -> backend := (module Mp)
 
+(* Set this to false for 8.19 and lower *)
+let sane_coq_base_version = true
+
+let sane_coq_branch =
+  CString.string_contains ~where:Coq_config.version ~what:"+lsp"
+
+let safe_coq = sane_coq_base_version || sane_coq_branch
+
 let select_best = function
-  | None -> if Mp.available then select Mp else select Coq
+  | None -> if Mp.available && safe_coq then select Mp else select Coq
   | Some backend -> select backend
 
 module Token = struct

--- a/etc/doc/USER_MANUAL.md
+++ b/etc/doc/USER_MANUAL.md
@@ -79,7 +79,11 @@ not fully completed. Also, you can work with bullets and `coq-lsp`
 will automatically admit unfinished ones, so you can follow the
 natural proof structure.
 
-## Settings
+### Embedded Markdown and LaTeX documents
+
+
+
+## Coq LSP Settings
 
 ### Goal display
 
@@ -90,6 +94,9 @@ Several settings for goal display exist.
 A setting to have `coq-lsp` check documents continuously exists.
 
 ## Memory management
+
+You can tell the server to free up memory with the "Coq LSP: Free
+memory" command.
 
 ## Advanced: Multiple workspaces
 
@@ -119,10 +126,13 @@ on Coq <= 8.19 do need to install a version of Coq with the backported
 fixes. See the information about Coq upstream bugs in the README for
 more information about available branches.
 
+`coq-lsp` will reject to enable the new interruption mode by default
+on Coq < 8.20 unless the `lsp` Coq branch version is detected.
+
 ## Advanced incremental tricks
 
 You can use the `Reset $id` and `Back $steps` commands to isolate
-parts of the document from each others in terms of rechecking.
+parts of the document from each other in terms of rechecking.
 
 For example, the command `Reset $id` will make the parts of the
 document after it use the state before the node `id` was found. Thus,


### PR DESCRIPTION
This very preliminary PR reifies the Coq API so we can pass an interruption / cancellation token around.

Two implementations of the API are provided:
- one using the "classical" `Control.interrupt` variable present in Coq
- one using `memprof-limits` by @gadmm

The code is very preliminary and will likely be rewritten to better accomodate the API, however the current version works, and testing is much appreciated! This is a delicate part of the system so testing is badly needed.

In the examples we had, `memprof-limits` works superb! In particular it works in all the examples where polling fails :D 

I think this should allow us to get rid of Coq polling eventually.

Some open issues:
- While token-based interruption works pretty well, there are a few corner cases where the user experience is not optimal. In particular, when a command that takes a lot of time to run (like a `Qed`) is interrupted (for example the user does a search), we need to restart it from scratch. That's a big PITA. We could solve this in OCaml 5 both with Domains or algebraic effects + continuations, however....
- ... unfortunately `memprof-limits` is still not ported to OCaml 5, thus https://github.com/ocaml/ocaml/issues/11411 is still open.

Also, it didn't take long for us to find a bug in Coq and how they handle resources, c.f. https://github.com/coq/coq/issues/17760

Thanks to @gadmm for all the interest and help.

Also cc: @HazardousPeach 

Bugs fixed when using the `memprof-limits` backend: #139 #484 #487 