### PR TITLE
[internal] Make diagnostic / messages severity types abstract

### DIFF
--- a/compiler/compile.ml
+++ b/compiler/compile.ml
@@ -6,7 +6,9 @@ let workspace_of_uri ~io ~uri ~workspaces =
   let file = Lang.LUri.File.to_string_file uri in
   match List.find_opt (fun (dir, _) -> is_in_dir ~dir ~file) workspaces with
   | None ->
-    Io.Report.message ~io ~lvl:1 ~message:("file not in workspace: " ^ file);
+    let lvl = Io.Level.error in
+    let message = "file not in workspace: " ^ file in
+    Io.Report.message ~io ~lvl ~message;
     snd (List.hd workspaces)
   | Some (_, workspace) -> workspace
 
@@ -25,7 +27,9 @@ let save_diags_file ~(doc : Fleche.Doc.t) =
 
 let compile_file ~cc file =
   let { Cc.io; root_state; workspaces } = cc in
-  io.message ~lvl:3 ~message:(Format.asprintf "compiling file %s@\n%!" file);
+  let lvl = Io.Level.info in
+  let message = Format.asprintf "compiling file %s@\n%!" file in
+  io.message ~lvl ~message;
   match Lang.LUri.(File.of_uri (of_string file)) with
   | Error _ -> ()
   | Ok uri -> (

--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -21,8 +21,9 @@ let sanitize_paths message =
 let log_workspace ~io (dir, w) =
   let message, extra = Coq.Workspace.describe w in
   Fleche.Io.Log.trace "workspace" ("initialized " ^ dir) ~extra;
+  let lvl = Fleche.Io.Level.info in
   let message = sanitize_paths message in
-  Fleche.Io.Report.message ~io ~lvl:3 ~message
+  Fleche.Io.Report.message ~io ~lvl ~message
 
 let load_plugin plugin_name = Fl_dynload.load_packages [ plugin_name ]
 let plugin_init = List.iter load_plugin

--- a/controller/coq_lsp.ml
+++ b/controller/coq_lsp.ml
@@ -61,9 +61,13 @@ let concise_cb ofn =
 
 (* Main loop *)
 let lsp_cb ofn =
+  let message ~lvl ~message =
+    let lvl = Fleche.Io.Level.to_int lvl in
+    LIO.logMessage ~lvl ~message
+  in
   Fleche.Io.CallBack.
     { trace = LIO.trace
-    ; message = LIO.logMessage
+    ; message
     ; diagnostics =
         (fun ~uri ~version diags ->
           Lsp.JLang.mk_diagnostics ~uri ~version diags |> ofn)

--- a/controller/rq_goals.ml
+++ b/controller/rq_goals.ml
@@ -6,7 +6,9 @@
 (************************************************************************)
 
 (* Replace by ppx when we can print goals properly in the client *)
-let mk_message (range, level, text) = Lsp.JFleche.Message.{ range; level; text }
+let mk_message (range, level, text) =
+  let level = Lang.Diagnostic.Severity.to_int level in
+  Lsp.JFleche.Message.{ range; level; text }
 
 let mk_messages node =
   Option.map Fleche.Doc.Node.messages node
@@ -15,10 +17,9 @@ let mk_messages node =
 let mk_error node =
   let open Fleche in
   let open Lang in
-  match
-    List.filter (fun d -> d.Diagnostic.severity < 2) node.Doc.Node.diags
-  with
+  match List.filter Diagnostic.is_error node.Doc.Node.diags with
   | [] -> None
+  (* XXX FIXME! *)
   | e :: _ -> Some e.Diagnostic.message
 
 (** Format for goal printing *)

--- a/coq/init.ml
+++ b/coq/init.ml
@@ -25,16 +25,17 @@ type coq_opts =
   ; debug : bool  (** Enable Coq Debug mode *)
   }
 
-let lvl_to_severity (lvl : Feedback.level) =
+let coq_lvl_to_severity (lvl : Feedback.level) =
+  let open Lang.Diagnostic.Severity in
   match lvl with
-  | Feedback.Debug -> 5
-  | Feedback.Info -> 4
-  | Feedback.Notice -> 3
-  | Feedback.Warning -> 2
-  | Feedback.Error -> 1
+  | Feedback.Debug -> hint (* Debug has not LSP number *)
+  | Feedback.Info -> hint
+  | Feedback.Notice -> information
+  | Feedback.Warning -> warning
+  | Feedback.Error -> error
 
 let add_message lvl loc msg q =
-  let lvl = lvl_to_severity lvl in
+  let lvl = coq_lvl_to_severity lvl in
   q := (loc, lvl, msg) :: !q
 
 let mk_fb_handler q Feedback.{ contents; _ } =

--- a/coq/message.ml
+++ b/coq/message.ml
@@ -1,4 +1,2 @@
 (** Messages from Coq *)
-type 'l t = 'l option * int * Pp.t
-
-type coq = Feedback.feedback
+type 'l t = 'l option * Lang.Diagnostic.Severity.t * Pp.t

--- a/coq/message.mli
+++ b/coq/message.mli
@@ -1,4 +1,2 @@
 (** Messages from Coq *)
-type 'l t = 'l option * int * Pp.t
-
-type coq = Feedback.feedback
+type 'l t = 'l option * Lang.Diagnostic.Severity.t * Pp.t

--- a/fleche/doc.mli
+++ b/fleche/doc.mli
@@ -27,7 +27,7 @@ module Node : sig
   end
 
   module Message : sig
-    type t = Lang.Range.t option * int * Pp.t
+    type t = Lang.Range.t option * Lang.Diagnostic.Severity.t * Pp.t
   end
 
   type t = private

--- a/fleche/io.ml
+++ b/fleche/io.ml
@@ -1,3 +1,15 @@
+module Level = struct
+  type t = int
+
+  (* We follow LSP spec *)
+  let error = 1
+  let warning = 2
+  let info = 3
+  let log = 4
+  let debug = 5
+  let to_int x = x
+end
+
 module CallBack = struct
   type t =
     { trace : string -> ?extra:string -> string -> unit

--- a/fleche/io.mli
+++ b/fleche/io.mli
@@ -1,9 +1,22 @@
+module Level : sig
+  type t
+
+  val error : t
+  val warning : t
+  val info : t
+  val log : t
+  val debug : t
+
+  (** Convert to LSP numeric code *)
+  val to_int : t -> int
+end
+
 module CallBack : sig
   type t =
     { trace : string -> ?extra:string -> string -> unit
           (** Send a log message, [extra] may contain information to be shown in
               verbose mode *)
-    ; message : lvl:int -> message:string -> unit
+    ; message : lvl:Level.t -> message:string -> unit
           (** Send a user-visible message *)
     ; diagnostics :
         uri:Lang.LUri.File.t -> version:int -> Lang.Diagnostic.t list -> unit
@@ -24,7 +37,7 @@ end
 
 module Report : sig
   (** User-visible message *)
-  val message : io:CallBack.t -> lvl:int -> message:string -> unit
+  val message : io:CallBack.t -> lvl:Level.t -> message:string -> unit
 
   val diagnostics :
        io:CallBack.t

--- a/fleche/theory.ml
+++ b/fleche/theory.ml
@@ -254,7 +254,8 @@ let create ~io ~env ~uri ~raw ~version =
        Check coq-lsp webpage (Working with multiple files section) for\n\
        instructions on how to install a fixed branch for earlier Coq versions."
     in
-    Io.Report.message ~io ~lvl:1 ~message;
+    let lvl = Io.Level.error in
+    Io.Report.message ~io ~lvl ~message;
     let doc = Doc.create_failed_permanent ~env ~uri ~raw ~version in
     Handle.create ~uri ~doc;
     Check.schedule ~uri)

--- a/lang/diagnostic.ml
+++ b/lang/diagnostic.ml
@@ -12,9 +12,19 @@ module Extra = struct
         }
 end
 
+module Severity = struct
+  type t = int
+
+  let error = 1
+  let warning = 2
+  let information = 3
+  let hint = 4
+  let to_int x = x
+end
+
 type t =
   { range : Range.t
-  ; severity : int
+  ; severity : Severity.t
   ; message : Pp.t
   ; extra : Extra.t list option
   }

--- a/lang/diagnostic.mli
+++ b/lang/diagnostic.mli
@@ -12,9 +12,21 @@ module Extra : sig
         }
 end
 
