### PR TITLE
[fleche] Add preliminary Document Completion hook

### DIFF
--- a/fleche/doc.mli
+++ b/fleche/doc.mli
@@ -54,6 +54,8 @@ module Completion : sig
     | Failed of Lang.Range.t  (** Critical failure, like an anomaly *)
     | FailedPermanent of Lang.Range.t
         (** Temporal Coq hack, avoids any computation *)
+
+  val is_completed : t -> bool
 end
 
 (** A Flèche document is basically a [node list], which is a crude form of a


### PR DESCRIPTION
Closes #506

Note the change of semantics for the document diagnostics modification, before we relied on `Theory` sending the diags on stop, we now properly send them as a part of eager diagnostics.