### PR TITLE
[compiler] Allow control of Coq's info and notice messages.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -144,10 +144,13 @@
  - Center the view if cursor goes out of scope in
    `sentenceNext/sentencePrevious` (@ejgallego, #718)
  - Switch Flèche range encoding to protocol native, this means UTF-16
-   for now (Léo Stefanesco, @ejgallego, #624, fixes #620, #621)
+   code points for now (Léo Stefanesco, @ejgallego, #624, fixes #620,
+   #621)
  - Give `Goals` panel focus back if it has lost it (in case of
    multiple panels in the second viewColumn of Vscode) whenever
    user navigates proofs (@Alidra @ejgallego, #722, #725)
+ - `fcc`: new option `--diags_level` to control whether Coq's notice
+   and info messages appear as diagnostics
 
 # coq-lsp 0.1.8.1: Spring fix
 -----------------------------

--- a/compiler/args.ml
+++ b/compiler/args.ml
@@ -14,6 +14,8 @@ type t =
   ; plugins : string list  (** Flèche plugins to load *)
   ; max_errors : int option
         (** Maximum erros before aborting the compilation *)
+  ; coq_diags_level : int
+        (** Whether to include feedback messages in the diagnostics *)
   }
 
 let compute_default_plugins ~no_vo ~plugins =

--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -36,12 +36,20 @@ let apply_config ~max_errors =
     max_errors
 
 let go ~int_backend args =
-  let { Args.cmdline; roots; display; debug; files; plugins; max_errors } =
+  let { Args.cmdline
+      ; roots
+      ; display
+      ; debug
+      ; files
+      ; plugins
+      ; max_errors
+      ; coq_diags_level
+      } =
     args
   in
   (* Initialize event callbacks, in testing don't do perfData *)
   let perfData = Option.is_empty fcc_test in
-  let io = Output.init display ~perfData in
+  let io = Output.init ~display ~perfData ~coq_diags_level in
   (* Initialize Coq *)
   let debug = debug || Fleche.Debug.backtraces || !Fleche.Config.v.debug in
   let root_state = coq_init ~debug in

--- a/compiler/fcc.ml
+++ b/compiler/fcc.ml
@@ -3,7 +3,8 @@ open Cmdliner
 open Fcc_lib
 
 let fcc_main int_backend roots display debug plugins files coqlib coqcorelib
-    ocamlpath rload_path load_path require_libraries no_vo max_errors =
+    ocamlpath rload_path load_path require_libraries no_vo max_errors
+    coq_diags_level =
   let vo_load_path = rload_path @ load_path in
   let ml_include_path = [] in
   let args = [] in
@@ -19,7 +20,16 @@ let fcc_main int_backend roots display debug plugins files coqlib coqcorelib
   in
   let plugins = Args.compute_default_plugins ~no_vo ~plugins in
   let args =
-    Args.{ cmdline; roots; display; files; debug; plugins; max_errors }
+    Args.
+      { cmdline
+      ; roots
+      ; display
+      ; files
+      ; debug
+      ; plugins
+      ; max_errors
+      ; coq_diags_level
+      }
   in
   Driver.go ~int_backend args
 
@@ -91,7 +101,7 @@ let fcc_cmd : int Cmd.t =
     Term.(
       const fcc_main $ int_backend $ roots $ display $ debug $ plugins $ file
       $ coqlib $ coqcorelib $ ocamlpath $ rload_paths $ qload_paths $ ri_from
-      $ no_vo $ max_errors)
+      $ no_vo $ max_errors $ coq_diags_level)
   in
   let exits = Exit_codes.[ fatal; stopped; scheduled; uri_failed ] in
   Cmd.(v (Cmd.info "fcc" ~exits ~version ~doc ~man) fcc_term)

--- a/compiler/output.ml
+++ b/compiler/output.ml
@@ -56,16 +56,18 @@ let set_callbacks (display : Args.Display.t) =
   Fleche.Io.CallBack.set cb;
   cb
 
-let set_config ~perfData =
+let set_config ~perfData ~coq_diags_level =
+  let show_coq_info_messages = coq_diags_level > 1 in
+  let show_notices_as_diagnostics = coq_diags_level > 0 in
   Fleche.Config.(
     v :=
       { !v with
         send_perf_data = perfData
       ; eager_diagnostics = false
-      ; show_coq_info_messages = true
-      ; show_notices_as_diagnostics = true
+      ; show_coq_info_messages
+      ; show_notices_as_diagnostics
       })
 
-let init display ~perfData =
-  set_config ~perfData;
+let init ~display ~coq_diags_level ~perfData =
+  set_config ~perfData ~coq_diags_level;
   set_callbacks display

--- a/compiler/output.mli
+++ b/compiler/output.mli
@@ -1,5 +1,9 @@
 (** Initialize Console Output System *)
-val init : Args.Display.t -> perfData:bool -> Fleche.Io.CallBack.t
+val init :
+     display:Args.Display.t
+  -> coq_diags_level:int
+  -> perfData:bool
+  -> Fleche.Io.CallBack.t
 
 (** Report progress on file compilation *)
 (* val report : unit -> unit *)

--- a/coq/args.ml
+++ b/coq/args.ml
@@ -96,3 +96,10 @@ let int_backend =
 let roots : string list Term.t =
   let doc = "Workspace(s) root(s)" in
   Arg.(value & opt_all string [] & info [ "root" ] ~docv:"ROOTS" ~doc)
+
+let coq_diags_level : int Term.t =
+  let doc =
+    "Controsl whether Coq Info and Notice message appear in diagnostics.\n\
+    \ 0 = None; 1 = Notices, 2 = Notices and Info"
+  in
+  Arg.(value & opt int 0 & info [ "diags_level" ] ~docv:"DIAGS_LEVEL" ~doc)

--- a/coq/args.mli
+++ b/coq/args.mli
@@ -18,3 +18,4 @@ val ml_include_path : string list Term.t
 val ri_from : (string option * string) list Term.t
 val int_backend : Limits.backend option Term.t
 val roots : string list Term.t
+val coq_diags_level : int Term.t

--- a/test/compiler/basic/run.t
+++ b/test/compiler/basic/run.t
@@ -107,22 +107,6 @@ Compile a dependent file without the dep being built
   b.v
   b.vo
   $ cat proj1/a.diags
-  {
-    "range": {
-      "start": { "line": 0, "character": 0 },
-      "end": { "line": 0, "character": 19 }
-    },
-    "severity": 4,
-    "message": "aa is defined"
-  }
-  {
-    "range": {
-      "start": { "line": 6, "character": 0 },
-      "end": { "line": 6, "character": 4 }
-    },
-    "severity": 4,
-    "message": "foo is defined"
-  }
   $ cat proj1/b.diags
   {
     "range": {
@@ -139,6 +123,47 @@ Compile a dependent file without the dep being built
     },
     "severity": 1,
     "message": "The reference a.aa was not found in the current environment."
+  }
+
+Compile a file with all messages:
+  $ rm -f proj1/a.{diags,vo}
+  $ fcc --root proj1 --diags_level=1 proj1/a.v
+  [message] Configuration loaded from Command-line arguments
+   - coqlib is at: [TEST_PATH]
+     + coqcorelib is at: [TEST_PATH]
+   - Modules [Coq.Init.Prelude] will be loaded by default
+   - 2 Coq path directory bindings in scope; 24 Coq plugin directory bindings in scope
+   - ocamlpath wasn't overriden
+     + findlib config: [TEST_PATH]
+     + findlib default location: [TEST_PATH]
+  [message] compiling file proj1/a.v
+  $ cat proj1/a.diags
+  $ fcc --root proj1 --diags_level=2 proj1/a.v
+  [message] Configuration loaded from Command-line arguments
+   - coqlib is at: [TEST_PATH]
+     + coqcorelib is at: [TEST_PATH]
+   - Modules [Coq.Init.Prelude] will be loaded by default
+   - 2 Coq path directory bindings in scope; 24 Coq plugin directory bindings in scope
+   - ocamlpath wasn't overriden
+     + findlib config: [TEST_PATH]
+     + findlib default location: [TEST_PATH]
+  [message] compiling file proj1/a.v
+  $ cat proj1/a.diags
+  {
+    "range": {
+      "start": { "line": 0, "character": 0 },
+      "end": { "line": 0, "character": 19 }
+    },
+    "severity": 4,
+    "message": "aa is defined"
+  }
+  {
+    "range": {
+      "start": { "line": 6, "character": 0 },
+      "end": { "line": 6, "character": 4 }
+    },
+    "severity": 4,
+    "message": "foo is defined"
   }
 
 Use two workspaces

--- a/test/compiler/exit_code/run.t
+++ b/test/compiler/exit_code/run.t
@@ -20,14 +20,6 @@ Compile normally, even with errors, we exit 0:
   $ cat Demo.diags
   {
     "range": {
-      "start": { "line": 8, "character": 0 },
-      "end": { "line": 8, "character": 4 }
-    },
-    "severity": 4,
-    "message": "add_0_r is defined"
-  }
-  {
-    "range": {
       "start": { "line": 11, "character": 8 },
       "end": { "line": 11, "character": 15 }
     },


### PR DESCRIPTION
New `--diags_level` option for `fcc`.

- `--diags_level=0`: no notice or info
- `--diags_level=1`: notice yes, info no
- `--diags_level=2`: notice yes, info yes

Future:

- `--diags_level=3`: notice yes, info yes, debug yes

but as of today I think Flèche cannot put debug in diagnostics (they are tho shown for goals calls)