### PR TITLE
[code] Preserve original focus when refocusing the panel.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -140,11 +140,14 @@
    feature inspired from Isabelle IDE (@ejgallego, #717)
  - Have VSCode wait for full LSP client shutdown on server
    restart. This fixes some bugs on extension restart (finally!)
-   (@ejgallgo, #719)
+   (@ejgallego, #719)
  - Center the view if cursor goes out of scope in
    `sentenceNext/sentencePrevious` (@ejgallego, #718)
  - Switch Flèche range encoding to protocol native, this means UTF-16
    for now (Léo Stefanesco, @ejgallego, #624, fixes #620, #621)
+ - Give `Goals` panel focus back if it has lost it (in case of
+   multiple panels in the second viewColumn of Vscode) whenever
+   user navigates proofs (@Alidra @ejgallego, #722, #725)
 
 # coq-lsp 0.1.8.1: Spring fix
 -----------------------------

--- a/editor/code/CHANGELOG.md
+++ b/editor/code/CHANGELOG.md
@@ -1,9 +1,6 @@
 # coq-lsp 0.1.8: Trick-or-treat
 -------------------------------
 
- - Give `Goals` panel focus back if it has lost it (in case of
-   multiple panels in the second viewColumn of Vscode) whenever
-   user navigates proofs
  - Update VSCode client dependencies, should bring some performance
    improvements to goal pretty printing (@ejgallego, #530)
  - Update goal display colors for light mode so they are actually

--- a/editor/code/src/goals.ts
+++ b/editor/code/src/goals.ts
@@ -99,7 +99,7 @@ export class InfoPanel {
       this.panelFactory();
     } else {
       if (!this.panel.active) {
-        this.panel.reveal(2, false);
+        this.panel.reveal(2, true);
       }
     }
   }


### PR DESCRIPTION
This amends #722, as otherwise keyboard navigation becomes impossible.

We also amend the changelog entry (should be under main)