### PR TITLE
[workspace] Support `-rifrom` option.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,9 @@
  - `coq-lsp` is now supported by the `coq-nix-toolbox` (@Zimmi48,
    @CohenCyril, #572, via
    https://github.com/coq-community/coq-nix-toolbox/pull/164 )
+ - Support for `-rifrom` in `_CoqProject` and in command line
+   (`--rifrom`). Thanks to Lasse Blaauwbroek for the report.
+   (@ejgallego, #581, fixes #579)
 
 # coq-lsp 0.1.7: Just-in-time
 -----------------------------

--- a/compiler/fcc.ml
+++ b/compiler/fcc.ml
@@ -3,7 +3,7 @@ open Cmdliner
 open Fcc_lib
 
 let fcc_main roots display debug plugins files coqlib coqcorelib ocamlpath
-    rload_path load_path =
+    rload_path load_path require_libraries =
   let vo_load_path = rload_path @ load_path in
   let ml_include_path = [] in
   let args = [] in
@@ -14,6 +14,7 @@ let fcc_main roots display debug plugins files coqlib coqcorelib ocamlpath
     ; vo_load_path
     ; ml_include_path
     ; args
+    ; require_libraries
     }
   in
   let args = Args.{ cmdline; roots; display; files; debug; plugins } in
@@ -98,6 +99,18 @@ let plugins : string list Term.t =
   let doc = "Compiler plugins to load" in
   Arg.(value & opt_all string [] & info [ "plugin" ] ~docv:"PLUGINS" ~doc)
 
+let rifrom : (string option * string) list Term.t =
+  let doc =
+    "FROM Require Import LIBRARY before creating the document, à la From Coq \
+     Require Import Prelude"
+  in
+  Term.(
+    const (List.map (fun (x, y) -> (Some x, y)))
+    $ Arg.(
+        value
+        & opt_all (pair string string) []
+        & info [ "rifrom"; "require-import-from" ] ~docv:"FROM,LIBRARY" ~doc))
+
 let fcc_cmd : unit Cmd.t =
   let doc = "Flèche Coq Compiler" in
   let man =
@@ -111,7 +124,7 @@ let fcc_cmd : unit Cmd.t =
   let fcc_term =
     Term.(
       const fcc_main $ roots $ display $ debug $ plugins $ file $ coqlib
-      $ coqcorelib $ ocamlpath $ rload_path $ load_path)
+      $ coqcorelib $ ocamlpath $ rload_path $ load_path $ rifrom)
   in
   Cmd.(v (Cmd.info "fcc" ~version ~doc ~man) fcc_term)
 

--- a/coq/workspace.mli
+++ b/coq/workspace.mli
@@ -63,6 +63,7 @@ module CmdLine : sig
     ; vo_load_path : Loadpath.vo_path list
     ; ml_include_path : string list
     ; args : string list
+    ; require_libraries : (string option * string) list  (** Library, From *)
     }
 end
 

--- a/examples/lists.mv
+++ b/examples/lists.mv
@@ -1,4 +1,4 @@
-### Welcome to Coq LSP
+## Welcome to Coq LSP
 
 - You can edit this document as you please
 - Coq will recognize the code snippets as Coq
@@ -9,6 +9,11 @@ From Coq Require Import List.
 Import ListNotations.
 ```
 
+### Here is a simple Proof about Lists
+$$
+  \forall~x~l,
+    \mathsf{rev}(l \mathrel{++} [x]) = x \mathrel{::} (\mathsf{rev}~l)
+$$
 ```coq
 Lemma rev_snoc_cons A :
   forall (x : A) (l : list A), rev (l ++ [x]) = x :: rev l.
@@ -19,6 +24,7 @@ Proof.
 Qed.
 ```
 
+### Here is another proof depending on it
 Try to update _above_ and **below**:
 ```coq
 Theorem rev_rev A : forall (l : list A), rev (rev l) = l.
@@ -31,3 +37,12 @@ Qed.
 ```
 
 Please edit your code here!
+
+## Here we do some lambda terms, because we can!
+
+```coq
+Inductive term :=
+  | Var : nat -> term
+  | Abs : term -> term
+  | Lam : term -> term -> term.
+```

--- a/test/CoqProject/_CoqProject
+++ b/test/CoqProject/_CoqProject
@@ -3,5 +3,6 @@
 
 -arg -w -arg -local-declaration
 -arg -w -arg +non-primitive-record
+-arg -rifrom -arg Coq.Lists -arg List
 
 test.v

--- a/test/CoqProject/test.v
+++ b/test/CoqProject/test.v
@@ -1,3 +1,5 @@
+Search _ list.
+
 Variable (A : nat).
 
 Set Primitive Projections.


### PR DESCRIPTION
Both in command line, `CoqProject`, and `fcc`.

Fixes: #579

Thanks to Lasse Blaauwbroek for the report.