### PR TITLE
[diagnostics] Add sentence's range to errors extra `data` field.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -70,6 +70,11 @@
  - new VSCode commands to allow to move one sentence backwards /
    forward, this is particularly useful when combined with lazy
    checking mode (@ejgallego, #671, fixes #263, fixes #580)
+ - change diagnostic `extra` field to `data`, so we now conform to the
+   LSP spec, include the data only when the `send_diags_extra_data`
+   server-side option is enabled (@ejgallego, #670)
+ - include range of full sentence in error diagnostic extra data
+   (@ejgallego, #670 , thanks to @driverag22 for the idea, cc: #663).
 
 # coq-lsp 0.1.8.1: Spring fix
 -----------------------------

--- a/editor/code/package.json
+++ b/editor/code/package.json
@@ -165,6 +165,11 @@
             "type": "number",
             "default": 150,
             "description": "Maximum number of errors per file, after that, coq-lsp will stop checking the file."
+          },
+          "coq-lsp.send_diags_extra_data": {
+            "type": "boolean",
+            "default": false,
+            "description": "Send extra diagnostics data, usually on error"
           }
         }
       },

--- a/etc/doc/PROTOCOL.md
+++ b/etc/doc/PROTOCOL.md
@@ -72,6 +72,18 @@ to determine the content type. Supported extensions are:
 As of today, `coq-lsp` implements two extensions to the LSP spec. Note
 that none of them are stable yet:
 
+### Extra diagnostics data
+
+This is enabled if the server-side option `send_diags_extra_data` is
+set to `true`. In this case, some diagnostics may come with extra data
+in the optional `data` field.
+
+This field is experimental, and it can change without warning. As of
+today we offer two kinds of extra information on errors:
+
+- range of the full sentence that displayed the error,
+- if the error was on a Require, information about the library that failed.
+
 ### Goal Display
 
 In order to display proof goals and information at point, `coq-lsp` supports the `proof/goals` request, parameters are:

--- a/fleche/config.ml
+++ b/fleche/config.ml
@@ -49,6 +49,9 @@ type t =
         (** Verbosity, 1 = reduced, 2 = default. As of today reduced will
             disable all logging, and the diagnostics and perf_data notification *)
   ; check_only_on_request : bool [@default false]
+        (** Experimental setting to check document lazily *)
+  ; send_diags_extra_data : bool [@default false]
+        (** Send extra diagnostic data on the `data` diagnostic field. *)
   }
 
 let default =
@@ -71,6 +74,7 @@ let default =
   ; send_perf_data = true
   ; send_diags = true
   ; check_only_on_request = false
+  ; send_diags_extra_data = false
   }
 
 let v = ref default

--- a/lang/diagnostic.ml
+++ b/lang/diagnostic.ml
@@ -4,8 +4,9 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-module Extra = struct
+module Data = struct
   type t =
+    | SentenceRange of Range.t
     | FailedRequire of
         { prefix : Libnames.qualid option
         ; refs : Libnames.qualid list
@@ -26,7 +27,7 @@ type t =
   { range : Range.t
   ; severity : Severity.t
   ; message : Pp.t
-  ; extra : Extra.t list option
+  ; data : Data.t list option [@default None]
   }
 
 let is_error { severity; _ } = severity = 1

--- a/lang/diagnostic.mli
+++ b/lang/diagnostic.mli
@@ -4,8 +4,9 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-module Extra : sig
+module Data : sig
   type t =
+    | SentenceRange of Range.t
     | FailedRequire of
         { prefix : Libnames.qualid option
         ; refs : Libnames.qualid list
@@ -28,7 +29,7 @@ type t =
   { range : Range.t
   ; severity : Severity.t
   ; message : Pp.t
-  ; extra : Extra.t list option
+  ; data : Data.t list option [@default None]
   }
 
 val is_error : t -> bool

--- a/lsp/jLang.ml
+++ b/lsp/jLang.ml
@@ -37,6 +37,15 @@ end
 module Diagnostic = struct
   module Libnames = Serlib.Ser_libnames
 
+  module Data = struct
+    module Lang = struct
+      module Range = Range
+      module Diagnostic = Lang.Diagnostic
+    end
+
+    type t = [%import: Lang.Diagnostic.Data.t] [@@deriving yojson]
+  end
+
   (* LSP Ranges, a bit different from Fleche's ranges as points don't include
      offsets *)
   module Point = struct
@@ -69,14 +78,15 @@ module Diagnostic = struct
     { range : Range.t
     ; severity : int
     ; message : string
+    ; data : Data.t list option [@default None]
     }
   [@@deriving yojson]
 
-  let to_yojson { Lang.Diagnostic.range; severity; message; extra = _ } =
+  let to_yojson { Lang.Diagnostic.range; severity; message; data } =
     let range = Range.conv range in
     let severity = Lang.Diagnostic.Severity.to_int severity in
     let message = Pp.to_string message in
-    _t_to_yojson { range; severity; message }
+    _t_to_yojson { range; severity; message; data }
 end
 
 let mk_diagnostics ~uri ~version ld : Yojson.Safe.t =


### PR DESCRIPTION
- We change diagnostics `extra` field to `data`, so we now conform to the LSP spec
- we include the data only when the `send_diags_extra_data` server-side option is enabled
- we now include range of full sentence in error diagnostic extra data

Thanks to @driverag22 for the idea, cc #663