### PR TITLE
Fix help printing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@
    when opening all of HoTT .v files (@ejgallego, @SkySkimmer,
    @bhaktishh, #744)
  - [memo] Provide API to query Hashtbl stats (@ejgallego, #753)
+ - [nix] Add `pet-server` deps to flake.nix (Léo Stefanesco, #754)
+ - [coq-lsp] Fix crash on `--help` option (Léo Stefanesco, @ejgallego,
+   #754)
 
 # coq-lsp 0.1.10: Hasta el 40 de Mayo _en effect_...
 ----------------------------------------------------

--- a/coq/args.ml
+++ b/coq/args.ml
@@ -84,14 +84,20 @@ let ri_from : (string option * string) list Term.t =
         & info [ "rifrom"; "require-import-from" ] ~docv:"FROM,LIBRARY" ~doc))
 
 let int_backend =
+  let docv = "BACKEND" in
+  let backends = [ ("Coq", Limits.Coq); ("Mp", Limits.Mp) ] in
+  let backends_str =
+    "either 'Mp', for memprof-limits token-based interruption,\n\
+    \  or 'Coq', for Coq's polling mode (unreliable). The 'Mp' backend is only \
+     supported in OCaml 4.x series."
+  in
   let doc =
-    "Select Interruption Backend. 'Mp' = memprof-limits token-based \
-     interruption , 'Coq' = Coq's polling mode (unreliable). The 'Mp' backend \
-     is only supported in OCaml 4.x series."
+    Printf.sprintf
+      "Select Interruption Backend, if absent, the best available for your \
+       OCaml version will be selected. %s is %s"
+      docv backends_str
   in
   let absent = "'Mp' for OCaml 4.x, 'Coq' for OCaml 5.x" in
-  let backends = [ ("Coq", Limits.Coq); ("Mp", Limits.Mp) ] in
-  let docv = Cmdliner.Arg.doc_alts_enum ~quoted:true backends in
   Arg.(
     value
     & opt (some (enum backends)) None

--- a/coq/args.ml
+++ b/coq/args.ml
@@ -85,16 +85,17 @@ let ri_from : (string option * string) list Term.t =
 
 let int_backend =
   let doc =
-    "Select Interruption Backend, if absent, the best available for your OCaml \
-     version will be selected"
+    "Select Interruption Backend. 'Mp' = memprof-limits token-based \
+     interruption , 'Coq' = Coq's polling mode (unreliable). The 'Mp' backend \
+     is only supported in OCaml 4.x series."
   in
+  let absent = "'Mp' for OCaml 4.x, 'Coq' for OCaml 5.x" in
+  let backends = [ ("Coq", Limits.Coq); ("Mp", Limits.Mp) ] in
+  let docv = Cmdliner.Arg.doc_alts_enum ~quoted:true backends in
   Arg.(
     value
-    & opt
-        (enum
-           [ ("Coq", Some Limits.Coq); ("Mp", Some Limits.Mp); ("auto", None) ])
-        None
-    & info [ "int_backend" ] ~docv:"INT_BACKEND" ~doc)
+    & opt (some (enum backends)) None
+    & info [ "int_backend" ] ~docv ~doc ~absent)
 
 let roots : string list Term.t =
   let doc = "Workspace(s) root(s)" in
@@ -102,7 +103,7 @@ let roots : string list Term.t =
 
 let coq_diags_level : int Term.t =
   let doc =
-    "Controsl whether Coq Info and Notice message appear in diagnostics.\n\
+    "Controls whether Coq Info and Notice message appear in diagnostics.\n\
     \ 0 = None; 1 = Notices, 2 = Notices and Info"
   in
   Arg.(value & opt int 0 & info [ "diags_level" ] ~docv:"DIAGS_LEVEL" ~doc)

--- a/coq/args.ml
+++ b/coq/args.ml
@@ -90,7 +90,10 @@ let int_backend =
   in
   Arg.(
     value
-    & opt (enum [ ("Coq", Some Limits.Coq); ("Mp", Some Limits.Mp) ]) None
+    & opt
+        (enum
+           [ ("Coq", Some Limits.Coq); ("Mp", Some Limits.Mp); ("auto", None) ])
+        None
     & info [ "int_backend" ] ~docv:"INT_BACKEND" ~doc)
 
 let roots : string list Term.t =

--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,8 @@
               uri
               dune-build-info
               ppx_inline_test
+              logs
+              lwt
               ;
           };
         };


### PR DESCRIPTION
Currently, `coq-lsp --help` crashed because `Cmdliner` cannot print the default option for `--int-backend`

It would be nicer to have `help` print the possible values of the enum, but I couldn't figure out how.