### PR TITLE
[petanque] Use lighter goal query on run_tac

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,8 @@
    we own is opened later (@ejgallego, #758, fixes #750)
  - [petanque] Allow `init` to be called multiple times (@ejgallego,
    @gbdrt, #766)
+ - [petanque] Faster query for goals status after `run_tac`
+   (@ejgallego, #768)
 
 # coq-lsp 0.1.10: Hasta el 40 de Mayo _en effect_...
 ----------------------------------------------------

--- a/fleche/info.ml
+++ b/fleche/info.ml
@@ -149,6 +149,14 @@ module O = Make (Offset)
 
 (* Related to goal request *)
 module Goals = struct
+  let get_goals_unit ~st =
+    let ppx _env _sigma _x = () in
+    Coq.State.lemmas ~st |> Option.map (Coq.Goals.reify ~ppx)
+
+  let get_goals ~st =
+    let ppx env sigma x = (env, sigma, x) in
+    Coq.State.lemmas ~st |> Option.map (Coq.Goals.reify ~ppx)
+
   let pr_goal ~token st =
     let ppx env sigma x =
       let { Coq.Protect.E.r; feedback } =

--- a/fleche/info.mli
+++ b/fleche/info.mli
@@ -52,6 +52,16 @@ module O : S with module P := Offset
 
 (** We move towards a more modular design here, for preprocessing *)
 module Goals : sig
+  val get_goals_unit :
+    st:Coq.State.t -> (unit Coq.Goals.reified_goal, Pp.t) Coq.Goals.goals option
+
+  val get_goals :
+       st:Coq.State.t
+    -> ( (Environ.env * Evd.evar_map * EConstr.t) Coq.Goals.reified_goal
+       , Pp.t )
+       Coq.Goals.goals
+       option
+
   val goals :
        token:Coq.Limits.Token.t
     -> st:Coq.State.t

--- a/petanque/agent.ml
+++ b/petanque/agent.ml
@@ -167,8 +167,8 @@ let parse_and_execute_in ~token ~loc tac st =
   match ast with
   | Some ast -> (
     let open Coq.Protect.E.O in
-    let* st = Fleche.Memo.Interp.eval ~token (st, ast) in
-    let+ goals = Fleche.Info.Goals.goals ~token ~st in
+    let+ st = Fleche.Memo.Interp.eval ~token (st, ast) in
+    let goals = Fleche.Info.Goals.get_goals_unit ~st in
     match goals with
     | None -> Run_result.Proof_finished st
     | Some goals when proof_finished goals -> Run_result.Proof_finished st


### PR DESCRIPTION
This avoids printing and unfreezing, which is no question a performance gain.