### PR TITLE
[coq] [memo] Better parameters for polymorphic state hashing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
  - [fleche] Preserve view hint across document changes. With this
    change, we get local continuous checking mode when the view-port
    heuristic is enabled (@ejgallego, #748)
+ - [memo] More precise hashing for Coq states, this improves cache
+   performance quite a bit (@ejgallego, #751)
 
 # coq-lsp 0.1.10: Hasta el 40 de Mayo _en effect_...
 ----------------------------------------------------

--- a/coq/state.ml
+++ b/coq/state.ml
@@ -60,7 +60,12 @@ let compare (x : t) (y : t) =
   else 1
 
 let equal x y = compare x y = 0
-let hash x = Hashtbl.hash x
+
+let hash x =
+  (* OCaml's defaults are 10, 100, but not so good for us, much improved
+     settings are below (best try so far) *)
+  let meaningful, total = (64, 256) in
+  Hashtbl.hash_param meaningful total x
 
 let mode ~st =
   Option.map


### PR DESCRIPTION
Default parameters where creating lots of collisions, producing chains of hundredths of entries in the memo table.

The new settings seem optimal.