### PR TITLE
[deps] Bump upper bound on JS libs to 0.18

### DIFF
--- a/coq-lsp.opam
+++ b/coq-lsp.opam
@@ -47,10 +47,10 @@ depends: [
   "ppx_deriving"        { >= "4.2.1"    }
   "ppx_deriving_yojson" { >= "3.4"      }
   "ppx_import"          { >= "1.5-3"    }
-  "sexplib"             { >= "v0.13.0" & < "v0.17" }
-  "ppx_sexp_conv"       { >= "v0.13.0" & < "v0.17" }
-  "ppx_compare"         { >= "v0.13.0" & < "v0.17" }
-  "ppx_hash"            { >= "v0.13.0" & < "v0.17" }
+  "sexplib"             { >= "v0.13.0" & < "v0.18" }
+  "ppx_sexp_conv"       { >= "v0.13.0" & < "v0.18" }
+  "ppx_compare"         { >= "v0.13.0" & < "v0.18" }
+  "ppx_hash"            { >= "v0.13.0" & < "v0.18" }
 ]
 
 depopts: ["lwt" "logs"]


### PR DESCRIPTION
Things seem to work pretty well with 0.17.