### PR TITLE
With Coq PR #18443, Prettyp.print_abbreviation takes an additional sigma

### DIFF
--- a/controller/rq_hover.ml
+++ b/controller/rq_hover.ml
@@ -90,7 +90,7 @@ let info_of_id env sigma id =
         | IndRef ir -> info_of_ind env sigma ir
         | ConstructRef cr -> info_of_constructor env cr |> print_type env sigma)
         |> fun x -> Some x
-      | Abbrev kn -> Some (Notation (Prettyp.print_abbreviation env kn))
+      | Abbrev kn -> Some (Notation (Prettyp.print_abbreviation env sigma kn))
     with _ -> None)
 
 let info_of_id ~st id =


### PR DESCRIPTION
To be merged synchronously with coq/coq#18443.