### PR TITLE
[ci] Fix test suite on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,15 +59,17 @@ jobs:
       - name: 🐫🐪🐫 Get dependencies
         run: opam exec -- make opam-deps
 
+      - name: 🐛 Test coq-lsp
+        if: matrix.os == 'windows-latest'
+        run: opam exec -- make winconfig
+
       - name: 🧱 Build coq-lsp
         run: opam exec -- make build
 
       - name: 🐛 Test coq-lsp
-        if: matrix.os != 'windows-latest'
         run: opam exec -- make test
 
       - name: 🐛 Test fcc
-        if: matrix.os != 'windows-latest'
         run: opam exec -- make test-compiler
 
   build-nix:

--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,27 @@ watch: coq_boot
 build-all: coq_boot
 	dune build $(DUNEOPT) @all
 
-# We set -libdir due to a Coq bug on win32, see https://github.com/coq/coq/pull/17289
+# We set -libdir due to a Coq bug on win32, see
+# https://github.com/coq/coq/pull/17289 , this can be removed once we
+# drop support for Coq 8.16
 vendor/coq/config/coq_config.ml:
-	cd vendor/coq \
-	&& ./configure -no-ask -prefix $(shell pwd)/_build/install/default/ \
-	        -libdir $(shell pwd)/_build/install/default/lib/coq \
+	EPATH=$(shell pwd) \
+	&& cd vendor/coq \
+	&& ./configure -no-ask -prefix "$$EPATH/_build/install/default/" \
+	        -libdir "$$EPATH/_build/install/default/lib/coq" \
+		-native-compiler no \
+	&& cp theories/dune.disabled theories/dune \
+	&& cp user-contrib/Ltac2/dune.disabled user-contrib/Ltac2/dune
+
+# We set windows parameters a bit better, note the need to use forward
+# slashed (cygpath -m) due to escaping :( , a conversion to `-w` is
+# welcomed if someones has time for this
+.PHONY: winconfig
+winconfig:
+	EPATH=$(shell cygpath -am .) \
+	&& cd vendor/coq \
+	&& ./configure -no-ask -prefix "$$EPATH\\_build\\install\\default\\" \
+	        -libdir "$$EPATH\\_build\\install\\default\\lib\\coq\\" \
 		-native-compiler no \
 	&& cp theories/dune.disabled theories/dune \
 	&& cp user-contrib/Ltac2/dune.disabled user-contrib/Ltac2/dune


### PR DESCRIPTION
Reverts #423 , the problem was due to us executing the tests natively from the Windows Powershell (as we want things to run), however we did set the path to a Cygwin-style one which didn't work from Powershell.

Closes #424 cc: #1 #481