### PR TITLE
[vscode] Workaround broken activation for `.mv` files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@
  - fix hover position computation on the presence of Utf characters
    (@ejgallego, #597, thanks to Pierre Courtieu for the report and
    example, closes #594)
+ - workaround seemingly VSCode activation bug that prevented extension
+   activation (@ejgallego @r3m0t, #598, cc #596, reported by Théo
+   Zimmerman)
 
 # coq-lsp 0.1.8: Trick-or-treat
 -------------------------------

--- a/editor/code/package.json
+++ b/editor/code/package.json
@@ -28,6 +28,9 @@
     "type": "git",
     "url": "https://github.com/ejgallego/coq-lsp"
   },
+  "activationEvents": [
+    "onLanguage:markdown"
+  ],
   "contributes": {
     "languages": [
       {


### PR DESCRIPTION
Suggested by Tomer Chachamu (thanks!) in
https://github.com/microsoft/vscode-discussions/discussions/901

Should fix issue #596 , however I'm not marking this as closed, as this workaround could actually be due to a VSCode bug.

Thanks to Théo Zimmerman for the report.