### PR TITLE
[compat] Drop support for Coq 8.16, update README

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,12 +4,18 @@ on:
   push:
     branches:
       - main
+      - v8.20
+      - v8.19
+      - v8.18
       - v8.17
       - v8.16
       - v8.15
   pull_request:
     branches:
       - main
+      - v8.20
+      - v8.19
+      - v8.18
       - v8.17
       - v8.16
       - v8.15

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,8 @@
    @ejgallego)
  - fix typo on package.json configuration section (@ejgallego, #645)
  - be more resilient with invalid _CoqProject files (@ejgallego, #646)
+ - support for Coq 8.16 has been abandoned due to lack of dev
+   resources (@ejgallego, #649)
 
 # coq-lsp 0.1.8: Trick-or-treat
 -------------------------------

--- a/README.md
+++ b/README.md
@@ -224,16 +224,17 @@ ready.
 
 ### 🏘️ Supported Coq Versions
 
-`coq-lsp` supports Coq 8.15, 8.16, Coq 8.17, Coq 8.18, and Coq's `master`
-branch. Code for each Coq version can be found in the corresponding branch.
+`coq-lsp` supports Coq 8.20, Coq 8.19, Coq 8.18, Coq 8.17, and Coq's `master`
+branch.  Code for each Coq version can be found in the corresponding branch.
 
-We recommended a minimum of Coq 8.17, due to better test coverage for that
-version. For 8.16, we recommend users to install the custom Coq tree as detailed
-in [Working With Multiple Files](#working-with-multiple-files)
+We recommended using Coq 8.19 or `master` version. For other Coq versions, we
+recommend users to install the custom Coq tree as detailed in [Coq Upstream
+Bugs](#coq-upstream-bugs).
 
-Support for older Coq versions is possible; it is possible to make `coq-lsp`
-work with Coq back to Coq 8.10/8.9. If you are interested in making that happen
-don't hesitate to get in touch with us.
+Support for Coq 8.15 and 8.16 has been phased out due to lack of development
+resources, but if you are interested it should possible to bring it back with
+reasonable effort. Support for older Coq versions is also possible, with a bit
+more effort; `coq-lsp` should work with Coq versions back to Coq 8.10/8.9.
 
 Note that this section covers user installs, if you would like to contribute to
 `coq-lsp` and build a development version, please check our [contributing
@@ -324,6 +325,8 @@ Unfortunately Coq releases contain bugs that affect `coq-lsp`. We strongly
 recommend that if you are installing via opam, you use the following branches
 that have some fixes backported:
 
+- For 8.20: No known problems
+- For 8.19: No known problems
 - For 8.18: `opam pin add coq-core https://github.com/ejgallego/coq.git#v8.18+lsp`
 - For 8.17: `opam pin add coq-core https://github.com/ejgallego/coq.git#v8.17+lsp`
 - For 8.16: `opam pin add coq      https://github.com/ejgallego/coq.git#v8.16+lsp`


### PR DESCRIPTION
We also tweak CI config to match what is done in the branches.