### PR TITLE
Adding definition kind LetContext

### DIFF
--- a/coq/ast.ml
+++ b/coq/ast.ml
@@ -143,6 +143,7 @@ let definition_detail = function
   | Instance -> "Instance"
   | Method -> "Method"
   | Let -> "Let"
+  | LetContext -> "LetContext"
 
 let theorem_detail = function
   | Decls.Theorem -> "Theorem"


### PR DESCRIPTION
This is in anticipation of coq/coq#13445 which introduces a new declaration `LetContext` for referring to local definitions introduced by `Context` (while, beforehand, it was using `Definition`). I however wonder whether this is maybe overkell: an alternative would be to use `Let`as we do for local definiitions, renouncing to make a difference between `Let x:=t` and `Context (x:=t)`.