### PR TITLE
[petanque] Improvements on protocol handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,9 @@
  - [petanque] New parameter `pre_commands` to `start` which allows
    instrumenting the goal before starting the proof (@ejgallego, Alex
    Sanchez-Stern #769)
+ - [petanque] New `http_headers={yes,no}` parameter for `pet` json
+   shell, plus some improvements on protocol handling (@ejgallego,
+   #770)
 
 # coq-lsp 0.1.10: Hasta el 40 de Mayo _en effect_...
 ----------------------------------------------------

--- a/petanque/agent.ml
+++ b/petanque/agent.ml
@@ -12,10 +12,13 @@ module State = struct
 
   let hash = Coq.State.hash
   let equal = Coq.State.equal
+  let name = "state"
 end
 
 module Env = struct
   type t = Fleche.Doc.Env.t
+
+  let name = "env"
 end
 
 (** Petanque errors *)

--- a/petanque/agent.mli
+++ b/petanque/agent.mli
@@ -10,6 +10,7 @@
 module State : sig
   type t
 
+  val name : string
   val hash : t -> int
   val equal : t -> t -> bool
 end
@@ -17,6 +18,8 @@ end
 module Env : sig
   (** Coq Workspaces / project enviroments *)
   type t
+
+  val name : string
 end
 
 (** Petanque errors *)

--- a/petanque/json_shell/pet.ml
+++ b/petanque/json_shell/pet.ml
@@ -1,16 +1,40 @@
 (* json rpc server *)
 open Petanque_json
 
+let use_http_headers = ref true
+
+let read_json inc =
+  match Yojson.Safe.from_channel inc with
+  | json -> Ok json
+  | exception Yojson.Json_error err -> Error err
+
+let read_message inc =
+  if !use_http_headers then Lsp.Io.read_message inc
+  else
+    try
+      match read_json inc with
+      | Error err -> Some (Error err)
+      | Ok json -> Some (Lsp.Base.Message.of_yojson json)
+    with End_of_file -> None
+
+let send_message msg =
+  if !use_http_headers then (
+    Lsp.Io.send_message Format.std_formatter msg;
+    Format.pp_print_flush Format.std_formatter ())
+  else
+    let msg = Lsp.Base.Message.to_yojson msg in
+    Format.fprintf Format.std_formatter "@[%s@]@\n%!"
+      (Yojson.Safe.to_string ?std:None msg)
+(* Format.fprintf Format.std_formatter "@[%a@]@\n%!" Yojson.Safe.pretty_print
+   msg *)
+
 let interp ~token request =
   match Interp.interp ~token request with
   | None -> ()
-  | Some response ->
-    let message = Lsp.Base.Message.response response in
-    Lsp.Io.send_message Format.std_formatter message;
-    Format.pp_print_flush Format.std_formatter ()
+  | Some response -> Lsp.Base.Message.response response |> send_message
 
 let rec loop ~token : unit =
-  match Lsp.Io.read_message stdin with
+  match read_message stdin with
   | None -> () (* EOF *)
   | Some (Ok request) ->
     interp ~token request;
@@ -28,7 +52,7 @@ let trace_notification hdr ?extra msg =
   let notification =
     Lsp.Base.(Notification.(make ~method_ ~params () |> Message.notification))
   in
-  Lsp.Io.send_message Format.std_formatter notification
+  send_message notification
 
 let message_notification ~lvl ~message =
   let module M = Protocol.Message in
@@ -39,11 +63,11 @@ let message_notification ~lvl ~message =
   let notification =
     Lsp.Base.(Notification.(make ~method_ ~params () |> Message.notification))
   in
-  Lsp.Io.send_message Format.std_formatter notification
+  send_message notification
 
 let trace_enabled = true
 
-let pet_main debug roots =
+let pet_main debug roots http_headers =
   Coq.Limits.start ();
   (* Don't trace for now *)
   if trace_enabled then (
@@ -51,9 +75,20 @@ let pet_main debug roots =
     Petanque.Agent.message_ref := message_notification);
   let token = Coq.Limits.Token.create () in
   let () = Utils.set_roots ~token ~debug ~roots in
+  use_http_headers := http_headers;
   loop ~token
 
 open Cmdliner
+
+let http_headers : bool Term.t =
+  let docv = "{yes|no}" in
+  let opts = [ ("yes", true); ("no", false) ] in
+  let absent = "yes" in
+  let doc =
+    "whether http-headers CONTENT-LENGHT are used in the JSON-RPC encoding"
+  in
+  Arg.(
+    value & opt (enum opts) true & info [ "http_headers" ] ~docv ~doc ~absent)
 
 let pet_cmd : unit Cmd.t =
   let doc = "Petanque Coq Environment" in
@@ -66,7 +101,7 @@ let pet_cmd : unit Cmd.t =
   in
   let version = Fleche.Version.server in
   let pet_term =
-    Term.(const pet_main $ Coq.Args.debug $ Coq.Args.roots)
+    Term.(const pet_main $ Coq.Args.debug $ Coq.Args.roots $ http_headers)
     (* const pet_main $ roots $ display $ debug $ plugins $ file $ coqlib *)
     (* $ coqcorelib $ ocamlpath $ rload_path $ load_path $ rifrom) *)
   in

--- a/petanque/json_shell/protocol.ml
+++ b/petanque/json_shell/protocol.ml
@@ -206,6 +206,10 @@ module Trace = struct
       }
     [@@deriving yojson]
   end
+
+  let make params =
+    let params = Params.to_yojson params |> Yojson.Safe.Util.to_assoc in
+    Lsp.Base.Message.Notification { method_; params }
 end
 
 (* Message notification *)
@@ -219,4 +223,8 @@ module Message = struct
       }
     [@@deriving yojson]
   end
+
+  let make params =
+    let params = Params.to_yojson params |> Yojson.Safe.Util.to_assoc in
+    Lsp.Base.Message.Notification { method_; params }
 end

--- a/petanque/json_shell/server.ml
+++ b/petanque/json_shell/server.ml
@@ -29,7 +29,7 @@ let rec handle_connection ~token ic oc () =
         let* () = Logs_lwt.info (fun m -> m "Sent reply") in
         let* () =
           Lwt_io.fprintl oc
-            (Yojson.Safe.to_string (Lsp.Base.Response.to_yojson reply))
+            (Yojson.Safe.to_string (Lsp.Base.Message.to_yojson reply))
         in
         handle_connection ~token ic oc ())
   with End_of_file -> return ()


### PR DESCRIPTION
We add a few improvements to the protocol handlers which make the experience of using `pet` from the command line easier:
- http headers can now be disabled by a parameter
- choice of printer for output
- obj_map will handle missing objects id properly
- incoming messages that are not handled are now logged