### PR TITLE
[fleche] Caching / sharing of .vo contents

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@
    heuristic is enabled (@ejgallego, #748)
  - [memo] More precise hashing for Coq states, this improves cache
    performance quite a bit (@ejgallego, #751)
+ - [fleche] This achieves an almost 50% memory reduction for example
+   when opening all of HoTT .v files (@ejgallego, @SkySkimmer,
+   @bhaktishh, #744)
 
 # coq-lsp 0.1.10: Hasta el 40 de Mayo _en effect_...
 ----------------------------------------------------

--- a/controller/nt_cache_trim.ml
+++ b/controller/nt_cache_trim.ml
@@ -62,6 +62,7 @@ let build_message () =
     caches
 
 let cache_trim () =
+  let () = M.Intern.clear () in
   let () = M.Interp.clear () in
   let () = M.Admit.clear () in
   let () = M.Init.clear () in

--- a/coq/init.ml
+++ b/coq/init.ml
@@ -85,19 +85,19 @@ let coq_init opts =
 (**************************************************************************)
 
 (* Inits the context for a document *)
-let doc_init ~root_state ~workspace ~uri () =
+let doc_init ~intern ~root_state ~workspace ~uri () =
   (* Lsp.Io.log_error "init" "starting"; *)
   Vernacstate.unfreeze_full_state (State.to_coq root_state);
 
   (* Set load paths from workspace info. *Important*, this has to happen before
      we declare the library below as [Declaremods/Library] will infer the module
      name by looking at the load path! *)
-  Workspace.apply ~uri workspace;
+  Workspace.apply ~intern ~uri workspace;
 
   (* We return the state at this point! *)
   Vernacstate.freeze_full_state () |> State.of_coq
 
-let doc_init ~token:_ ~root_state ~workspace ~uri =
+let doc_init ~token:_ ~intern ~root_state ~workspace ~uri =
   (* Don't interrupt document creation. *)
   let token = Limits.create_atomic () in
-  Protect.eval ~token ~f:(doc_init ~root_state ~workspace ~uri) ()
+  Protect.eval ~token ~f:(doc_init ~intern ~root_state ~workspace ~uri) ()

--- a/coq/init.mli
+++ b/coq/init.mli
@@ -29,6 +29,7 @@ val coq_init : coq_opts -> State.t
 
 val doc_init :
      token:Limits.Token.t
+  -> intern:Library.Intern.t
   -> root_state:State.t
   -> workspace:Workspace.t
   -> uri:Lang.LUri.File.t

--- a/coq/interp.mli
+++ b/coq/interp.mli
@@ -19,7 +19,11 @@
     assumed not to interact with the file-system, etc... Note these commands
     will be memoized. *)
 val interp :
-  token:Limits.Token.t -> st:State.t -> Ast.t -> (State.t, Loc.t) Protect.E.t
+     token:Limits.Token.t
+  -> intern:Library.Intern.t
+  -> st:State.t
+  -> Ast.t
+  -> (State.t, Loc.t) Protect.E.t
 
 (** Interpretation of "require". We wrap this function for two reasons:
 
@@ -28,6 +32,7 @@ val interp :
 module Require : sig
   val interp :
        token:Limits.Token.t
+    -> intern:Library.Intern.t
     -> st:State.t
     -> Files.t
     -> Ast.Require.t

--- a/coq/workspace.ml
+++ b/coq/workspace.ml
@@ -262,11 +262,10 @@ let describe_guess = function
   | Error msg -> (msg, "")
 
 (* Require a set of libraries *)
-let load_objs libs =
+let load_objs ~intern libs =
   let rq_file { Require.library; from; flags } =
     let mp = Libnames.qualid_of_string library in
     let mfrom = Option.map Libnames.qualid_of_string from in
-    let intern = Vernacinterp.fs_intern in
     Flags_.silently
       (Vernacentries.vernac_require ~intern mfrom flags)
       [ (mp, Vernacexpr.ImportAll) ]
@@ -296,7 +295,7 @@ let dirpath_of_uri ~uri =
   ldir
 
 (* NOTE: Use exhaustive match below to avoid bugs by skipping fields *)
-let apply ~uri
+let apply ~intern ~uri
     { coqlib = _
     ; coqcorelib = _
     ; ocamlpath
@@ -315,7 +314,7 @@ let apply ~uri
   findlib_init ~ml_include_path ~ocamlpath;
   List.iter Loadpath.add_vo_path vo_load_path;
   Declaremods.start_library (dirpath_of_uri ~uri);
-  load_objs require_libs
+  load_objs ~intern require_libs
 
 (* This can raise, and will do in incorrect CoqProject files *)
 let dirpath_of_string_exn coq_path = Libnames.dirpath_of_string coq_path

--- a/coq/workspace.mli
+++ b/coq/workspace.mli
@@ -94,7 +94,7 @@ val guess :
 val default : debug:bool -> cmdline:CmdLine.t -> t
 
 (** [apply libname w] will prepare Coq for a new file [libname] on workspace [w] *)
-val apply : uri:Lang.LUri.File.t -> t -> unit
+val apply : intern:Library.Intern.t -> uri:Lang.LUri.File.t -> t -> unit
 
 (** *)
 val dirpath_of_uri : uri:Lang.LUri.File.t -> Names.DirPath.t

--- a/fleche/doc.ml
+++ b/fleche/doc.ml
@@ -630,7 +630,10 @@ end = struct
       ->
       Io.Log.trace "recovery" "bullet";
       Coq.State.admit_goal ~token ~st
-      |> Coq.Protect.E.bind ~f:(fun st -> Coq.Interp.interp ~token ~st v)
+      |> Coq.Protect.E.bind ~f:(fun st ->
+             (* We skip the cache here, but likely we don't want to do that. *)
+             let intern = Vernacinterp.fs_intern in
+             Coq.Interp.interp ~token ~intern ~st v)
     | _ ->
       (* Fallback to qed special lex case *)
       lex_recovery_heuristic ~token last_tok contents nodes st

--- a/fleche/memo.ml
+++ b/fleche/memo.ml
@@ -1,5 +1,7 @@
 module CS = Stats
 
+let intern = Vernacinterp.fs_intern
+
 module Stats = struct
   type t =
     { stats : Stats.t
@@ -287,7 +289,7 @@ module VernacEval = struct
 
   type output = Coq.State.t
 
-  let eval ~token (st, stm) = Coq.Interp.interp ~token ~st stm
+  let eval ~token (st, stm) = Coq.Interp.interp ~token ~intern ~st stm
 end
 
 module Interp = CEval (VernacEval)
@@ -316,7 +318,7 @@ module RequireEval = struct
   type output = Coq.State.t
 
   let eval ~token (st, files, stm) =
-    Coq.Interp.Require.interp ~token ~st files stm
+    Coq.Interp.Require.interp ~token ~intern ~st files stm
 end
 
 module Require = CEval (RequireEval)
@@ -347,7 +349,7 @@ module InitEval = struct
   type output = Coq.State.t
 
   let eval ~token (root_state, workspace, uri) =
-    Coq.Init.doc_init ~token ~root_state ~workspace ~uri
+    Coq.Init.doc_init ~token ~intern ~root_state ~workspace ~uri
 
   let input_info (st, ws, file) =
     Format.asprintf "st %d | ws %d | file %s" (Hashtbl.hash st)

--- a/fleche/memo.ml
+++ b/fleche/memo.ml
@@ -20,6 +20,8 @@ module Intern = struct
         let () = Hashtbl.add hc dp lib in
         lib
     else Vernacinterp.fs_intern dp
+
+  let clear () = Hashtbl.clear hc
 end
 
 let intern = Intern.intern

--- a/fleche/memo.mli
+++ b/fleche/memo.mli
@@ -9,6 +9,10 @@ module Stats : sig
   val zero : t
 end
 
+module Intern : sig
+  val clear : unit -> unit
+end
+
 (** Flèche memo / cache tables, with some advanced features *)
 module type S = sig
   type input


### PR DESCRIPTION
We add a basic .vo parsing cache; this often results in large memory savings when working simultaneously with several files.

Based on work from #641 and coq/coq#17393