### PR TITLE
Give focus back to Goals panel when navigating proofs

### DIFF
--- a/editor/code/CHANGELOG.md
+++ b/editor/code/CHANGELOG.md
@@ -1,6 +1,9 @@
 # coq-lsp 0.1.8: Trick-or-treat
 -------------------------------
 
+ - Give `Goals` panel focus back if it has lost it (in case of
+   multiple panels in the second viewColumn of Vscode) whenever
+   user navigates proofs
  - Update VSCode client dependencies, should bring some performance
    improvements to goal pretty printing (@ejgallego, #530)
  - Update goal display colors for light mode so they are actually

--- a/editor/code/src/goals.ts
+++ b/editor/code/src/goals.ts
@@ -97,6 +97,10 @@ export class InfoPanel {
   ensurePanel() {
     if (!this.panel) {
       this.panelFactory();
+    } else {
+      if (!this.panel.active) {
+        this.panel.reveal(2, false);
+      }
     }
   }
   postMessage({ method, params }: CoqMessagePayload) {


### PR DESCRIPTION
The `Goals` panel is shown in the second column of Vscode. If the user opens a second panel in this column the `Goals` panel may loose focus and proofs and not visible to user when he navigates the proofs again.

This PR, gives the focus back automatically to the `Goals` panel if it has lost it as soon as the user navigates the proofs again.