### PR TITLE
[vscode] [goals] Handle goal requests better when in Live Share

### DIFF
--- a/editor/code/lib/types.ts
+++ b/editor/code/lib/types.ts
@@ -124,3 +124,31 @@ export interface DocumentPerfParams {
   summary: string;
   timings: SentencePerfParams[];
 }
+
+// View messaging interfaces; should go on their own file
+export interface RenderGoals {
+  method: "renderGoals";
+  params: GoalAnswer<PpString>;
+}
+
+export interface WaitingForInfo {
+  method: "waitingForInfo";
+  params: GoalRequest;
+}
+
+export interface ErrorData {
+  textDocument: VersionedTextDocumentIdentifier;
+  position: Position;
+  message: string;
+}
+
+export interface InfoError {
+  method: "infoError";
+  params: ErrorData;
+}
+
+export type CoqMessagePayload = RenderGoals | WaitingForInfo | InfoError;
+
+export interface CoqMessageEvent extends MessageEvent {
+  data: CoqMessagePayload;
+}

--- a/editor/code/src/config.ts
+++ b/editor/code/src/config.ts
@@ -1,4 +1,4 @@
-import { DocumentSelector } from "vscode";
+import { TextDocumentFilter } from "vscode-languageclient";
 
 export interface CoqLspServerConfig {
   client_version: string;
@@ -72,7 +72,20 @@ export namespace CoqLspClientConfig {
   }
 }
 
-export const coqLSPDocumentSelector: DocumentSelector = [
-  { language: "coq" },
-  { language: "markdown", pattern: "**/*.mv" },
-];
+export namespace CoqSelector {
+  // All Coq files, regardless of the scheme.
+  export const all: TextDocumentFilter[] = [
+    { language: "coq" },
+    { language: "markdown", pattern: "**/*.mv" },
+  ];
+
+  // Local Coq files, suitable for interaction with a local server
+  export const local: TextDocumentFilter[] = all.map((selector) => {
+    return { ...selector, scheme: "file" };
+  });
+
+  // VSCode Live Share URIs
+  export const vsls: TextDocumentFilter[] = all.map((selector) => {
+    return { ...selector, scheme: "vsls" };
+  });
+}

--- a/editor/code/src/progress.ts
+++ b/editor/code/src/progress.ts
@@ -11,7 +11,7 @@ import {
   VersionedTextDocumentIdentifier,
 } from "vscode-languageclient";
 import { BaseLanguageClient } from "vscode-languageclient";
-import { coqLSPDocumentSelector } from "./config";
+import { CoqSelector } from "./config";
 
 enum CoqFileProgressKind {
   Processing = 1,
@@ -71,7 +71,7 @@ export class FileProgressManager {
   });
   private cleanDecos() {
     for (const editor of window.visibleTextEditors) {
-      if (languages.match(coqLSPDocumentSelector, editor.document) > 0) {
+      if (languages.match(CoqSelector.all, editor.document) > 0) {
         editor.setDecorations(progressDecoration, []);
       }
     }


### PR DESCRIPTION
While we get approval for implementing full Live Share support in `coq-lsp`, we fix some problems with the current implementation of selectors and API calls for goals, in particular:

- consolidate and implement Coq document selectors into 3 kinds (all, local, vsls documents)
- handle cases for vsls goals request correctly
- expose types for infoView protocol, improve such types
- display info message about goals not available in VSLS