### PR TITLE
[vscode] Require VSCode >= 1.82

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@
  - workaround seemingly VSCode activation bug that prevented extension
    activation (@ejgallego @r3m0t, #598, cc #596, reported by Théo
    Zimmerman)
+ - require VSCode >= 1.82 in package.json . Our VSCode extension uses
+   `vscode-languageclient` 9 which imposes this. (@ejgallego, #599,
+   thanks to Théo Zimmerman for the report)
 
 # coq-lsp 0.1.8: Trick-or-treat
 -------------------------------

--- a/editor/code/package.json
+++ b/editor/code/package.json
@@ -11,7 +11,7 @@
   ],
   "publisher": "ejgallego",
   "engines": {
-    "vscode": "^1.75.0"
+    "vscode": "^1.82.0"
   },
   "categories": [
     "Programming Languages",


### PR DESCRIPTION
This is required by our use of `vscode-languageclient` 9.

Thanks to Théo Zimmerman for the report.