+module Severity : sig
+  type t
+
+  val error : t
+  val warning : t
+  val information : t
+  val hint : t
+
+  (** Convert to LSP-like levels *)
+  val to_int : t -> int
+end
+
 type t =
   { range : Range.t
-  ; severity : int
+  ; severity : Severity.t
   ; message : Pp.t
   ; extra : Extra.t list option
   }

--- a/lsp/jLang.ml
+++ b/lsp/jLang.ml
@@ -73,8 +73,9 @@ module Diagnostic = struct
   [@@deriving yojson]
 
   let to_yojson { Lang.Diagnostic.range; severity; message; extra = _ } =
-    let message = Pp.to_string message in
     let range = Range.conv range in
+    let severity = Lang.Diagnostic.Severity.to_int severity in
+    let message = Pp.to_string message in
     _t_to_yojson { range; severity; message }
 end
 

--- a/plugins/astdump/main.ml
+++ b/plugins/astdump/main.ml
@@ -19,16 +19,22 @@ let dump_asts ~out_file pp asts =
   Format.pp_print_flush fmt ();
   Stdlib.close_out out
 
-let dump_ast ~io:_ ~(doc : Doc.t) =
+let dump_ast ~io ~(doc : Doc.t) =
   let uri = doc.uri in
   let uri_str = Lang.LUri.File.to_string_uri uri in
   let out_file_j = Lang.LUri.File.to_string_file uri ^ ".json.astdump" in
   let out_file_s = Lang.LUri.File.to_string_file uri ^ ".sexp.astdump" in
