### PR TITLE
[refactor] Consolidation of auxiliary functions.

### DIFF
--- a/compiler/compile.ml
+++ b/compiler/compile.ml
@@ -6,12 +6,12 @@ let workspace_of_uri ~io ~uri ~workspaces ~default =
   let file = Lang.LUri.File.to_string_file uri in
   match List.find_opt (fun (dir, _) -> is_in_dir ~dir ~file) workspaces with
   | None ->
-    let lvl = Io.Level.error in
+    let lvl = Io.Level.Error in
     let message = "file not in workspace: " ^ file in
     Io.Report.message ~io ~lvl ~message;
     default
   | Some (_, Error err) ->
-    let lvl = Io.Level.error in
+    let lvl = Io.Level.Error in
     let message = "invalid workspace for: " ^ file ^ " " ^ err in
     Io.Report.message ~io ~lvl ~message;
     default
@@ -38,7 +38,7 @@ let status_of_doc (doc : Doc.t) =
 
 let compile_file ~cc file : int =
   let { Cc.io; root_state; workspaces; default; token } = cc in
-  let lvl = Io.Level.info in
+  let lvl = Io.Level.Info in
   let message = Format.asprintf "compiling file %s" file in
   Io.Report.message ~io ~lvl ~message;
   match Lang.LUri.(File.of_uri (of_string file)) with

--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -22,8 +22,8 @@ let sanitize_paths message =
 
 let log_workspace ~io (dir, w) =
   let message, extra = Coq.Workspace.describe_guess w in
-  Fleche.Io.Log.trace "workspace" ("initialized " ^ dir) ~extra;
-  let lvl = Fleche.Io.Level.info in
+  Fleche.Io.Log.trace "workspace" ~extra "initialized %s" dir;
+  let lvl = Fleche.Io.Level.Info in
   let message = sanitize_paths message in
   Fleche.Io.Report.message ~io ~lvl ~message
 

--- a/controller/cache.ml
+++ b/controller/cache.ml
@@ -15,7 +15,7 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-module LIO = Lsp.Io
+module L = Fleche.Io.Log
 
 (* Cache stuff *)
 let memo_cache_file = ".coq-lsp.cache"
@@ -23,9 +23,9 @@ let memo_cache_file = ".coq-lsp.cache"
 let memo_save_to_disk () =
   try
     (* Fleche.Memo.save_to_disk ~file:memo_cache_file; *)
-    LIO.trace "memo" "cache saved to disk"
+    L.trace "memo" "cache saved to disk"
   with exn ->
-    LIO.trace "memo" (Printexc.to_string exn);
+    L.trace "memo" "%s" (Printexc.to_string exn);
     Sys.remove memo_cache_file;
     ()
 
@@ -35,12 +35,12 @@ let save_to_disk () = if false then memo_save_to_disk ()
 let memo_read_from_disk () =
   try
     if Sys.file_exists memo_cache_file then (
-      LIO.trace "memo" "trying to load cache file";
+      L.trace "memo" "trying to load cache file";
       (* Fleche.Memo.load_from_disk ~file:memo_cache_file; *)
-      LIO.trace "memo" "cache file loaded")
-    else LIO.trace "memo" "cache file not present"
+      L.trace "memo" "cache file loaded")
+    else L.trace "memo" "cache file not present"
   with exn ->
-    LIO.trace "memo" ("loading cache failed: " ^ Printexc.to_string exn);
+    L.trace "memo" "loading cache failed: %s" (Printexc.to_string exn);
     Sys.remove memo_cache_file;
     ()
 

--- a/controller/lsp_core.mli
+++ b/controller/lsp_core.mli
@@ -42,6 +42,7 @@ end
 
 val lsp_init_process :
      ofn:(Lsp.Base.Message.t -> unit)
+  -> io:Fleche.Io.CallBack.t
   -> cmdline:Coq.Workspace.CmdLine.t
   -> debug:bool
   -> Lsp.Base.Message.t

--- a/controller/nt_cache_trim.mli
+++ b/controller/nt_cache_trim.mli
@@ -1,1 +1,1 @@
-val notification : unit -> unit
+val notification : io:Fleche.Io.CallBack.t -> unit

