### PR TITLE
[build] [test] Fix CRAM tests on OPAM files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ test: build test/server/node_modules
 	cd test/server && npm test
 
 .PHONY: test-compiler
-test-compiler: build
-	OCAMLPATH=_build/install/default/lib:$$OCAMLPATH FCC_TEST=true dune runtest
+test-compiler:
+	dune runtest
 
 .PHONY: fmt format
 fmt format:

--- a/test/compiler/dune
+++ b/test/compiler/dune
@@ -2,4 +2,6 @@
  (deps
   (source_tree proj1)
   (source_tree proj2)
+  ; For the plugins to be built
+  (package coq-lsp)
   %{bin:fcc}))

--- a/test/compiler/run.t
+++ b/test/compiler/run.t
@@ -1,6 +1,7 @@
 General tests for the Flèche Compiler
 
 Describe the project
+  $ export FCC_TEST=true
   $ fcc --root proj1
   [message] Configuration loaded from Command-line arguments
    - coqlib is at: [TEST_PATH]


### PR DESCRIPTION
We stop using makefile hacks and set the test sanitization in the `run.t` file, and the plugin deps in the `dune` file.