### PR TITLE
[coq] Don't link the STM

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,7 @@
    reported by @arthuraa, #500)
  - Be more resilient when serializing unknowns Asts (@ejgallego, #503,
    reported by Gijs Pennings)
+ - Coq's STM is not linked anymore to `coq-lsp` (@ejgallego, #511)
 
 # coq-lsp 0.1.6: Peek
 ---------------------

--- a/coq/dune
+++ b/coq/dune
@@ -3,4 +3,4 @@
  (public_name coq-lsp.coq)
  ; Unfortunate we have to link the STM due to the LTAC plugin
  ; depending on it, we should fix this upstream
- (libraries lang coq-core.vernac coq-core.stm coq-serapi.serlib))
+ (libraries lang coq-core.vernac coq-serapi.serlib))


### PR DESCRIPTION
This has been possible since some time in Coq `master`