### PR TITLE
[fleche] [doc] Interpret require via special custom path.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,6 +56,8 @@
    (@ejgallego, #660)
  - monitor all Coq-level calls under an interruption token
    (@ejgallego, #661)
+ - interpret require thru our own custom execution env-aware path
+   (@bhaktishh, @ejgallego, #642, #643, #644)
 
 # coq-lsp 0.1.8.1: Spring fix
 -----------------------------

--- a/compiler/compile.ml
+++ b/compiler/compile.ml
@@ -33,7 +33,8 @@ let compile_file ~cc file =
   | Error _ -> ()
   | Ok uri -> (
     let workspace = workspace_of_uri ~io ~workspaces ~uri ~default in
-    let env = Doc.Env.make ~init:root_state ~workspace in
+    let files = Coq.Files.make () in
+    let env = Doc.Env.make ~init:root_state ~workspace ~files in
     let raw = Util.input_all file in
     let () = Theory.create ~io ~token ~env ~uri ~raw ~version:1 in
     match Theory.Check.maybe_check ~io ~token with

--- a/controller/lsp_core.ml
+++ b/controller/lsp_core.ml
@@ -263,7 +263,8 @@ let do_open ~io ~token ~(state : State.t) params =
   in
   let Lsp.Doc.TextDocumentItem.{ uri; version; text; _ } = document in
   let init, workspace = State.workspace_of_uri ~uri ~state in
-  let env = Fleche.Doc.Env.make ~init ~workspace in
+  let files = Coq.Files.make () in
+  let env = Fleche.Doc.Env.make ~init ~workspace ~files in
   Fleche.Theory.create ~io ~token ~env ~uri ~raw:text ~version
 
 let do_change ~ofn ~io ~token params =

--- a/fleche/doc.mli
+++ b/fleche/doc.mli
@@ -65,9 +65,11 @@ module Env : sig
   type t = private
     { init : Coq.State.t
     ; workspace : Coq.Workspace.t
+    ; files : Coq.Files.t
     }
 
-  val make : init:Coq.State.t -> workspace:Coq.Workspace.t -> t
+  val make :
+    init:Coq.State.t -> workspace:Coq.Workspace.t -> files:Coq.Files.t -> t
 end
 
 (** A Flèche document is basically a [node list], which is a crude form of a


### PR DESCRIPTION
This will allow us to:

- postpone the document checking when the require is not ready
- correctly track file dependencies in memoization
- apply the .vo parsing optimization, by intercepting the call

Depends on #643 