### PR TITLE
[lsp] Fix bug when retrieving URIs from document params

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@
    Saavedra (@Nfsaavedra, #536)
  - Properly concatenate warnings from _CoqProject (@ejgallego,
    reported by @mituharu, #541, fixes #540)
+ - Fix broken `coq/saveVo` and `coq/getDocument` requests due to a
+   parsing problem with extra fields in their requests (@ejgallego,
+   #549, reported by @Zimmi48)
 
 # coq-lsp 0.1.7: Just-in-time
 -----------------------------

--- a/lsp/doc.ml
+++ b/lsp/doc.ml
@@ -17,8 +17,10 @@ module TextDocumentItem = struct
   [@@deriving yojson]
 end
 
+(* Sometimes we use this to parse VersionedTextDocumentIdentifier, we use {
+   strict = false } as a quick fix *)
 module TextDocumentIdentifier = struct
-  type t = { uri : Lang.LUri.File.t } [@@deriving yojson]
+  type t = { uri : Lang.LUri.File.t } [@@deriving yojson { strict = false }]
 end
 
 module OVersionedTextDocumentIdentifier = struct


### PR DESCRIPTION
That made the `coq/saveVo` fail with an invalid parsing error.

The issue was that when we handle generically the requests that need to wait for the document to be completed, we were retrieving the `uri` parameter using the de-serializer for the `TextDocumentIdentifier` data-type, however both `coq/getDocument` and `coq/saveVo` use `VersionedTextDocumentIdentifier`.

As the JSON parser finds this extra param, it fails. We solve this making the parser in this case no strict, but further hardening is needed at this level.

Thanks to Théo Zimmerman for the report and help with debugging this issue.