### PR TITLE
[memo] Cache control and eviction improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,6 +60,9 @@
    (@bhaktishh, @ejgallego, #642, #643, #644)
  - new `coq-lsp.plugin.goaldump` plugin, as an example on how to dump
    goals from a document (@ejgallego @gbdrt, #619)
+ - new trim command (both in the server and in VSCode) to liberate
+   space used in the cache (@ejgallego, #662, fixes #367 cc: #253 #236
+   #348)
 
 # coq-lsp 0.1.8.1: Spring fix
 -----------------------------

--- a/controller/coq_lsp.ml
+++ b/controller/coq_lsp.ml
@@ -27,7 +27,7 @@ open Lsp_core
 (* Do cleanup here if necessary *)
 let exit_message () =
   let message = "server exiting" in
-  LIO.logMessage ~lvl:1 ~message
+  LIO.logMessage ~lvl:Error ~message
 
 let lsp_cleanup () = exit_message ()
 
@@ -63,7 +63,7 @@ let concise_cb ofn =
 let lsp_cb ofn =
   let message ~lvl ~message =
     let lvl = Fleche.Io.Level.to_int lvl in
-    LIO.logMessage ~lvl ~message
+    LIO.logMessageInt ~lvl ~message
   in
   Fleche.Io.CallBack.
     { trace = LIO.trace
@@ -165,7 +165,7 @@ let lsp_main bt coqcorelib coqlib ocamlpath vo_load_path ml_include_path
   with
   | Lsp_exit ->
     let message = "[LSP shutdown] EOF\n" in
-    LIO.logMessage ~lvl:1 ~message
+    LIO.logMessage ~lvl:Error ~message
   | exn ->
     let bt = Printexc.get_backtrace () in
     let exn, info = Exninfo.capture exn in
@@ -175,7 +175,7 @@ let lsp_main bt coqcorelib coqlib ocamlpath vo_load_path ml_include_path
       Pp.(string_of_ppcmds CErrors.(iprint (exn, info)));
     LIO.trace "server crash" (exn_msg ^ bt);
     let message = "[uncontrolled LSP shutdown] server crash\n" ^ exn_msg in
-    LIO.logMessage ~lvl:1 ~message
+    LIO.logMessage ~lvl:Error ~message
 
 (* Arguments handling *)
 open Cmdliner

--- a/controller/nt_cache_trim.ml
+++ b/controller/nt_cache_trim.ml
@@ -1,0 +1,95 @@
+module OCaml = struct
+  (* Version using formatter instead of out_channel *)
+  open Gc
+  open Format
+
+  let _print_stat c () =
+    let st = stat () in
+    fprintf c "minor_collections:      %d\n" st.minor_collections;
+    fprintf c "major_collections:      %d\n" st.major_collections;
+    fprintf c "compactions:            %d\n" st.compactions;
+    fprintf c "forced_major_collections: %d\n" st.forced_major_collections;
+    fprintf c "\n";
+    let l1 = String.length (sprintf "%.0f" st.minor_words) in
+    fprintf c "minor_words:    %*.0f\n" l1 st.minor_words;
+    fprintf c "promoted_words: %*.0f\n" l1 st.promoted_words;
+    fprintf c "major_words:    %*.0f\n" l1 st.major_words;
+    fprintf c "\n";
+    let l2 = String.length (sprintf "%d" st.top_heap_words) in
+    fprintf c "top_heap_words: %*d\n" l2 st.top_heap_words;
+    fprintf c "heap_words:     %*d\n" l2 st.heap_words;
+    fprintf c "live_words:     %*d\n" l2 st.live_words;
+    fprintf c "free_words:     %*d\n" l2 st.free_words;
+    fprintf c "largest_free:   %*d\n" l2 st.largest_free;
+    fprintf c "fragments:      %*d\n" l2 st.fragments;
+    fprintf c "\n";
+    fprintf c "live_blocks: %d\n" st.live_blocks;
+    fprintf c "free_blocks: %d\n" st.free_blocks;
+    fprintf c "heap_chunks: %d\n" st.heap_chunks
+
+  let print_stat_simple c () =
+    let st = stat () in
+    let l2 = String.length (sprintf "%d" st.top_heap_words) in
+    fprintf c "live:  %*d\n" l2 st.live_words;
+    fprintf c "free:  %*d\n" l2 st.free_words;
+    fprintf c "----------\n";
+    ()
+end
+
+module M = Fleche.Memo
+module LIO = Lsp.Io
+
+let caches () =
+  [ ("interp", M.Interp.all_freqs ())
+  ; ("admit", M.Admit.all_freqs ())
+  ; ("init", M.Init.all_freqs ())
+  ; ("require", M.Require.all_freqs ())
+  ]
+
+let pp_cache fmt (name, freqs) =
+  let zsum = List.filter (Int.equal 0) freqs in
+  let pp_zsum fmt l = Format.fprintf fmt "{ 0-entries: %d }" (List.length l) in
+  let fsum = Base.List.take freqs 20 in
+  let pp_sep fmt () = Format.fprintf fmt ",@," in
+  let pp_fsum = Format.(pp_print_list ~pp_sep pp_print_int) in
+  Format.fprintf fmt "@[%s: %d | %a @[(%a)@]@]" name (List.length freqs) pp_zsum
+    zsum pp_fsum fsum
+
+let build_message () =
+  let caches = caches () in
+  Format.asprintf "@[Cache trim requested:@\n @[<v>%a@]@]"
+    (Format.pp_print_list pp_cache)
+    caches
+
+let cache_trim () =
+  let () = M.Interp.clear () in
+  let () = M.Admit.clear () in
+  let () = M.Init.clear () in
+  let () = M.Require.clear () in
+  ()
+
+let gc_stats hd msg =
+  let message =
+    Format.asprintf "[%s] %s:@\n%a" hd msg OCaml.print_stat_simple ()
+  in
+  LIO.logMessage ~lvl:Info ~message
+
+let full_major hd =
+  gc_stats hd "before full major";
+  Gc.full_major ();
+  gc_stats hd "after full major";
+  ()
+
+let do_trim () =
+  full_major "pre ";
+  cache_trim ();
+  let message = Format.asprintf "%s@\n---------@\n" "trimming" in
+  LIO.logMessage ~lvl:Info ~message;
+  full_major "post";
+  ()
+
+let notification () =
+  let message = build_message () in
+  LIO.logMessage ~lvl:Info ~message;
+  do_trim ();
+  ()

--- a/controller/nt_cache_trim.mli
+++ b/controller/nt_cache_trim.mli
@@ -1,0 +1,1 @@
+val notification : unit -> unit

--- a/controller/rq_goals.ml
+++ b/controller/rq_goals.ml
@@ -41,7 +41,7 @@ let parse_and_execute_in ~token ~loc tac st =
   let open Coq.Protect.E.O in
   let* ast = parse ~token ~loc tac st in
   match ast with
-  | Some ast -> (Fleche.Memo.Interp.eval ~token (st, ast)).res
+  | Some ast -> Fleche.Memo.Interp.eval ~token (st, ast)
   (* On EOF we return the previous state, the command was the empty string or a
      comment *)
   | None -> Coq.Protect.E.ok st

--- a/controller/rq_init.ml
+++ b/controller/rq_init.ml
@@ -41,7 +41,7 @@ let check_client_version client_version : unit =
       Format.asprintf "Incorrect client version: %s , expected %s."
         client_version server_version
     in
-    LIO.logMessage ~lvl:1 ~message
+    LIO.(logMessage ~lvl:Lvl.Error ~message)
 
 (* Maybe this should be [cwd] ? *)
 let default_workspace_root = "."
@@ -54,7 +54,7 @@ let parse_fpath x =
        "rootPath is not absolute: " ^ path
        ^ " . This is not robust, please use absolute paths or rootURI"
      in
-     LIO.logMessage ~lvl:2 ~message);
+     LIO.logMessage ~lvl:LIO.Lvl.Warning ~message);
   Lang.LUri.of_string ("file:///" ^ path) |> Lang.LUri.File.of_uri
 
 let parse_null_or f = function

--- a/editor/code/package.json
+++ b/editor/code/package.json
@@ -101,6 +101,10 @@
       {
         "command": "coq-lsp.save",
         "title": "Coq LSP: Save .vo file for the current buffer"
+      },
+      {
+        "command": "coq-lsp.trim",
+        "title": "Coq LSP: Request the server to trim caches and compact memory (useful to try reduce memory comsumption)"
       }
     ],
     "keybindings": [

--- a/editor/code/src/client.ts
+++ b/editor/code/src/client.ts
@@ -19,6 +19,7 @@ import {
 import {
   BaseLanguageClient,
   LanguageClientOptions,
+  NotificationType,
   RequestType,
   RevealOutputChannelOn,
   VersionedTextDocumentIdentifier,
@@ -259,6 +260,12 @@ export function activateCoqLSP(
     client.sendRequest(docReq, params).then((fd) => console.log(fd));
   };
 
+  const trimNot = new NotificationType<{}>("coq/trimCaches");
+
+  const cacheTrim = () => {
+    client.sendNotification(trimNot, {});
+  };
+
   const saveReq = new RequestType<FlecheDocumentParams, void, void>(
     "coq/saveVo"
   );
@@ -325,6 +332,7 @@ export function activateCoqLSP(
 
   coqCommand("restart", restart);
   coqCommand("toggle", toggle);
+  coqCommand("trim", cacheTrim);
 
   coqEditorCommand("goals", goals);
   coqEditorCommand("document", getDocument);

--- a/etc/doc/PROTOCOL.md
+++ b/etc/doc/PROTOCOL.md
@@ -303,3 +303,8 @@ export interface DocumentPerfParams {
 #### Changelog
 
 - v0.1.7: Initial version
+
+### Trim cache notification
+
+The `coq/trimCaches` notification from client to server tells the
+server to free memory. It has no parameters.

--- a/examples/Rtrigo1.v
+++ b/examples/Rtrigo1.v
@@ -571,6 +571,8 @@ Proof.
   intro x; rewrite sin_plus; rewrite sin_PI2; rewrite cos_PI2; ring.
 Qed.
 
+(* We do what we can; it is what it is... *)
+
 Lemma PI2_RGT_0 : 0 < PI / 2.
 Proof.
   unfold Rdiv in |- *; apply Rmult_lt_0_compat;

--- a/fleche/doc.ml
+++ b/fleche/doc.ml
@@ -637,8 +637,8 @@ end
 
 let interp_and_info ~st ~files ast =
   match Coq.Ast.Require.extract ast with
-  | None -> Memo.Interp.eval (st, ast)
-  | Some ast -> Memo.Require.eval (st, files, ast)
+  | None -> Memo.Interp.evalS (st, ast)
+  | Some ast -> Memo.Require.evalS (st, files, ast)
 
 let interp_and_info ~token ~parsing_time ~st ~files ast =
   let { Gc.major_words = mw_prev; _ } = Gc.quick_stat () in

--- a/fleche/io.ml
+++ b/fleche/io.ml
@@ -13,7 +13,7 @@ end
 module CallBack = struct
   type t =
     { trace : string -> ?extra:string -> string -> unit
-    ; message : lvl:int -> message:string -> unit
+    ; message : lvl:Level.t -> message:string -> unit
     ; diagnostics :
         uri:Lang.LUri.File.t -> version:int -> Lang.Diagnostic.t list -> unit
     ; fileProgress :

--- a/fleche/memo.mli
+++ b/fleche/memo.mli
@@ -7,63 +7,61 @@ module Stats : sig
     }
 end
 
-module Init : sig
-  type t = Coq.State.t * Coq.Workspace.t * Lang.LUri.File.t
+(** Flèche memo / cache tables, with some advanced features *)
+module type S = sig
+  type input
 
-  (** [size ()] Return the size in words, expensive *)
+  (** For now, to generalize later if needed *)
+  type output
+
+  (** [eval i] Eval an input [i] *)
+  val eval :
+    token:Coq.Limits.Token.t -> input -> (output, Loc.t) Coq.Protect.E.t
+
+  (** [eval i] Eval an input [i] and produce stats *)
+  val evalS :
+    token:Coq.Limits.Token.t -> input -> (output, Loc.t) Coq.Protect.E.t Stats.t
+
+  (** [size ()] Return the cache size in words, expensive *)
   val size : unit -> int
 
-  val eval :
-    token:Coq.Limits.Token.t -> t -> (Coq.State.t, Loc.t) Coq.Protect.E.t
+  (** [freqs ()]: (sorted) histogram *)
+  val all_freqs : unit -> int list
+
+  (** debug data for input *)
+  val input_info : input -> string
+
+  (** clears the cache *)
+  val clear : unit -> unit
 end
 
-module Interp : sig
-  type t = Coq.State.t * Coq.Ast.t
+(** Document creation cache *)
+module Init :
+  S
+    with type input = Coq.State.t * Coq.Workspace.t * Lang.LUri.File.t
+     and type output = Coq.State.t
 
-  (** Interpret a command, possibly memoizing it *)
-  val eval :
-       token:Coq.Limits.Token.t
-    -> t
-    -> (Coq.State.t, Loc.t) Coq.Protect.E.t Stats.t
+(** Vernacular evaluation cache, invariant w.r.t. Coq's Ast locations, results
+    are repaired. *)
+module Interp :
+  S with type input = Coq.State.t * Coq.Ast.t and type output = Coq.State.t
 
-  (** [size ()] Return the size in words, expensive *)
-  val size : unit -> int
+(** Require evaluation cache, also invariant w.r.t. locations inside
+    [Coq.Ast.Require.t] *)
+module Require :
+  S
+    with type input = Coq.State.t * Coq.Files.t * Coq.Ast.Require.t
+     and type output = Coq.State.t
 
-  (** debug *)
-  val input_info : t -> string
-end
-
-module Require : sig
-  type t = Coq.State.t * Coq.Files.t * Coq.Ast.Require.t
-
-  (** Interpret a require, possibly memoizing it *)
-  val eval :
-       token:Coq.Limits.Token.t
-    -> t
-    -> (Coq.State.t, Loc.t) Coq.Protect.E.t Stats.t
-
-  (** [size ()] Return the size in words, expensive *)
-  val size : unit -> int
-
-  (** debug *)
-  val input_info : t -> string
-end
-
-module Admit : sig
-  type t = Coq.State.t
-
-  (** [size ()] Return the size in words, expensive *)
-  val size : unit -> int
-
-  val eval :
-    token:Coq.Limits.Token.t -> t -> (Coq.State.t, Loc.t) Coq.Protect.E.t
-end
+(** Admit evaluation cache *)
+module Admit : S with type input = Coq.State.t and type output = Coq.State.t
 
 module CacheStats : sig
   val reset : unit -> unit
 
-  (** Returns the hit ratio of the cache *)
+  (** Returns the hit ratio of the cache, etc... *)
   val stats : unit -> string
 end
 
+(** Size of all caches, very expensive *)
 val all_size : unit -> int

--- a/lsp/io.ml
+++ b/lsp/io.ml
@@ -93,7 +93,31 @@ end
 let trace_value = ref TraceValue.Off
 let set_trace_value value = trace_value := value
 
+module Lvl = struct
+  (* 1-5 *)
+  type t =
+    | Error
+    | Warning
+    | Info
+    | Log
+    | Debug
+
+  let to_int = function
+    | Error -> 1
+    | Warning -> 2
+    | Info -> 3
+    | Log -> 4
+    | Debug -> 5
+end
+
 let logMessage ~lvl ~message =
+  let method_ = "window/logMessage" in
+  let lvl = Lvl.to_int lvl in
+  let params = `Assoc [ ("type", `Int lvl); ("message", `String message) ] in
+  let msg = Base.mk_notification ~method_ ~params in
+  !fn msg
+
+let logMessageInt ~lvl ~message =
   let method_ = "window/logMessage" in
   let params = `Assoc [ ("type", `Int lvl); ("message", `String message) ] in
   let msg = Base.mk_notification ~method_ ~params in

--- a/lsp/io.mli
+++ b/lsp/io.mli
@@ -47,8 +47,21 @@ end
 (** Set the trace value *)
 val set_trace_value : TraceValue.t -> unit
 
+module Lvl : sig
+  (* 1-5 *)
+  type t =
+    | Error
+    | Warning
+    | Info
+    | Log
+    | Debug
+end
+
 (** Send a [window/logMessage] notification to the client *)
-val logMessage : lvl:int -> message:string -> unit
+val logMessage : lvl:Lvl.t -> message:string -> unit
+
+(** Send a [window/logMessage] notification to the client *)
+val logMessageInt : lvl:int -> message:string -> unit
 
 (** Send a [$/logTrace] notification to the client *)
 val logTrace : message:string -> extra:string option -> unit


### PR DESCRIPTION
New trim command (both in the server and in VSCode) to liberate
space used in the cache.

Command available as

`Coq LSP: Request the server to trim caches and compact memory`

Fixes #367

cc: #253 #236 #348 , which may be greatly alleviated by this PR.
