### PR TITLE
[petanque] Allow `init` to be called multiple times

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,8 @@
  - [code] Don't start server on extension activation, unless an editor
    we own is active. We also auto-start the server if a document that
    we own is opened later (@ejgallego, #758, fixes #750)
+ - [petanque] Allow `init` to be called multiple times (@ejgallego,
+   @gbdrt, #766)
 
 # coq-lsp 0.1.10: Hasta el 40 de Mayo _en effect_...
 ----------------------------------------------------

--- a/petanque/test/basic_api.ml
+++ b/petanque/test/basic_api.ml
@@ -23,6 +23,8 @@ let start ~token =
   (* Will this work on Windows? *)
   let open Coq.Compat.Result.O in
   let root, uri = prepare_paths () in
+  (* Twice to test for #766 *)
+  let* _env = Agent.init ~token ~debug ~root in
   let* env = Agent.init ~token ~debug ~root in
   Agent.start ~token ~env ~uri ~thm:"rev_snoc_cons"
 


### PR DESCRIPTION
We need to rework the protocol as to better reflect the Coq/Flèche workspace mode, but this hotfix will work meanwhile.