--- a/controller/rq_common.ml
+++ b/controller/rq_common.ml
@@ -28,19 +28,18 @@ let id_from_start s start =
   let end_ = if end_ > 1 && s.[end_ - 1] = '.' then end_ - 1 else end_ in
   if start < end_ then (
     let id = String.sub s start (end_ - start) in
-    Lsp.Io.trace "find_id" ("found: " ^ id);
+    Fleche.Io.Log.trace "find_id" "found: %s" id;
     Some id)
   else None
 
 let find_id s c =
   let start = find_start s c in
-  Lsp.Io.trace "find_id" ("start: " ^ string_of_int start);
+  Fleche.Io.Log.trace "find_id" "start: %d" start;
   id_from_start s start
 
 let get_id_at_point ~contents ~point =
   let line, character = point in
-  Lsp.Io.trace "get_id_at_point"
-    ("l: " ^ string_of_int line ^ " c: " ^ string_of_int character);
+  Fleche.Io.Log.trace "get_id_at_point" "l: %d c: %d)" line character;
   let { Fleche.Contents.lines; _ } = contents in
   if line <= Array.length lines then
     let line = Array.get lines line in
@@ -144,7 +143,7 @@ module CoqModule = struct
     let glob = Filename.remove_extension vo ^ ".glob" in
     match Coq.Glob.open_file glob with
     | Error err ->
