### PR TITLE
[goals] [fleche] Add tactic-based preprocessing to goals request.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,9 @@
  - New lexical qed detection error recovery rule; this makes a very
    large usability difference in practice when editing inside proofs.
    (@ejgallego, #567, fixes #33)
+ - New `pretac` field for preprocessing of goals with a tactic using
+   speculative execution, this is experimental for now (@amblafont,
+   @ejgallego, #573, helps with #558)
 
 # coq-lsp 0.1.7: Just-in-time
 -----------------------------

--- a/controller/lsp_core.ml
+++ b/controller/lsp_core.ml
@@ -297,9 +297,12 @@ let get_pp_format params =
     get_pp_format_from_config ()
   | None -> get_pp_format_from_config ()
 
+let get_pretac params = ostring_field "pretac" params
+
 let do_goals ~params =
   let pp_format = get_pp_format params in
-  let handler = Rq_goals.goals ~pp_format in
+  let pretac = get_pretac params in
+  let handler = Rq_goals.goals ~pp_format ?pretac () in
   do_position_request ~postpone:true ~handler ~params
 
 let do_definition =

--- a/controller/rq_goals.ml
+++ b/controller/rq_goals.ml
@@ -35,16 +35,57 @@ let pp ~pp_format pp =
   | Pp -> Lsp.JCoq.Pp.to_yojson pp
   | Str -> `String (Pp.string_of_ppcmds pp)
 
-let goals ~pp_format ~doc ~point =
+(* XXX: Speculative execution here requires more thought, about errors,
+   location, we need to make the request fail if it is not good, etc... Moreover
+   we should tune whether we cache the results; we try this for now. *)
+let parse_and_execute_in tac st =
+  (* Parse tac, loc==FIXME *)
+  let str = Gramlib.Stream.of_string tac in
+  let str = Coq.Parsing.Parsable.make ?loc:None str in
+  match Coq.Parsing.parse ~st str with
+  | Coq.Protect.E.{ r = Interrupted; feedback = _ }
+  | Coq.Protect.E.{ r = Completed (Error _); feedback = _ }
+  | Coq.Protect.E.{ r = Completed (Ok None); feedback = _ } -> None
+  | Coq.Protect.E.{ r = Completed (Ok (Some ast)); feedback = _ } -> (
+    let open Fleche.Memo in
+    (* XXX use the bind in Coq.Protect.E *)
+    match (Interp.eval (st, ast)).res with
+    | Coq.Protect.E.{ r = Interrupted; feedback = _ }
+    | Coq.Protect.E.{ r = Completed (Error _); feedback = _ } -> None
+    | Coq.Protect.E.{ r = Completed (Ok st); feedback = _ } -> Some st)
+
+let run_pretac ?pretac st =
+  match pretac with
+  | None ->
+    (* Debug option *)
+    (* Lsp.Io.trace "goals" "pretac empty"; *)
+    Some st
+  | Some tac -> Fleche.Info.in_state ~st ~f:(parse_and_execute_in tac) st
+
+let get_goal_info ~doc ~point ?pretac () =
+  let open Fleche in
+  let goals_mode = get_goals_mode () in
+  let node = Info.LC.node ~doc ~point goals_mode in
+  match node with
+  | None -> None
+  | Some node ->
+    let st = run_pretac ?pretac node.Doc.Node.state in
+    Option.bind st (fun st ->
+        let goals = Info.Goals.goals ~st in
+        let program = Info.Goals.program ~st in
+        Some (goals, program))
+
+let option_split = Option.cata (fun (x, y) -> (Some x, Some y)) (None, None)
+
+let goals ~pp_format ?pretac () ~doc ~point =
   let open Fleche in
   let uri, version = (doc.Doc.uri, doc.version) in
   let textDocument = Lsp.Doc.VersionedTextDocumentIdentifier.{ uri; version } in
   let position =
     Lang.Point.{ line = fst point; character = snd point; offset = -1 }
   in
-  let goals_mode = get_goals_mode () in
-  let goals = Info.LC.goals ~doc ~point goals_mode in
-  let program = Info.LC.program ~doc ~point goals_mode in
+  let goals, program = get_goal_info ~doc ~point ?pretac () |> option_split in
+  let goals = Option.flatten goals in
   let node = Info.LC.node ~doc ~point Exact in
   let messages = mk_messages node in
   let error = Option.bind node mk_error in

--- a/controller/rq_goals.mli
+++ b/controller/rq_goals.mli
@@ -9,4 +9,6 @@ type format =
   | Pp
   | Str
 
-val goals : pp_format:format -> Request.position
+(** [goals ~pp_format ?pretac] Serve goals at point; users can request
+    pre-processing and formatting using the provided parameters. *)
+val goals : pp_format:format -> ?pretac:string -> unit -> Request.position

--- a/controller/rq_hover.ml
+++ b/controller/rq_hover.ml
@@ -108,7 +108,7 @@ let info_of_id ~st id =
 
 let info_of_id_at_point ~node id =
   let st = node.Fleche.Doc.Node.state in
-  Fleche.Info.LC.in_state ~st ~f:(info_of_id ~st) id
+  Fleche.Info.in_state ~st ~f:(info_of_id ~st) id
 
 let pp_typ id = function
   | Def typ ->

--- a/editor/code/lib/types.ts
+++ b/editor/code/lib/types.ts
@@ -69,6 +69,7 @@ export interface GoalRequest {
   textDocument: VersionedTextDocumentIdentifier;
   position: Position;
   pp_format?: "Pp" | "Str";
+  pretac?: string;
 }
 
 export type Pp =

--- a/editor/code/src/goals.ts
+++ b/editor/code/src/goals.ts
@@ -126,6 +126,8 @@ export class InfoPanel {
       uri.toString(),
       version
     );
+    // let pretac = "idtac.";
+    // let cursor: GoalRequest = { textDocument, position, pretac };
     let cursor: GoalRequest = { textDocument, position };
     let strCursor: GoalRequest = {
       textDocument,

--- a/etc/doc/PROTOCOL.md
+++ b/etc/doc/PROTOCOL.md
@@ -80,6 +80,7 @@ interface GoalRequest {
     textDocument: VersionedTextDocumentIdentifier;
     position: Position;
     pp_format?: 'Pp' | 'Str';
+    pretac?: string;
 }
 ```
 
@@ -162,6 +163,7 @@ was the default.
 
 #### Changelog
 
+- v0.1.8: new optional `pretac` field for post-processing, backwards compatible with 0.1.7
 - v0.1.7: program information added, rest of fields compatible with 0.1.6
 - v0.1.7: pp_format field added to request, backwards compatible
 - v0.1.6: the `Pp` parameter can now be either Coq's `Pp.t` type or `string` (default)

--- a/fleche/info.mli
+++ b/fleche/info.mli
@@ -47,13 +47,19 @@ module type S = sig
   val node : (approx, Doc.Node.t) query
   val range : (approx, Lang.Range.t) query
   val ast : (approx, Doc.Node.Ast.t) query
-  val goals : (approx, Pp.t Coq.Goals.reified_pp) query
-  val program : (approx, Declare.OblState.View.t Names.Id.Map.t) query
   val messages : (approx, Doc.Node.Message.t list) query
   val info : (approx, Doc.Node.Info.t) query
   val completion : (string, string list) query
-  val in_state : st:Coq.State.t -> f:('a -> 'b option) -> 'a -> 'b option
 end
 
 module LC : S with module P := LineCol
 module O : S with module P := Offset
+
+(** Helper that absorbs errors into [None] *)
+val in_state : st:Coq.State.t -> f:('a -> 'b option) -> 'a -> 'b option
+
+(** We move towards a more modular design here, for preprocessing *)
+module Goals : sig
+  val goals : st:Coq.State.t -> Pp.t Coq.Goals.reified_pp option
+  val program : st:Coq.State.t -> Declare.OblState.View.t Names.Id.Map.t
+end


### PR DESCRIPTION
We add a new parameter `pretac` to the `GoalRequest`, that allows to query for goals but running a set of tactics (or commands) first.

This is an experiment for now; in particular it'd be nice to rework the API for speculative execution prior merge.

This should help a great way towards #558 
