### PR TITLE
[lsp] Fix typo in response parsing.

### DIFF
--- a/lsp/base.ml
+++ b/lsp/base.ml
@@ -107,7 +107,7 @@ module Message = struct
       Response.Ok { id; result }
     | Some error ->
       let error = U.to_assoc error in
-      let code = int_field "message" error in
+      let code = int_field "code" error in
       let message = string_field "message" error in
       let data = None in
       Error { id; code; message; data }


### PR DESCRIPTION
We didn't catch this as the server doesn't yet implement any client request.