### PR TITLE
[petanque] Allow to instrument with extra commands before proof start

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,9 @@
    @gbdrt, #766)
  - [petanque] Faster query for goals status after `run_tac`
    (@ejgallego, #768)
+ - [petanque] New parameter `pre_commands` to `start` which allows
+   instrumenting the goal before starting the proof (@ejgallego, Alex
+   Sanchez-Stern #769)
 
 # coq-lsp 0.1.10: Hasta el 40 de Mayo _en effect_...
 ----------------------------------------------------

--- a/petanque/agent.mli
+++ b/petanque/agent.mli
@@ -57,12 +57,18 @@ val message_ref : (lvl:Fleche.Io.Level.t -> message:string -> unit) ref
 val init :
   token:Coq.Limits.Token.t -> debug:bool -> root:Lang.LUri.File.t -> Env.t R.t
 
-(** [start uri thm] start a new proof for theorem [thm] in file [uri]. *)
+(** [start ~token ~env ~uri ~pre_commands ~thm] start a new proof for theorem
+    [thm] in file [uri] under [env]. [token] can be used to interrupt the
+    computation. Returns the proof state or error otherwise. [pre_commands] is a
+    string of dot-separated Coq commands that will be executed before the proof
+    starts. *)
 val start :
      token:Coq.Limits.Token.t
   -> env:Env.t
   -> uri:Lang.LUri.File.t
+  -> ?pre_commands:string
   -> thm:string
+  -> unit
   -> State.t R.t
 
 (** [run_tac ~token ~st ~tac] tries to run [tac] over state [st] *)

--- a/petanque/json_shell/protocol.ml
+++ b/petanque/json_shell/protocol.ml
@@ -73,6 +73,7 @@ module Start = struct
     type t =
       { env : int
       ; uri : Lsp.JLang.LUri.File.t
+      ; pre_commands : string option [@default None]
       ; thm : string
       }
     [@@deriving yojson]
@@ -87,6 +88,7 @@ module Start = struct
       type t =
         { env : Env.t
         ; uri : Lsp.JLang.LUri.File.t
+        ; pre_commands : string option [@default None]
         ; thm : string
         }
       [@@deriving yojson]
@@ -96,8 +98,8 @@ module Start = struct
       type t = State.t [@@deriving yojson]
     end
 
-    let handler ~token { Params.env; uri; thm } =
-      Agent.start ~token ~env ~uri ~thm
+    let handler ~token { Params.env; uri; pre_commands; thm } =
+      Agent.start ~token ~env ~uri ?pre_commands ~thm ()
   end
 end
 

--- a/petanque/test/basic_api.ml
+++ b/petanque/test/basic_api.ml
@@ -26,7 +26,7 @@ let start ~token =
   (* Twice to test for #766 *)
   let* _env = Agent.init ~token ~debug ~root in
   let* env = Agent.init ~token ~debug ~root in
-  Agent.start ~token ~env ~uri ~thm:"rev_snoc_cons"
+  Agent.start ~token ~env ~uri ~thm:"rev_snoc_cons" ()
 
 let extract_st (st : _ Agent.Run_result.t) =
   match st with

--- a/petanque/test/json_api.ml
+++ b/petanque/test/json_api.ml
@@ -55,7 +55,7 @@ let run (ic, oc) =
   (* Will this work on Windows? *)
   let root, uri = prepare_paths () in
   let* env = S.init { debug; root } in
-  let* st = S.start { env; uri; thm = "rev_snoc_cons" } in
+  let* st = S.start { env; uri; pre_commands = None; thm = "rev_snoc_cons" } in
   let* premises = S.premises { st } in
   (if print_premises then
      Format.(eprintf "@[%a@]@\n%!" (pp_print_list pp_premise) premises));

--- a/petanque/test/json_api_failure.ml
+++ b/petanque/test/json_api_failure.ml
@@ -33,7 +33,7 @@ let run (ic, oc) =
   (* Will this work on Windows? *)
   let root, uri = prepare_paths () in
   let* env = S.init { debug; root } in
-  let* st = S.start { env; uri; thm = "rev_snoc_cons" } in
+  let* st = S.start { env; uri; pre_commands = None; thm = "rev_snoc_cons" } in
   let* _premises = S.premises { st } in
   let* st = S.run_tac { st; tac = "induction l." } in
   let* st = r ~st ~tac:"-" in


### PR DESCRIPTION
We add a new parameter `pre_commands` to `start`, which will be
executed before starting the proof.