-      Fleche.Io.Log.trace "rq_definition:open_file" ("Error: " ^ err);
+      Fleche.Io.Log.trace "rq_definition:open_file" "Error: %s" err;
       Error err
     | Ok g -> (
       match Coq.Glob.get_info g name with

--- a/controller/rq_init.mli
+++ b/controller/rq_init.mli
@@ -10,4 +10,6 @@ val do_settings : (string * Yojson.Safe.t) list -> unit
 
 (** Returns answer request + workspace root directory *)
 val do_initialize :
-  params:(string * Yojson.Safe.t) list -> Yojson.Safe.t * string list
+     io:Fleche.Io.CallBack.t
+  -> params:(string * Yojson.Safe.t) list
+  -> Yojson.Safe.t * string list

--- a/coq/compat.ml
+++ b/coq/compat.ml
@@ -1,5 +1,21 @@
 (* Compatibility file *)
 
+module Ocaml_413 = struct
+  module String = struct
+    open String
+
+    let starts_with ~prefix s =
+      let len_s = length s
+      and len_pre = length prefix in
+      let rec aux i =
+        if i = len_pre then true
+        else if unsafe_get s i <> unsafe_get prefix i then false
+        else aux (i + 1)
+      in
+      len_s >= len_pre && aux 0
+  end
+end
+
 module Ocaml_414 = struct
   module In_channel = struct
     (* 4.14 can do this: In_channel.with_open_bin file In_channel.input_all, so

--- a/coq/compat.mli
+++ b/coq/compat.mli
@@ -1,5 +1,11 @@
 (* Compatiblity and general utils *)
 
+module Ocaml_413 : sig
+  module String : sig
+    val starts_with : prefix:string -> string -> bool
+  end
+end
+
 (* We should at some point remove all of this file in favor of a standard
    library that suits our needs *)
 module Ocaml_414 : sig

--- a/fleche/contents.ml
+++ b/fleche/contents.ml
@@ -113,10 +113,8 @@ module WaterProof = struct
       List.fold_left coq_block_to_span ("", start_point) code_blocks
     in
     (if waterproof_debug then
-       let msg =
-         "pos:\n" ^ String.concat "\n" code_pos ^ "\nContents:\n" ^ contents
-       in
-       Io.Log.trace "waterproof" msg);
+       let code_pos = String.concat "\n" code_pos in
+       Io.Log.trace "waterproof" "pos:\n%s\nContents:\n%s" code_pos contents);
     R.Ok contents
 
   let from_json json =

--- a/fleche/info.ml
+++ b/fleche/info.ml
@@ -37,8 +37,7 @@ module LineCol : Point with type t = int * int = struct
     | None -> String.length text - offset
 
   let rec to_offset cur lc (l, c) text =
-    Io.Log.trace "to_offset"
-      (Format.asprintf "cur: %d | lc: %d | l: %d c: %d" cur lc l c);
+    Io.Log.trace "to_offset" "cur: %d | lc: %d | l: %d c: %d" cur lc l c;
     if lc = l then cur + c
     else
       let ll = line_length cur text + 1 in
@@ -50,9 +49,8 @@ module LineCol : Point with type t = int * int = struct
 
   let debug_in_range hdr line col line1 col1 line2 col2 =
     if debug_in_range then
-      Io.Log.trace hdr
-        (Format.asprintf "(%d, %d) in (%d,%d)-(%d,%d)" line col line1 col1 line2
-           col2)
+      Io.Log.trace hdr "(%d, %d) in (%d,%d)-(%d,%d)" line col line1 col1 line2
+        col2
 
   let in_range ?range (line, col) =
     (* Coq starts at 1, lsp at 0 *)

--- a/fleche/io.ml
+++ b/fleche/io.ml
@@ -1,13 +1,10 @@
 module Level = struct
-  type t = int
-
-  (* We follow LSP spec *)
-  let error = 1
-  let warning = 2
-  let info = 3
-  let log = 4
-  let debug = 5
-  let to_int x = x
+  type t =
+    | Error
+    | Warning
+    | Info
+    | Log
+    | Debug
 end
 
 module CallBack = struct
@@ -38,7 +35,12 @@ module CallBack = struct
 end
 
 module Log = struct
-  let trace d ?extra m = !CallBack.cb.trace d ?extra m
+  let trace_ d ?extra m = !CallBack.cb.trace d ?extra m
+  let trace d ?extra = Format.kasprintf (fun m -> trace_ d ?extra m)
+
+  let trace_object hdr obj =
+    (* Fixme, use the extra parameter *)
+    trace hdr "[%s]: @[%a@]" hdr Yojson.Safe.(pretty_print ~std:false) obj
 
   let feedback feedback =
     if not (CList.is_empty feedback) then
@@ -50,6 +52,7 @@ end
 
 module Report = struct
   let message ~io ~lvl ~message = io.CallBack.message ~lvl ~message
+  let msg ~io ~lvl = Format.kasprintf (fun m -> message ~io ~lvl ~message:m)
   let diagnostics ~io ~uri ~version d = io.CallBack.diagnostics ~uri ~version d
 
   let fileProgress ~io ~uri ~version d =

--- a/fleche/io.mli
+++ b/fleche/io.mli
@@ -1,14 +1,10 @@
 module Level : sig
-  type t
-
-  val error : t
-  val warning : t
-  val info : t
-  val log : t
-  val debug : t
-
-  (** Convert to LSP numeric code *)
-  val to_int : t -> int
+  type t =
+    | Error
+    | Warning
+    | Info
+    | Log
+    | Debug
 end
 
 module CallBack : sig
@@ -32,7 +28,14 @@ end
 
 module Log : sig
   (** Debug trace *)
-  val trace : string -> ?extra:string -> string -> unit
+  val trace :
+    string -> ?extra:string -> ('a, Format.formatter, unit) format -> 'a
+
+  (** Raw LSP method *)
+  val trace_ : string -> ?extra:string -> string -> unit
+
+  (** Log JSON object to server info log *)
+  val trace_object : string -> Yojson.Safe.t -> unit
 
   (** For unexpected feedback, remove eventually or just assert false? *)
   val feedback : Loc.t Coq.Message.t list -> unit
@@ -40,6 +43,10 @@ end
 
 module Report : sig
   (** User-visible message *)
+  val msg :
+    io:CallBack.t -> lvl:Level.t -> ('a, Format.formatter, unit) format -> 'a
+
+  (** Raw LSP method *)
   val message : io:CallBack.t -> lvl:Level.t -> message:string -> unit
 
   val diagnostics :

--- a/lang/lUri.ml
+++ b/lang/lUri.ml
@@ -24,4 +24,5 @@ module File = struct
   let hash = Hashtbl.hash
   let compare = Stdlib.compare
   let equal = Stdlib.( = )
+  let pp fmt uri = Format.fprintf fmt "%a" Uri.pp uri.uri
 end

--- a/lang/lUri.mli
+++ b/lang/lUri.mli
@@ -36,4 +36,7 @@ module File : sig
 
   (** hash *)
   val hash : t -> int
+
+  (** print *)
+  val pp : Format.formatter -> t -> unit
 end

--- a/lsp/io.ml
+++ b/lsp/io.ml
@@ -54,6 +54,8 @@ let read_raw_message ic =
   | Invalid_argument msg -> Some (Error msg)
 
 let mut = Mutex.create ()
+
+(* This needs a fix as to log protocol stuff not using the protocol *)
 let log = ref (fun _ _ -> ())
 
 let send_json fmt obj =
@@ -95,7 +97,7 @@ let set_trace_value value = trace_value := value
 
 module Lvl = struct
   (* 1-5 *)
-  type t =
+  type t = Fleche.Io.Level.t =
     | Error
     | Warning
     | Info
@@ -159,24 +161,14 @@ let mk_logTrace ~message ~extra =
 
 let logTrace ~message ~extra = mk_logTrace ~message ~extra |> !fn
 
-let trace hdr ?extra msg =
-  let message = Format.asprintf "[%s]: @[%s@]" hdr msg in
-  logTrace ~message ~extra
-
-let trace_object hdr obj =
-  let message =
-    Format.asprintf "[%s]: @[%a@]" hdr Yojson.Safe.(pretty_print ~std:false) obj
-  in
-  (* Fixme, use the extra parameter *)
-  trace hdr message
-
-let () = log := trace_object
+(* Disabled for now, see comment above *)
+(* let () = log := trace_object *)
 
 (** Misc helpers *)
 let read_message ic =
   match read_raw_message ic with
   | None -> None (* EOF *)
   | Some (Ok com) ->
-    if Fleche.Debug.read then trace_object "read" com;
+    if Fleche.Debug.read then !log "read" com;
     Some (Base.Message.of_yojson com)
   | Some (Error err) -> Some (Error err)

--- a/lsp/io.mli
+++ b/lsp/io.mli
@@ -17,7 +17,7 @@
 
 (** JSON-RPC input/output *)
 
-(** Set the log function *)
+(** Set the log output function *)
 val set_log_fn : (Base.Notification.t -> unit) -> unit
 
 (** Read a JSON-RPC message from channel; [None] signals [EOF] *)
@@ -44,12 +44,14 @@ val set_trace_value : TraceValue.t -> unit
 
 module Lvl : sig
   (* 1-5 *)
-  type t =
+  type t = Fleche.Io.Level.t =
     | Error
     | Warning
     | Info
     | Log
     | Debug
+
+  val to_int : t -> int
 end
 
 module MessageParams : sig
@@ -86,10 +88,3 @@ val mk_logTrace : message:string -> extra:string option -> Base.Notification.t
 
 (** Send a [$/logTrace] notification to the client *)
 val logTrace : message:string -> extra:string option -> unit
-
-(** [log hdr ?extra message] Log [message] to server info log with header [hdr].
-    [extra] will be used when [trace_value] is set to [Verbose] *)
-val trace : string -> ?extra:string -> string -> unit
-
-(** Log JSON object to server info log *)
-val trace_object : string -> Yojson.Safe.t -> unit

--- a/petanque/json_shell/pet.ml
+++ b/petanque/json_shell/pet.ml
@@ -49,7 +49,7 @@ let trace_notification hdr ?extra msg =
   send_message (Lsp.Base.Message.Notification notification)
 
 let message_notification ~lvl ~message =
-  let type_ = Fleche.Io.Level.to_int lvl in
+  let type_ = Lsp.Io.Lvl.to_int lvl in
   let notification = Lsp.Io.mk_logMessage ~type_ ~message in
   send_message (Lsp.Base.Message.Notification notification)
 
@@ -57,7 +57,7 @@ let trace_enabled = true
 
 let log_error err =
   let message = Petanque.Agent.Error.to_string err in
-  message_notification ~lvl:Fleche.Io.Level.error ~message
+  message_notification ~lvl:Lsp.Io.Lvl.Error ~message
 
 let pet_main debug roots http_headers =
   Coq.Limits.start ();

--- a/plugins/astdump/main.ml
+++ b/plugins/astdump/main.ml
@@ -1,39 +1,32 @@
 open Fleche
 
 let pp_json fmt (ast : Doc.Node.Ast.t) =
-  let jast = Lsp.JCoq.Ast.to_yojson ast.v in
-  Yojson.Safe.pretty_print fmt jast
+  Lsp.JCoq.Ast.to_yojson ast.v |> Yojson.Safe.pretty_print fmt
 
 let pp_sexp fmt (ast : Doc.Node.Ast.t) =
-  let sast =
-    Serlib.Ser_vernacexpr.sexp_of_vernac_control (Coq.Ast.to_coq ast.v)
-  in
-  Sexplib.Sexp.pp_hum fmt sast
+  Serlib.Ser_vernacexpr.sexp_of_vernac_control (Coq.Ast.to_coq ast.v)
+  |> Sexplib.Sexp.pp_hum fmt
 
 let pw pp fmt ast = Format.fprintf fmt "@[%a@]" pp ast
 
 let dump_asts ~out_file pp asts =
-  let out = Stdlib.open_out out_file in
-  let fmt = Format.formatter_of_out_channel out in
-  List.iter (pw pp fmt) asts;
-  Format.pp_print_flush fmt ();
-  Stdlib.close_out out
+  let f fmt asts = List.iter (pw pp fmt) asts in
+  Coq.Compat.format_to_file ~file:out_file ~f asts
 
 let dump_ast ~io ~token:_ ~(doc : Doc.t) =
   let uri = doc.uri in
   let uri_str = Lang.LUri.File.to_string_uri uri in
-  let out_file_j = Lang.LUri.File.to_string_file uri ^ ".json.astdump" in
-  let out_file_s = Lang.LUri.File.to_string_file uri ^ ".sexp.astdump" in
-  let lvl = Io.Level.info in
-  let message = Format.asprintf "[ast plugin] dumping ast for %s ..." uri_str in
-  Io.Report.message ~io ~lvl ~message;
+  let lvl = Io.Level.Info in
+  Io.Report.msg ~io ~lvl "[ast plugin] dumping ast for %s ..." uri_str;
   let asts = Doc.asts doc in
+  (* Output json *)
+  let out_file_j = Lang.LUri.File.to_string_file uri ^ ".json.astdump" in
   let () = dump_asts ~out_file:out_file_j pp_json asts in
+  (* Output sexp *)
+  let out_file_s = Lang.LUri.File.to_string_file uri ^ ".sexp.astdump" in
   let () = dump_asts ~out_file:out_file_s pp_sexp asts in
-  let message =
-    Format.asprintf "[ast plugin] dumping ast for %s was completed!" uri_str
-  in
-  Io.Report.message ~io ~lvl ~message;
+  Io.Report.msg ~io ~lvl "[ast plugin] dumping ast for %s was completed!"
+    uri_str;
   ()
 
 let main () = Theory.Register.Completed.add dump_ast

--- a/plugins/simple/main.ml
+++ b/plugins/simple/main.ml
@@ -1,12 +1,10 @@
 open Fleche
 
-let simple_action ~io ~token:_ ~doc =
-  let uri = Lang.LUri.File.to_string_uri doc.Doc.uri in
-  let lvl = Io.Level.info in
-  let message =
-    Format.asprintf "[example plugin] file checking for %s was completed" uri
-  in
-  Io.Report.message ~io ~lvl ~message
+let msg_info ~io = Io.(Report.msg ~io ~lvl:Info)
+
+let simple_action ~io ~token:_ ~(doc : Doc.t) =
+  msg_info ~io "[example plugin] file checking for %a was completed"
+    Lang.LUri.File.pp doc.uri
 
 let main () = Theory.Register.Completed.add simple_action
 let () = main ()

--- a/test/compiler/basic/run.t
+++ b/test/compiler/basic/run.t
@@ -242,6 +242,6 @@ We do the same for the goaldump plugin:
      + findlib default location: [TEST_PATH]
   [message] compiling file proj1/a.v
   [message] [goaldump plugin] dumping goals for proj1/a.v ...
-  [message] [ast plugin] dumping ast for proj1/a.v was completed!
+  [message] [goaldump plugin] dumping ast for proj1/a.v was completed!
   $ ls proj1/a.v.json.goaldump
   proj1/a.v.json.goaldump


### PR DESCRIPTION
We do some cleanup on auxiliary and infra functions:

- use filename output functions from common libs
- add `Format` based logging functions
- remove `Lsp.Io` use to trace, use Fleche Callbacks instead