### PR TITLE
[build] Don't use `-rectypes` on compilation.

### DIFF
--- a/dune
+++ b/dune
@@ -1,7 +1,1 @@
-(env
- (dev
-  (flags :standard -rectypes))
- (release
-  (flags :standard -rectypes)))
-
 (vendored_dirs vendor)


### PR DESCRIPTION
It's been a while Coq doesn't require that.