-  Format.eprintf "[ast plugin] dumping ast for %s ...@\n%!" uri_str;
+  let lvl = Io.Level.info in
+  let message = Format.asprintf "[ast plugin] dumping ast for %s ..." uri_str in
+  Io.Report.message ~io ~lvl ~message;
   let asts = Doc.asts doc in
   let () = dump_asts ~out_file:out_file_j pp_json asts in
   let () = dump_asts ~out_file:out_file_s pp_sexp asts in
-  Format.eprintf "[ast plugin] dumping ast for %s was completed!@\n%!" uri_str
+  let message =
+    Format.asprintf "[ast plugin] dumping ast for %s was completed!" uri_str
+  in
+  Io.Report.message ~io ~lvl ~message;
+  ()
 
 let main () = Theory.Register.add dump_ast
 let () = main ()

--- a/plugins/simple/main.ml
+++ b/plugins/simple/main.ml
@@ -1,6 +1,12 @@
-let simple_action ~io:_ ~doc =
-  let uri = Lang.LUri.File.to_string_uri doc.Fleche.Doc.uri in
-  Format.eprintf "[example plugin] file checking for %s was completed@\n%!" uri
+open Fleche
 
-let main () = Fleche.Theory.Register.add simple_action
+let simple_action ~io ~doc =
+  let uri = Lang.LUri.File.to_string_uri doc.Doc.uri in
+  let lvl = Io.Level.info in
+  let message =
+    Format.asprintf "[example plugin] file checking for %s was completed" uri
+  in
+  Io.Report.message ~io ~lvl ~message
+
+let main () = Theory.Register.add simple_action
 let () = main ()

--- a/test/compiler/run.t
+++ b/test/compiler/run.t
@@ -170,7 +170,7 @@ Load the example plugin
      + findlib default location: [TEST_PATH]
   [message] compiling file proj1/a.v
   
-  [example plugin] file checking for proj1/a.v was completed
+  [message] [example plugin] file checking for proj1/a.v was completed
 
 Load the astdump plugin
   $ fcc --plugin=coq-lsp.plugin.astdump --root proj1 proj1/a.v
@@ -184,8 +184,8 @@ Load the astdump plugin
      + findlib default location: [TEST_PATH]
   [message] compiling file proj1/a.v
   
-  [ast plugin] dumping ast for proj1/a.v ...
-  [ast plugin] dumping ast for proj1/a.v was completed!
+  [message] [ast plugin] dumping ast for proj1/a.v ...
+  [message] [ast plugin] dumping ast for proj1/a.v was completed!
 
 EJGA: I'd be nice to check the checksum of files here, however
 `md5sum` is not avilable on all of our CI platforms yet. `ls -l`


### PR DESCRIPTION
This is a bit more disciplined and will prevent bugs now that we are writing more and more plugins.