### PR TITLE
[fcc] Understand arguments for Coq environment

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
  - Fix broken `coq/saveVo` and `coq/getDocument` requests due to a
    parsing problem with extra fields in their requests (@ejgallego,
    #547, reported by @Zimmi48)
+ - `fcc` now understands the `--coqlib`, `--coqcorelib`,
+   `--ocamlpath`, `-Q` and `-R` arguments (@ejgallego, #555)
 
 # coq-lsp 0.1.7: Just-in-time
 -----------------------------

--- a/compiler/args.ml
+++ b/compiler/args.ml
@@ -6,7 +6,8 @@ module Display = struct
 end
 
 type t =
-  { roots : string list  (** workspace root(s) *)
+  { cmdline : Coq.Workspace.CmdLine.t
+  ; roots : string list  (** workspace root(s) *)
   ; files : string list  (** files to compile *)
   ; debug : bool  (** run in debug mode *)
   ; display : Display.t  (** display level *)

--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -21,22 +21,12 @@ let load_plugin plugin_name = Fl_dynload.load_packages [ plugin_name ]
 let plugin_init = List.iter load_plugin
 
 let go args =
-  let { Args.roots; display; debug; files; plugins } = args in
+  let { Args.cmdline; roots; display; debug; files; plugins } = args in
   (* Initialize event callbacks *)
   let io = Output.init display in
   (* Initialize Coq *)
   let debug = debug || Fleche.Debug.backtraces || !Fleche.Config.v.debug in
   let root_state = coq_init ~debug in
-  let cmdline =
-    { Coq.Workspace.CmdLine.coqcorelib =
-        Filename.concat Coq_config.coqlib "../coq-core/"
-    ; coqlib = Coq_config.coqlib
-    ; ocamlpath = None
-    ; vo_load_path = []
-    ; ml_include_path = []
-    ; args = []
-    }
-  in
   let roots = if List.length roots < 1 then [ Sys.getcwd () ] else roots in
   let workspaces =
     List.map (fun dir -> (dir, Coq.Workspace.guess ~cmdline ~debug ~dir)) roots


### PR DESCRIPTION
`fcc` now understands the `--coqlib`, `--coqcorelib`, `--ocamlpath`, '-Q`, and `-R` arguments.