### PR TITLE
[goals] Allow goal mode as LSP parameter, internals

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@
  - require VSCode >= 1.82 in package.json . Our VSCode extension uses
    `vscode-languageclient` 9 which imposes this. (@ejgallego, #599,
    thanks to Théo Zimmerman for the report)
+ - `proof/goals` request: new `mode` parameter, to specify goals
+   after/before sentence display; renamed `pretac` to `command`, as to
+   provide official support for speculative execution (@ejgallego, #600)
 
 # coq-lsp 0.1.8: Trick-or-treat
 -------------------------------

--- a/controller/rq_goals.ml
+++ b/controller/rq_goals.ml
@@ -21,10 +21,6 @@ let mk_error node =
   | [] -> None
   | e :: _ -> Some e.Diagnostic.message
 
-let get_goals_mode () =
-  if !Fleche.Config.v.goal_after_tactic then Fleche.Info.PrevIfEmpty
-  else Fleche.Info.Prev
-
 (** Format for goal printing *)
 type format =
   | Pp
@@ -62,10 +58,9 @@ let run_pretac ?pretac st =
     Some st
   | Some tac -> Fleche.Info.in_state ~st ~f:(parse_and_execute_in tac) st
 
-let get_goal_info ~doc ~point ?pretac () =
+let get_goal_info ~doc ~point ~mode ~pretac () =
   let open Fleche in
-  let goals_mode = get_goals_mode () in
-  let node = Info.LC.node ~doc ~point goals_mode in
+  let node = Info.LC.node ~doc ~point mode in
   match node with
   | None -> (None, None)
   | Some node -> (
@@ -76,14 +71,14 @@ let get_goal_info ~doc ~point ?pretac () =
       let program = Info.Goals.program ~st in
       (goals, Some program))
 
-let goals ~pp_format ?pretac () ~doc ~point =
+let goals ~pp_format ~mode ~pretac () ~doc ~point =
   let open Fleche in
   let uri, version = (doc.Doc.uri, doc.version) in
   let textDocument = Lsp.Doc.VersionedTextDocumentIdentifier.{ uri; version } in
   let position =
     Lang.Point.{ line = fst point; character = snd point; offset = -1 }
   in
-  let goals, program = get_goal_info ~doc ~point ?pretac () in
+  let goals, program = get_goal_info ~doc ~point ~mode ~pretac () in
   let node = Info.LC.node ~doc ~point Exact in
   let messages = mk_messages node in
   let error = Option.bind node mk_error in

--- a/controller/rq_goals.mli
+++ b/controller/rq_goals.mli
@@ -11,4 +11,9 @@ type format =
 
 (** [goals ~pp_format ?pretac] Serve goals at point; users can request
     pre-processing and formatting using the provided parameters. *)
-val goals : pp_format:format -> ?pretac:string -> unit -> Request.position
+val goals :
+     pp_format:format
+  -> mode:Fleche.Info.approx
+  -> pretac:string option
+  -> unit
+  -> Request.position

--- a/editor/code/lib/types.ts
+++ b/editor/code/lib/types.ts
@@ -70,6 +70,8 @@ export interface GoalRequest {
   position: Position;
   pp_format?: "Pp" | "Str";
   pretac?: string;
+  command?: string;
+  mode?: "Prev" | "After";
 }
 
 export type Pp =

--- a/etc/doc/PROTOCOL.md
+++ b/etc/doc/PROTOCOL.md
@@ -82,6 +82,8 @@ interface GoalRequest {
     position: Position;
     pp_format?: 'Pp' | 'Str';
     pretac?: string;
+    command?: string;
+    mode?: 'Prev' | 'After';
 }
 ```
 
@@ -164,6 +166,9 @@ was the default.
 
 #### Changelog
 
+- v0.1.9: backwards compatible with 0.1.8
+  + new optional `mode : "Prev" | "After"` field to indicate desired goal position
+  + `command` field, alias of `pretac`, as this is not limited to tactics
 - v0.1.8: new optional `pretac` field for post-processing, backwards compatible with 0.1.7
 - v0.1.7: program information added, rest of fields compatible with 0.1.6
 - v0.1.7: pp_format field added to request, backwards compatible


### PR DESCRIPTION
- we rename `pretac` to `command`, as it is a better name
- we allow `mode` to specify the mode without having to reconfigure the server