### PR TITLE
[hover] [api] Allow hover access to full document.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
    information on hover; previous flag was fixed in code, which is way
    less flexible. This also fixes the option being on in 0.1.8 by
    mistake (@ejgallego, #588)
+ - hover plugins can now access the full document, this is convenient
+   for many use cases (@ejgallego, #591)
 
 # coq-lsp 0.1.8: Trick-or-treat
 -------------------------------

--- a/controller/rq_hover.mli
+++ b/controller/rq_hover.mli
@@ -11,12 +11,22 @@ open Fleche
 
 module Handler : sig
   (** Returns [Some markdown] if there is some hover to match *)
-  type 'node h =
+  type 'node h_node =
     contents:Contents.t -> point:int * int -> node:'node -> string option
 
+  type h_doc =
+    doc:Doc.t -> point:int * int -> node:Doc.Node.t option -> string option
+
+  (** Many use cases could be grouped into a hook that would pass an
+      [Identifier_context.] object, containing the object, its location,
+      documentation, and some other relevant information.
+
+      For now we provide hooks for node inspection, contents inspection, and
+      document (usually TOC + contents) inspection. *)
   type t =
-    | MaybeNode : Doc.Node.t option h -> t
-    | WithNode : Doc.Node.t h -> t
+    | MaybeNode : Doc.Node.t option h_node -> t
+    | WithNode : Doc.Node.t h_node -> t
+    | WithDoc : h_doc -> t
 end
 
 (** Register a hover plugin *)


### PR DESCRIPTION
This is necessary for some use cases, tho we may want to refine later, for example, to provide identifier context.