### PR TITLE
[coq] API to handle Require Ast specifically

### DIFF
--- a/coq/ast.ml
+++ b/coq/ast.ml
@@ -24,6 +24,44 @@ module Id = struct
   module Map = Names.Id.Map
 end
 
+module Require = struct
+  type ast = t
+
+  open Ppx_hash_lib.Std.Hash.Builtin
+  open Ppx_compare_lib.Builtin
+  module Loc = Serlib.Ser_loc
+  module Libnames = Serlib.Ser_libnames
+  module Attributes = Serlib.Ser_attributes
+  module Vernacexpr = Serlib.Ser_vernacexpr
+
+  type t =
+    { from : Libnames.qualid option
+    ; export : Vernacexpr.export_with_cats option
+    ; mods : (Libnames.qualid * Vernacexpr.import_filter_expr) list
+    ; loc : Loc.t option
+          [@ignore]
+          [@hash.ignore]
+          (* We need to ignore the loc of the Require statement, maybe it'd be
+             better to keep the wrapping of the original vernac into a
+             CAst.t? *)
+    ; attrs : Attributes.vernac_flag list
+    ; control : Vernacexpr.control_flag list
+    }
+  [@@deriving hash, compare]
+
+  (** Determine if the Ast is a Require *)
+  let extract = function
+    | { CAst.v =
+          { Vernacexpr.expr =
+              Vernacexpr.(VernacSynterp (VernacRequire (from, export, mods)))
+          ; control
+          ; attrs
+          }
+      ; loc
+      } -> Some { from; export; mods; loc; attrs; control }
+    | _ -> None
+end
+
 module Kinds = struct
   (* LSP kinds *)
   let _file = 1

--- a/coq/ast.mli
+++ b/coq/ast.mli
@@ -15,6 +15,23 @@ module Id : sig
   module Map : CMap.ExtS with type key = t and module Set := Set
 end
 
+module Require : sig
+  type ast = t
+
+  type t = private
+    { from : Libnames.qualid option
+    ; export : Vernacexpr.export_with_cats option
+    ; mods : (Libnames.qualid * Vernacexpr.import_filter_expr) list
+    ; loc : Loc.t option
+    ; attrs : Attributes.vernac_flag list
+    ; control : Vernacexpr.control_flag list
+    }
+  [@@deriving hash, compare]
+
+  (** Determine if the Ast is a Require *)
+  val extract : ast -> t option
+end
+
 (** [make_info ~st ast] Compute info about a possible definition in [ast], we
     need [~st] to compute the type. *)
 val make_info :

--- a/coq/dune
+++ b/coq/dune
@@ -5,5 +5,5 @@
  ; depending on it, we should fix this upstream
  (inline_tests)
  (preprocess
-  (pps ppx_inline_test))
+  (pps ppx_compare ppx_hash ppx_inline_test))
  (libraries lang coq-core.vernac coq-serapi.serlib))

--- a/coq/files.ml
+++ b/coq/files.ml
@@ -10,18 +10,15 @@
 
 (************************************************************************)
 (* Coq Language Server Protocol                                         *)
