### PR TITLE
[fleche] Improve toc to return nodes instead of ranges.

### DIFF
--- a/controller/rq_definition.ml
+++ b/controller/rq_definition.ml
@@ -11,8 +11,9 @@ let request ~token:_ ~(doc : Fleche.Doc.t) ~point =
     (fun id_at_point ->
       let { Fleche.Doc.toc; _ } = doc in
       match CString.Map.find_opt id_at_point toc with
-      | Some range ->
+      | Some node ->
         let uri = doc.uri in
+        let range = node.range in
         Lsp.Core.Location.({ uri; range } |> to_yojson)
       | None -> `Null)
     `Null

--- a/fleche/doc.mli
+++ b/fleche/doc.mli
@@ -29,6 +29,7 @@ module Node : sig
 
   type t = private
     { range : Lang.Range.t
+    ; prev : t option
     ; ast : Ast.t option  (** Ast of node *)
     ; state : Coq.State.t  (** (Full) State of node *)
     ; diags : Lang.Diagnostic.t list  (** Diagnostics associated to the node *)
@@ -82,7 +83,7 @@ type t = private
   ; completed : Completion.t
         (** Status of the document, usually either completed, suspended, or
             waiting for some IO / external event *)
-  ; toc : Lang.Range.t CString.Map.t  (** table of contents *)
+  ; toc : Node.t CString.Map.t  (** table of contents *)
   ; env : Env.t  (** External document enviroment *)
   ; root : Coq.State.t
         (** [root] contains the first state document state, obtained by applying

--- a/petanque/agent.ml
+++ b/petanque/agent.ml
@@ -82,18 +82,10 @@ let find_thm ~(doc : Fleche.Doc.t) ~thm =
   | None ->
     let msg = Format.asprintf "@[[find_thm] Theorem not found!@]" in
     Error (Error.Theorem_not_found msg)
-  | Some range ->
+  | Some node ->
     if pet_debug then Format.eprintf "@[[find_thm] Theorem found!@\n@]%!";
     (* let point = (range.start.line, range.start.character) in *)
-    let point = (range.end_.line, range.end_.character) in
-    let approx = Fleche.Info.PrevIfEmpty in
-    let node = Fleche.Info.LC.node ~doc ~point approx in
-    let error =
-      Error.Theorem_not_found
-        (Format.asprintf "@[[find_thm] No node found for point (%d, %d) @]"
-           (fst point) (snd point))
-    in
-    Base.Result.of_option ~error node |> Result.map Fleche.Doc.Node.state
+    Ok (Fleche.Doc.Node.state node)
 
 let pp_diag fmt { Lang.Diagnostic.message; _ } =
   Format.fprintf fmt "%a" Pp.pp_with message


### PR DESCRIPTION
This is a big improvements for plugins that often use the `toc` as a document access point, for example to do speculative execution.

We also add an option `node.prev` field, which is very useful to go back on document nodes when these where obtained by some other method.