### PR TITLE
[fleche] Handle performance data correctly for cached sentences

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -98,6 +98,10 @@
  - Update `package-lock.json` for latest bugfixes (@ejgallego, #687)
  - Update Nix flake enviroment (@Alizter, #684 #688)
  - Update `prettier` (@Alizter @ejgallego, #684 #688)
+ - Store original performance data in the cache, so we now display the
+   original timing and memory data even for cached commands (@ejgallego, #)
+ - Fix type errors in the Performance Data Notifications (@ejgallego,
+   @Alizter, #)
 
 # coq-lsp 0.1.8.1: Spring fix
 -----------------------------

--- a/editor/code/lib/types.ts
+++ b/editor/code/lib/types.ts
@@ -114,9 +114,9 @@ export interface FlecheSaveParams {
 }
 
 export interface SentencePerfParams {
-  loc: Loc;
+  Range: Range;
   time: number;
-  mem: number;
+  memory: number;
 }
 
 export interface DocumentPerfParams {

--- a/editor/code/views/perf/App.tsx
+++ b/editor/code/views/perf/App.tsx
@@ -33,14 +33,14 @@ function printWords(w: number) {
 
 function SentencePerfCell({ field, value }) {
   switch (field) {
-    case "loc":
+    case "range":
       let r = value as Range;
       return (
         <span>{`l: ${r.start.line} c: ${r.start.character} -- l: ${r.end.line} c: ${r.end.character}`}</span>
       );
     case "time":
       return <span>{`${value.toFixed(4).toString()} secs`}</span>;
-    case "mem":
+    case "memory":
       return <span>{printWords(value)}</span>;
     default:
       return null;

--- a/etc/doc/PROTOCOL.md
+++ b/etc/doc/PROTOCOL.md
@@ -303,9 +303,9 @@ hotspots and memory use by sentences.
 
 ```typescript
 export interface SentencePerfParams {
-    loc: Loc,
+    range: Range,
     time: number,
-    mem, number
+    memory, number
 }
 
 export interface DocumentPerfParams {
@@ -317,6 +317,13 @@ export interface DocumentPerfParams {
 
 #### Changelog
 
+- v0.1.9:
+  + Fields renamed: `loc -> range`, `mem -> memory`
+  + Fixed type for `range`, it was always `Range`
+  + We now send the real time, even if the command was cached
+  + `memory` now means difference in memory from `GC.quick_stat`
+  + we send all the sentences in the document, not only the top 10
+    hotspots, and we send them in document order
 - v0.1.7: Initial version
 
 ### Trim cache notification

--- a/fleche/doc.mli
+++ b/fleche/doc.mli
@@ -14,13 +14,10 @@ module Node : sig
   end
 
   module Info : sig
-    type t = private
-      { cache_hit : bool
-      ; parsing_time : float
-      ; time : float option
-      ; mw_prev : float
-      ; mw_after : float
-      ; stats : Stats.t  (** Info about cumulative stats *)
+    type t =
+      { parsing_time : float
+      ; stats : Memo.Stats.t option
+      ; global_stats : Stats.Global.t  (** Info about cumulative stats *)
       }
 
     val print : t -> string

--- a/fleche/memo.mli
+++ b/fleche/memo.mli
@@ -1,9 +1,9 @@
 module Stats : sig
-  type 'a t =
-    { res : 'a
-    ; cache_hit : bool
-    ; memory : int
-    ; time : float
+  type t =
+    { stats : Stats.t
+    ; time_hash : float
+          (** Time in hashing consumed in the original execution *)
+    ; cache_hit : bool  (** Whether we had a cache hit *)
     }
 end
 
@@ -20,7 +20,9 @@ module type S = sig
 
   (** [eval i] Eval an input [i] and produce stats *)
   val evalS :
-    token:Coq.Limits.Token.t -> input -> (output, Loc.t) Coq.Protect.E.t Stats.t
+       token:Coq.Limits.Token.t
+    -> input
+    -> (output, Loc.t) Coq.Protect.E.t * Stats.t
 
   (** [size ()] Return the cache size in words, expensive *)
   val size : unit -> int
@@ -56,7 +58,7 @@ module Require :
 (** Admit evaluation cache *)
 module Admit : S with type input = Coq.State.t and type output = Coq.State.t
 
-module CacheStats : sig
+module GlobalCacheStats : sig
   val reset : unit -> unit
 
   (** Returns the hit ratio of the cache, etc... *)

--- a/fleche/perf.ml
+++ b/fleche/perf.ml
@@ -7,9 +7,9 @@
 
 module Sentence = struct
   type t =
-    { loc : Lang.Range.t
+    { range : Lang.Range.t
     ; time : float
-    ; mem : float
+    ; memory : float
     }
 end
 

--- a/fleche/perf.mli
+++ b/fleche/perf.mli
@@ -7,9 +7,9 @@
 
 module Sentence : sig
   type t =
-    { loc : Lang.Range.t
+    { range : Lang.Range.t
     ; time : float
-    ; mem : float
+    ; memory : float
     }
 end
 

--- a/fleche/perf_analysis.ml
+++ b/fleche/perf_analysis.ml
@@ -5,18 +5,31 @@ let rec list_take n = function
   | x :: xs -> if n = 0 then [] else x :: list_take (n - 1) xs
 
 let mk_loc_time (n : Doc.Node.t) =
-  let time = Option.default 0.0 n.info.time in
-  let mem = n.info.mw_after -. n.info.mw_prev in
-  let loc = n.Doc.Node.range in
-  Sentence.{ loc; time; mem }
+  let time, memory =
+    Option.cata
+      (fun (stats : Memo.Stats.t) -> (stats.stats.time, stats.stats.memory))
+      (0.0, 0.0) n.info.stats
+  in
+  let range = n.Doc.Node.range in
+  Sentence.{ range; time; memory }
 
 let get_stats ~(doc : Doc.t) =
   match List.rev doc.nodes with
-  | [] -> "no stats"
-  | n :: _ -> Stats.to_string n.info.stats
+  | [] -> "no global stats"
+  | n :: _ -> Stats.Global.to_string n.info.global_stats
 
 (** Turn into a config option at some point? This is very expensive *)
 let display_cache_size = false
+
+let node_time_compare (n1 : Doc.Node.t) (n2 : Doc.Node.t) =
+  match (n1.info.stats, n2.info.stats) with
+  | Some s1, Some s2 -> -compare s1.stats.time s2.stats.time
+  | None, Some _ -> 1
+  | Some _, None -> -1
+  | None, None -> 0
+
+(* Old mode of sending only the 10 hotspots *)
+let hotspot = false
 
 let make (doc : Doc.t) =
   let n_stm = List.length doc.nodes in
@@ -28,11 +41,9 @@ let make (doc : Doc.t) =
     Format.asprintf "{ num sentences: %d@\n; stats: %s; cache: %a@\n}" n_stm
       stats Stats.pp_words cache_size
   in
-  let top =
-    List.stable_sort
-      (fun (n1 : Doc.Node.t) n2 -> compare n2.info.time n1.info.time)
-      doc.nodes
+  let timings =
+    if hotspot then List.stable_sort node_time_compare doc.nodes |> list_take 10
+    else doc.nodes
   in
-  let top = list_take 10 top in
-  let timings = List.map mk_loc_time top in
+  let timings = List.map mk_loc_time timings in
   { summary; timings }

--- a/fleche/stats.mli
+++ b/fleche/stats.mli
@@ -1,4 +1,4 @@
-(** time-based stats *)
+(** time and memory-based stats *)
 module Kind : sig
   type t =
     | Hashing
@@ -6,17 +6,36 @@ module Kind : sig
     | Exec
 end
 
-val get : kind:Kind.t -> float
-val record : kind:Kind.t -> f:('a -> 'b) -> 'a -> 'b * float
+type t =
+  { time : float
+  ; memory : float
+  }
+
+(** [record ~kind ~f x] returns [f x] with timing and memory use data attached
+    to it; it will also update the global table for [kind] *)
+val record : kind:Kind.t -> f:('a -> 'b) -> 'a -> 'b * t
+
+(** [get_accumulated ~kind] returns global accumulated stats for [kind] *)
+val get_accumulated : kind:Kind.t -> t
+
+(** [reset ()] Reset global accumulated stats *)
 val reset : unit -> unit
 
-type t
+module Global : sig
+  (** Operations to save/restore global accumulated state *)
+  type nonrec 'a stats = t
 
-val zero : unit -> t
-val to_string : t -> string
-val dump : unit -> t
-val restore : t -> unit
-val get_f : t -> kind:Kind.t -> float
+  type t
+
+  val zero : unit -> t
+  val dump : unit -> t
+  val restore : t -> unit
+
+  (** Get a particular field *)
+  val get_f : t -> kind:Kind.t -> unit stats
+
+  val to_string : t -> string
+end
 
 (** Pretty-print memory info as words *)
 val pp_words : Format.formatter -> float -> unit


### PR DESCRIPTION
We extend `Memo` as to store the original performance execution data, this way, we can display it correctly, and we distinguish the case where a sentence was memoized better.

This is a fix, because before we would display the wrong data for incremental checking.

This is complementary to #686 and #689.

We cherry pick the protocol fixes from #689 as to have this PR in mergeable / testeable shape.