-(* Copyright 2022-2023 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
-(* Written by: Emilio J. Gallego Arias                                  *)
+(* Copyright 2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2019-2024 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
+(* Written by: Emilio J. Gallego Arias & Bhakti Shah                    *)
 (************************************************************************)
 
-(** Specific to Coq *)
-val to_range : lines:string array -> Loc.t -> Lang.Range.t
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
 
-val to_orange : lines:string array -> Loc.t option -> Lang.Range.t option
+type t = int [@@deriving hash, compare]
 
-(** Separation of parsing and execution made this API hard to use for us *)
-val with_control :
-     fn:(unit -> unit)
-  -> control:Vernacexpr.control_flag list
-  -> st:State.t
-  -> unit
+let make () = 0
+let bump i = i + 1

--- a/coq/files.mli
+++ b/coq/files.mli
@@ -10,18 +10,14 @@
 
 (************************************************************************)
 (* Coq Language Server Protocol                                         *)
-(* Copyright 2022-2023 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
-(* Written by: Emilio J. Gallego Arias                                  *)
+(* Copyright 2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2019-2024 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
+(* Written by: Emilio J. Gallego Arias & Bhakti Shah                    *)
 (************************************************************************)
 
-(** Specific to Coq *)
-val to_range : lines:string array -> Loc.t -> Lang.Range.t
+type t [@@deriving hash, compare]
 
-val to_orange : lines:string array -> Loc.t option -> Lang.Range.t option
+val make : unit -> t
 
-(** Separation of parsing and execution made this API hard to use for us *)
-val with_control :
-     fn:(unit -> unit)
-  -> control:Vernacexpr.control_flag list
-  -> st:State.t
-  -> unit
+(** [bump ()] Signal the files have changed *)
+val bump : t -> t

--- a/coq/interp.mli
+++ b/coq/interp.mli
@@ -15,4 +15,16 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
+(** Intepretation of "pure" Coq commands, that is to say, commands that are
+    assumed not to interact with the file-system, etc... Note these commands
+    will be memoized. *)
 val interp : st:State.t -> Ast.t -> (State.t, Loc.t) Protect.E.t
+
+(** Interpretation of "require". We wrap this function for two reasons:
+
+    - to make the read-effect dependency explicit
+    - to workaround the lack of a pure interface in Coq *)
+module Require : sig
+  val interp :
+    st:State.t -> Files.t -> Ast.Require.t -> (State.t, Loc.t) Protect.E.t
+end

--- a/coq/utils.ml
+++ b/coq/utils.ml
@@ -42,3 +42,48 @@ let to_range ~lines (p : Loc.t) : Lang.Range.t =
     }
 
 let to_orange ~lines = Option.map (to_range ~lines)
+
+(* Separation of parsing and execution made upstream API hard to use for us
+   :/ *)
+let pmeasure (measure, print) fn =
+  match measure fn () with
+  | Ok _ as r -> Feedback.msg_notice @@ print r
+  | Error (exn, _) as r ->
+    Feedback.msg_notice @@ print r;
+    Exninfo.iraise exn
+
+let with_fail fn =
+  try
+    fn ();
+    CErrors.user_err (Pp.str "The command has not failed!")
+  with exn when CErrors.noncritical exn ->
+    let exn = Exninfo.capture exn in
+    let msg = CErrors.iprint exn in
+    Feedback.msg_notice ?loc:None
+      Pp.(str "The command has indeed failed with message:" ++ fnl () ++ msg)
+
+let with_ctrl ctrl ~st ~fn =
+  let st = State.to_coq st in
+  match ctrl with
+  | Vernacexpr.ControlTime ->
+    pmeasure System.(measure_duration, fmt_transaction_result) fn
+  | Vernacexpr.ControlInstructions ->
+    pmeasure System.(count_instructions, fmt_instructions_result) fn
+  | Vernacexpr.ControlTimeout n -> (
+    match Control.timeout (float_of_int n) fn () with
+    | None -> Exninfo.iraise (Exninfo.capture CErrors.Timeout)
+    | Some x -> x)
+  (* fail and succeed *)
+  | Vernacexpr.ControlFail ->
+    with_fail fn;
+    Vernacstate.Interp.invalidate_cache ();
+    Vernacstate.unfreeze_full_state st
+  | Vernacexpr.ControlSucceed ->
+    fn ();
+    Vernacstate.Interp.invalidate_cache ();
+    Vernacstate.unfreeze_full_state st
+  (* Unsupported by coq-lsp, maybe deprecate upstream *)
+  | Vernacexpr.ControlRedirect _ -> fn ()
+
+let with_control ~fn ~control ~st =
+  List.fold_right (fun ctrl fn () -> with_ctrl ctrl ~st ~fn) control fn ()

--- a/fleche/doc.ml
+++ b/fleche/doc.ml
@@ -2,7 +2,7 @@
 (* Flèche => document manager: Document                                 *)
 (* Copyright 2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
 (* Copyright 2019-2023 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
-(* Written by: Emilio J. Gallego Arias                                  *)
+(* Written by: Emilio J. Gallego Arias & coq-lsp contributors           *)
 (************************************************************************)
 
 (* Should be moved to the right place *)
@@ -157,13 +157,10 @@ end = struct
 
   (* ast-dependent error diagnostic generation *)
   let extra_diagnostics_of_ast ast =
-    match (Node.Ast.to_coq ast).v with
-    | Vernacexpr.
-        { expr = VernacSynterp (VernacRequire (prefix, _export, module_refs))
-        ; _
-        } ->
-      let refs = List.map fst module_refs in
-      Some [ Lang.Diagnostic.Extra.FailedRequire { prefix; refs } ]
+    match Coq.Ast.Require.extract ast.Node.Ast.v with
+    | Some { Coq.Ast.Require.from; mods; _ } ->
+      let refs = List.map fst mods in
+      Some [ Lang.Diagnostic.Extra.FailedRequire { prefix = from; refs } ]
     | _ -> None
 
   let error ~range ~msg ~ast =

--- a/fleche/doc.mli
+++ b/fleche/doc.mli
@@ -1,8 +1,8 @@
 (************************************************************************)
 (* Flèche => document manager: Document                                 *)
 (* Copyright 2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
-(* Copyright 2019-2023 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
-(* Written by: Emilio J. Gallego Arias                                  *)
+(* Copyright 2019-2024 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
+(* Written by: Emilio J. Gallego Arias & coq-lsp contributors           *)
 (************************************************************************)
 
 module Node : sig


### PR DESCRIPTION
We add some convenience functions to inspect and evaluate Coq's requires specifically.

Note that we don't yet handle the attributes / control pair of the require, this is required to be fixed before merge (likely requires cut and paste from Coq code + Coq PR to export the relevant functions to do without duplication)