### PR TITLE
[vscode] Have `coq-lsp.pp_type` changes take effect immediately

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -75,6 +75,9 @@
    server-side option is enabled (@ejgallego, #670)
  - include range of full sentence in error diagnostic extra data
    (@ejgallego, #670 , thanks to @driverag22 for the idea, cc: #663).
+ - The `coq-lsp.pp_type` VSCode client option now takes effect
+   immediately, no more need to restart the server to get different
+   goal display formats (@ejgallego, #675)
 
 # coq-lsp 0.1.8.1: Spring fix
 -----------------------------

--- a/editor/code/src/client.ts
+++ b/editor/code/src/client.ts
@@ -79,6 +79,14 @@ export function activateCoqLSP(
 ): CoqLspAPI {
   window.showInformationMessage("Coq LSP Extension: Going to activate!");
 
+  workspace.onDidChangeConfiguration((cfgChange) => {
+    if (cfgChange.affectsConfiguration("coq-lsp")) {
+      // Refactor to remove the duplicate call below
+      const wsConfig = workspace.getConfiguration("coq-lsp");
+      config = CoqLspClientConfig.create(wsConfig);
+    }
+  });
+
   function coqCommand(command: string, fn: () => void) {
     let disposable = commands.registerCommand("coq-lsp." + command, fn);
     context.subscriptions.push(disposable);
@@ -208,7 +216,13 @@ export function activateCoqLSP(
     let uri = editor.document.uri;
     let version = editor.document.version;
     let position = editor.selection.active;
-    infoPanel.updateFromServer(client, uri, version, position);
+    infoPanel.updateFromServer(
+      client,
+      uri,
+      version,
+      position,
+      config.pp_format
+    );
   };
 
   const goalsCall = (

--- a/editor/code/src/config.ts
+++ b/editor/code/src/config.ts
@@ -1,4 +1,4 @@
-import { DocumentSelector, ExtensionContext, workspace } from "vscode";
+import { DocumentSelector } from "vscode";
 
 export interface CoqLspServerConfig {
   client_version: string;
@@ -48,14 +48,30 @@ export enum ShowGoalsOnCursorChange {
 
 export interface CoqLspClientConfig {
   show_goals_on: ShowGoalsOnCursorChange;
+  pp_format: "Pp" | "Str";
+}
+
+function pp_type_to_pp_format(pp_type: 0 | 1 | 2): "Pp" | "Str" {
+  switch (pp_type) {
+    case 0:
+      return "Str";
+    case 1:
+      return "Pp";
+    case 2:
+      return "Pp";
+  }
 }
 
 export namespace CoqLspClientConfig {
   export function create(wsConfig: any): CoqLspClientConfig {
-    let obj: CoqLspClientConfig = { show_goals_on: wsConfig.show_goals_on };
+    let obj: CoqLspClientConfig = {
+      show_goals_on: wsConfig.show_goals_on,
+      pp_format: pp_type_to_pp_format(wsConfig.pp_type),
+    };
     return obj;
   }
 }
+
 export const coqLSPDocumentSelector: DocumentSelector = [
   { language: "coq" },
   { language: "markdown", pattern: "**/*.mv" },

--- a/editor/code/src/goals.ts
+++ b/editor/code/src/goals.ts
@@ -134,21 +134,26 @@ export class InfoPanel {
     client: BaseLanguageClient,
     uri: Uri,
     version: number,
-    position: Position
+    position: Position,
+    pp_format: "Pp" | "Str"
   ) {
     let textDocument = VersionedTextDocumentIdentifier.create(
       uri.toString(),
       version
     );
-    // let pretac = "idtac.";
-    // let cursor: GoalRequest = { textDocument, position, pretac };
-    let cursor: GoalRequest = { textDocument, position };
+
+    // Example to test the `command` parameter
+    // let command = "idtac.";
+    // let cursor: GoalRequest = { textDocument, position, command };
+    let cursor: GoalRequest = { textDocument, position, pp_format };
+    this.sendGoalsRequest(client, cursor);
+
     let strCursor: GoalRequest = {
       textDocument,
       position,
       pp_format: "Str",
     };
-    this.sendGoalsRequest(client, cursor);
+
     let vizx = extensions.getExtension("inQWIRE.vizx");
     if (vizx?.isActive) {
       console.log("vizx active in updateFromServer");


### PR DESCRIPTION
Having to restart the server to change goal display setting was not needed.

Eventually we can expose this setting even the panel UI for easier use if needed.