### PR TITLE
[fleche] Store document environment in [Doc.t]

### DIFF
--- a/compiler/compile.ml
+++ b/compiler/compile.ml
@@ -30,8 +30,9 @@ let compile_file ~cc file =
   | Error _ -> ()
   | Ok uri -> (
     let workspace = workspace_of_uri ~io ~workspaces ~uri in
+    let env = Doc.Env.make ~init:root_state ~workspace in
     let raw = Util.input_all file in
-    let () = Theory.create ~io ~root_state ~workspace ~uri ~raw ~version:1 in
+    let () = Theory.create ~io ~env ~uri ~raw ~version:1 in
     match Theory.Check.maybe_check ~io with
     | None -> ()
     | Some (_, doc) ->

--- a/controller/lsp_core.ml
+++ b/controller/lsp_core.ml
@@ -251,8 +251,9 @@ let do_open ~io ~(state : State.t) params =
     |> Lsp.Doc.TextDocumentItem.of_yojson |> Result.get_ok
   in
   let Lsp.Doc.TextDocumentItem.{ uri; version; text; _ } = document in
-  let root_state, workspace = State.workspace_of_uri ~uri ~state in
-  Fleche.Theory.create ~io ~root_state ~workspace ~uri ~raw:text ~version
+  let init, workspace = State.workspace_of_uri ~uri ~state in
+  let env = Fleche.Doc.Env.make ~init ~workspace in
+  Fleche.Theory.create ~io ~env ~uri ~raw:text ~version
 
 let do_change ~ofn ~io params =
   let uri, version = Helpers.get_uri_version params in

--- a/fleche/doc.mli
+++ b/fleche/doc.mli
@@ -58,18 +58,35 @@ module Completion : sig
   val is_completed : t -> bool
 end
 
+(** Enviroment external to the document, this includes for now the [init] Coq
+    state and the [workspace], which are used to build the first state of the
+    document, usually by importing the prelude and other libs implicitly. *)
+module Env : sig
+  type t = private
+    { init : Coq.State.t
+    ; workspace : Coq.Workspace.t
+    }
+
+  val make : init:Coq.State.t -> workspace:Coq.Workspace.t -> t
+end
+
 (** A Flèche document is basically a [node list], which is a crude form of a
     meta-data map [Range.t -> data], where for now [data] is the contents of
     [Node.t]. *)
 type t = private
-  { uri : Lang.LUri.File.t
-  ; version : int
-  ; contents : Contents.t
-  ; toc : Lang.Range.t CString.Map.t
-  ; root : Coq.State.t
-  ; nodes : Node.t list
-  ; diags_dirty : bool
+  { uri : Lang.LUri.File.t  (** [uri] of the document *)
+  ; version : int  (** [version] of the document *)
+  ; contents : Contents.t  (** [contents] of the document *)
+  ; nodes : Node.t list  (** List of document nodes *)
   ; completed : Completion.t
+        (** Status of the document, usually either completed, suspended, or
+            waiting for some IO / external event *)
+  ; toc : Lang.Range.t CString.Map.t  (** table of contents *)
+  ; env : Env.t  (** External document enviroment *)
+  ; root : Coq.State.t
+        (** [root] contains the first state document state, obtained by applying
+            a workspace to Coq's initial state *)
+  ; diags_dirty : bool  (** internal field *)
   }
 
 (** Return the list of all asts in the doc *)
@@ -80,8 +97,7 @@ val diags : t -> Lang.Diagnostic.t list
 
 (** Create a new Coq document, this is cached! *)
 val create :
-     state:Coq.State.t
-  -> workspace:Coq.Workspace.t
+     env:Env.t
   -> uri:Lang.LUri.File.t
   -> version:int
   -> raw:string
@@ -113,7 +129,7 @@ val save : doc:t -> (unit, Loc.t) Coq.Protect.E.t
 
 (** This is internal, to workaround the Coq multiple-docs problem *)
 val create_failed_permanent :
-     state:Coq.State.t
+     env:Env.t
   -> uri:Lang.LUri.File.t
   -> version:int
   -> raw:string

--- a/fleche/theory.mli
+++ b/fleche/theory.mli
@@ -25,8 +25,7 @@ end
 (** Create a document inside a theory *)
 val create :
      io:Io.CallBack.t
-  -> root_state:Coq.State.t
-  -> workspace:Coq.Workspace.t
+  -> env:Doc.Env.t
   -> uri:Lang.LUri.File.t
   -> raw:string
   -> version:int


### PR DESCRIPTION
This is convenient as we may need to re-create the initial document state when the environment has changed.

This patch doesn't fully take advantage of the document env, but it is a prerequisite for the cleanup in #604, in particular to allow a document to recover on `bump` if the init state failed.