### PR TITLE
[code] Display and allow status bar item to toggle continuous / lazy …

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -151,6 +151,8 @@
    user navigates proofs (@Alidra @ejgallego, #722, #725)
  - `fcc`: new option `--diags_level` to control whether Coq's notice
    and info messages appear as diagnostics
+ - Display the continous/on-request checking mode in the status bar,
+   allow to change it by clicking on it (@ejgallego, #721)
 
 # coq-lsp 0.1.8.1: Spring fix
 -----------------------------


### PR DESCRIPTION
…mode

We display the continuous / lazy mode checking in the status bar item, and we allow to toggle them with a click.

There are some usability questions with the current setup tho, I wonder if we should move the start / stop server command to the tooltip or to a `LanguageStatusItem` as done in other extensions.

cc: #24