### PR TITLE
[code] [types] Generalize TS perf datatype.

### DIFF
--- a/editor/code/lib/types.ts
+++ b/editor/code/lib/types.ts
@@ -125,15 +125,15 @@ export interface PerfInfo {
   time_hash: number;
 }
 
-export interface SentencePerfParams {
-  range: Range;
+export interface SentencePerfParams<R> {
+  range: R;
   info: PerfInfo;
 }
 
-export interface DocumentPerfParams {
+export interface DocumentPerfParams<R> {
   textDocument: VersionedTextDocumentIdentifier;
   summary: string;
-  timings: SentencePerfParams[];
+  timings: SentencePerfParams<R>[];
 }
 
 // View messaging interfaces; should go on their own file
@@ -167,7 +167,7 @@ export interface CoqMessageEvent extends MessageEvent {
 // For perf panel data
 export interface PerfUpdate {
   method: "update";
-  params: DocumentPerfParams;
+  params: DocumentPerfParams<Range>;
 }
 
 export interface PerfReset {

--- a/editor/code/src/perf.ts
+++ b/editor/code/src/perf.ts
@@ -6,16 +6,17 @@ import {
   WebviewViewResolveContext,
   window,
 } from "vscode";
+import { Range } from "vscode-languageserver-types";
 import { NotificationType } from "vscode-languageclient";
 import { DocumentPerfParams, PerfMessagePayload } from "../lib/types";
 
-export const coqPerfData = new NotificationType<DocumentPerfParams>(
+export const coqPerfData = new NotificationType<DocumentPerfParams<Range>>(
   "$/coq/filePerfData"
 );
 
 export class PerfDataView implements Disposable {
   private panel: Disposable;
-  private updateWebView: (data: DocumentPerfParams) => void = () => {};
+  private updateWebView: (data: DocumentPerfParams<Range>) => void = () => {};
 
   constructor(extensionUri: Uri) {
     let resolveWebviewView = (
@@ -50,7 +51,7 @@ export class PerfDataView implements Disposable {
       </body>
       </html>`;
 
-      this.updateWebView = (params: DocumentPerfParams) => {
+      this.updateWebView = (params: DocumentPerfParams<Range>) => {
         let message: PerfMessagePayload = { method: "update", params };
         webview.webview.postMessage(message);
       };
@@ -68,7 +69,7 @@ export class PerfDataView implements Disposable {
   dispose() {
     this.panel.dispose();
   }
-  update(data: DocumentPerfParams) {
+  update(data: DocumentPerfParams<Range>) {
     this.updateWebView(data);
   }
 }

--- a/editor/code/views/perf/App.tsx
+++ b/editor/code/views/perf/App.tsx
@@ -1,5 +1,5 @@
 import { WebviewApi } from "vscode-webview";
-import React, { ReactElement, useEffect, useState } from "react";
+import { ReactElement, useEffect, useState } from "react";
 import {
   VSCodeDataGrid,
   VSCodeDataGridRow,
@@ -13,15 +13,15 @@ import {
   SentencePerfParams,
 } from "../../lib/types";
 
-const vscode: WebviewApi<DocumentPerfParams> = acquireVsCodeApi();
+const vscode: WebviewApi<DocumentPerfParams<Range>> = acquireVsCodeApi();
 
-let empty: DocumentPerfParams = {
+let empty: DocumentPerfParams<Range> = {
   textDocument: { uri: "", version: 0 },
   summary: "No Data Yet",
   timings: [],
 };
 
-function validateViewState(p: DocumentPerfParams) {
+function validateViewState(p: DocumentPerfParams<Range>) {
   return (
     p.textDocument &&
     p.summary &&
@@ -32,9 +32,11 @@ function validateViewState(p: DocumentPerfParams) {
   );
 }
 
-function validOrEmpty(p: DocumentPerfParams | undefined): DocumentPerfParams {
+function validOrEmpty(
+  p: DocumentPerfParams<Range> | undefined
+): DocumentPerfParams<Range> {
   // XXX We need to be careful here, when we update the
-  // DocumentPerfParams data type, the saved data here will make the
+  // DocumentPerfParams<Range> data type, the saved data here will make the
   // view crash
   if (p && validateViewState(p)) return p;
   else return empty;
@@ -54,7 +56,7 @@ function printWords(w: number) {
 
 // XXX: Would be nice to have typing here, but...
 interface PerfCellP {
-  field: keyof SentencePerfParams | string;
+  field: keyof SentencePerfParams<Range> | string;
   value: any;
 }
 
@@ -79,10 +81,10 @@ function SentencePerfCell({ field, value }: PerfCellP) {
 
 interface PerfParamsP {
   idx: number;
-  value: SentencePerfParams;
+  value: SentencePerfParams<Range>;
 }
 
-function perfFlatten(v: SentencePerfParams) {
+function perfFlatten(v: SentencePerfParams<Range>) {
   return {
     range: v.range,
     time: v.info.time,
@@ -109,11 +111,11 @@ function SentencePerfRow({ idx, value }: PerfParamsP) {
   );
 }
 
-function timeCmp(t1: SentencePerfParams, t2: SentencePerfParams) {
+function timeCmp(t1: SentencePerfParams<Range>, t2: SentencePerfParams<Range>) {
   return t2.info.time - t1.info.time;
 }
 
-function viewSort(p: DocumentPerfParams) {
+function viewSort(p: DocumentPerfParams<Range>) {
   let textDocument = p.textDocument;
   let summary = p.summary;
   let tlength = p.timings.length;

--- a/editor/code/views/perf/index.tsx
+++ b/editor/code/views/perf/index.tsx
@@ -1,5 +1,5 @@
 // This is the script that is loaded by Coq's webview
-import React from "react";
+import * as React from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
 

--- a/editor/code/views/perf/tsconfig.json
+++ b/editor/code/views/perf/tsconfig.json
@@ -5,5 +5,5 @@
     "target": "ESNext",
     "jsx": "react-jsx"
   },
-  "include": ["**/*.ts", "../../lib/**/*"]
+  "include": ["**/*.ts", "**/*.tsx", "../../lib/**/*"]
 }

--- a/etc/doc/PROTOCOL.md
+++ b/etc/doc/PROTOCOL.md
@@ -138,6 +138,8 @@ interface GoalAnswer<Pp> {
   error?: Pp;
   program?: ProgramInfo;
 }
+
+const goalReq : RequestType<GoalRequest, GoalAnswer<PpString>, void>
 ```
 
 which can be then rendered by the client in way that is desired.
@@ -268,6 +270,8 @@ interface FlecheDocument {
     spans: RangedSpan[];
     completed : CompletionStatus
 };
+
+const docReq : RequestType<FlecheDocumentParams, FlecheDocument, void>
 ```
 
 #### Changelog
@@ -303,7 +307,7 @@ option is enabled); it includes information about execution hotspots,
 caching, and memory use by sentences:
 
 ```typescript
-export interface PerfInfo {
+interface PerfInfo {
   // Original Execution Time (when not cached)
   time: number;
   // Difference in words allocated in the heap using `Gc.quick_stat`
@@ -314,16 +318,18 @@ export interface PerfInfo {
   time_hash: number;
 }
 
-export interface SentencePerfParams {
-  range: Range;
+interface SentencePerfParams<R> {
+  range: R;
   info: PerfInfo;
 }
 
-export interface DocumentPerfParams {
+interface DocumentPerfParams<R> {
   textDocument: VersionedTextDocumentIdentifier;
   summary: string;
-  timings: SentencePerfParams[];
+  timings: SentencePerfParams<R>[];
 }
+
+const coqPerfData : NotificationType<DocumentPerfParams<Range>>
 ```
 
 #### Changelog
@@ -338,6 +344,7 @@ export interface DocumentPerfParams {
   + `memory` now means difference in memory from `GC.quick_stat`
   + `filePerfData` will send the full document, ordered linearly, in
     0.1.7 we only sent the top 10 hotspots
+  + generalized typed over `R` parameter for range
 - v0.1.8: Spec was accidentally broken, types were invalid
 - v0.1.7: Initial version
 


### PR DESCRIPTION
This is useful for #686.

We also fix a misconfiguration of the perf view compilation.