### PR TITLE
[lsp] [petanque] Allow access to `petanque` protocol from the lsp server

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,6 +56,8 @@
    #550)
  - [petanque] Allow memoization control on `petanque/run` via a new
    parameter `memo` (@ejgallego, #780)
+ - [lsp] [petanque] Allow acces to `petanque` protocol from the lsp
+   server (@ejgallego, #778)
 
 # coq-lsp 0.1.10: Hasta el 40 de Mayo _en effect_...
 ----------------------------------------------------

--- a/controller/dune
+++ b/controller/dune
@@ -1,7 +1,7 @@
 (library
  (name controller)
  (modules :standard \ coq_lsp)
- (libraries coq fleche lsp dune-build-info))
+ (libraries coq fleche petanque petanque_json lsp dune-build-info))
 
 (executable
  (name coq_lsp)

--- a/editor/code/lib/types.ts
+++ b/editor/code/lib/types.ts
@@ -208,3 +208,15 @@ export interface CoqStoppedStatus {
 }
 
 export type CoqServerStatus = CoqBusyStatus | CoqIdleStatus | CoqStoppedStatus;
+
+// Petanque types, canonical source agent.mli
+export interface PetStartParams {
+  uri: string;
+  pre_commands: string | null;
+  thm: string;
+}
+
+export interface PetRunParams {
+  st: number;
+  tac: string;
+}

--- a/editor/code/package.json
+++ b/editor/code/package.json
@@ -132,6 +132,14 @@
       {
         "command": "coq-lsp.heatmap.toggle",
         "title": "Coq LSP: Toggle heatmap"
+      },
+      {
+        "command": "coq-lsp.petanque.start",
+        "title": "Coq LSP: Start a petanque session for theorem (Coq developer-only command)"
+      },
+      {
+        "command": "coq-lsp.petanque.run",
+        "title": "Coq LSP: Run a tactic over a petanque session (Coq developer-only command)"
       }
     ],
     "keybindings": [

--- a/editor/code/src/client.ts
+++ b/editor/code/src/client.ts
@@ -15,6 +15,7 @@ import {
   languages,
   Uri,
   TextEditorVisibleRangesChangeEvent,
+  InputBoxOptions,
 } from "vscode";
 
 import * as vscode from "vscode";
@@ -54,6 +55,7 @@ import { FileProgressManager } from "./progress";
 import { coqPerfData, PerfDataView } from "./perf";
 import { sentenceNext, sentencePrevious } from "./edit";
 import { HeatMap, HeatMapConfig } from "./heatmap";
+import { petanqueStart, petanqueRun, petSetClient } from "./petanque";
 import { debounce, throttle } from "throttle-debounce";
 
 // Convert perf data to VSCode format
@@ -154,6 +156,7 @@ export function activateCoqLSP(
     );
     context.subscriptions.push(disposable);
   }
+
   function checkForVSCoq() {
     let vscoq =
       extensions.getExtension("maximedenes.vscoq") ||
@@ -216,6 +219,7 @@ export function activateCoqLSP(
 
     let cP = new Promise<BaseLanguageClient>((resolve) => {
       client = clientFactory(context, clientOptions, wsConfig);
+      petSetClient(client);
       fileProgress = new FileProgressManager(client);
       perfDataHook = client.onNotification(coqPerfData, (data) => {
         perfDataView.update(data);
@@ -518,6 +522,9 @@ export function activateCoqLSP(
   coqEditorCommand("sentencePrevious", sentencePrevious);
 
   coqEditorCommand("heatmap.toggle", heatMapToggle);
+
+  coqEditorCommand("petanque.start", petanqueStart);
+  coqEditorCommand("petanque.run", petanqueRun);
 
   createEnableButton();
 

--- a/editor/code/src/petanque.ts
+++ b/editor/code/src/petanque.ts
@@ -1,0 +1,60 @@
+import { window, InputBoxOptions, TextEditor } from "vscode";
+import { BaseLanguageClient, RequestType } from "vscode-languageclient";
+import { PetRunParams, PetStartParams } from "../lib/types";
+
+const petStartReq = new RequestType<PetStartParams, number, void>(
+  "petanque/start"
+);
+let client: BaseLanguageClient;
+
+export function petSetClient(newClient: BaseLanguageClient) {
+  client = newClient;
+}
+
+export const petanqueStart = (editor: TextEditor) => {
+  let uri = editor.document.uri.toString();
+  let pre_commands = null;
+
+  // Imput theorem name
+  let inputOptions: InputBoxOptions = {
+    title: "Petanque Start",
+    prompt: "Name of the theorem to start a session ",
+  };
+  window
+    .showInputBox(inputOptions)
+    .then<PetStartParams>((thm_user) => {
+      let thm = thm_user ?? "petanque_debug";
+      let params: PetStartParams = { uri, pre_commands, thm };
+      return Promise.resolve<PetStartParams>(params);
+    })
+    .then((params: PetStartParams) => {
+      client
+        .sendRequest(petStartReq, params)
+        .then((id) =>
+          window.setStatusBarMessage(`petanque/start succeed ${id}`, 5000)
+        )
+        .catch((error) => {
+          let err_message = error.toString();
+          console.log(`error in save: ${err_message}`);
+          window.showErrorMessage(err_message);
+        });
+    });
+};
+
+const petRunReq = new RequestType<PetRunParams, any, void>("petanque/run");
+
+export const petanqueRun = (editor: TextEditor) => {
+  // XXX Read from user
+  let params: PetRunParams = { st: 1, tac: "idtac." };
+  client
+    .sendRequest(petRunReq, params)
+    .then((answer: any) => {
+      let res = JSON.stringify(answer);
+      window.setStatusBarMessage(`petanque/run succeed ${res}`, 5000);
+    })
+    .catch((error) => {
+      let err_message = error.toString();
+      console.log(`error in save: ${err_message}`);
+      window.showErrorMessage(err_message);
+    });
+};

--- a/examples/petanque.v
+++ b/examples/petanque.v
@@ -1,0 +1,2 @@
+Theorem petanque_debug : True.
+Proof. now auto. Qed.

--- a/fleche/theory.ml
+++ b/fleche/theory.ml
@@ -405,3 +405,7 @@ module Request = struct
     | FullDoc -> Handle.remove_cp_request ~uri ~id
     | PosInDoc { point; _ } -> Handle.remove_pt_request ~uri ~id ~point
 end
+
+(* xxx to remove *)
+let find_doc ~uri =
+  Handle._find_opt ~uri |> Option.map (fun { Handle.doc; _ } -> doc)

--- a/fleche/theory.mli
+++ b/fleche/theory.mli
@@ -93,3 +93,6 @@ module Register : sig
     val add : t -> unit
   end
 end
+
+(* XXX this is temporal for petanque, will fix before merge *)
+val find_doc : uri:Lang.LUri.File.t -> Doc.t option

--- a/petanque/README.md
+++ b/petanque/README.md
@@ -50,11 +50,18 @@ See the contributing guide for instructions on how to do the last.
 
 ## Running `petanque` JSON shell
 
-You can use `petanque` in 2 different ways:
+You can use `petanque` in 3 different ways:
 
-- call the API directly from your OCaml program
+- call the API using JSON-RPC directly in `coq-lsp`, over the LSP
+  protocol
 - use the provided `pet` and `pet-server` JSON-RPC shells, usually
-  with a library such as Pytanque.
+  with a library such as Pytanque
+- call the API directly from your OCaml program
+
+See `agent.mli` for an overview of the API. The
+`petanque/setWorkspace` method is only available in the `pet` and
+`pet-server` shells; when `petanque` is used from LSP, the workspace
+needs to be set using LSP in the usual way.
 
 To execute the `pet` JSON-RPC shell do:
 ```

--- a/petanque/agent.ml
+++ b/petanque/agent.ml
@@ -101,17 +101,12 @@ let protect_to_result (r : _ Coq.Protect.E.t) : (_, _) Result.t =
     Error (Error.Anomaly (Pp.string_of_ppcmds msg))
   | { r = Completed (Ok r); feedback = _ } -> Ok r
 
-let fn = ref (fun ~token:_ _uri -> Error (Error.System "No handler for fn"))
-
-let start ~token ~uri ?pre_commands ~thm () =
-  match !fn ~token uri with
-  | Ok doc ->
-    let open Coq.Compat.Result.O in
-    let* node = find_thm ~doc ~thm in
-    (* Usually single shot, so we don't memoize *)
-    let memo = false in
-    execute_precommands ~token ~memo ~pre_commands ~node |> protect_to_result
-  | Error err -> Error err
+let start ~token ~doc ?pre_commands ~thm () =
+  let open Coq.Compat.Result.O in
+  let* node = find_thm ~doc ~thm in
+  (* Usually single shot, so we don't memoize *)
+  let memo = false in
+  execute_precommands ~token ~memo ~pre_commands ~node |> protect_to_result
 
 let proof_finished { Coq.Goals.goals; stack; shelf; given_up; _ } =
   List.for_all CList.is_empty [ goals; shelf; given_up ] && CList.is_empty stack

--- a/petanque/agent.mli
+++ b/petanque/agent.mli
@@ -40,16 +40,34 @@ module Run_result : sig
     | Current_state of 'a
 end
 
-val fn : (token:Coq.Limits.Token.t -> Lang.LUri.File.t -> Fleche.Doc.t R.t) ref
+(** Protocol notes:
 
-(** [start ~token ~fn ~uri ~pre_commands ~thm] start a new proof for theorem
-    [thm] in file [uri] under [fn]. [token] can be used to interrupt the
-    computation. Returns the proof state or error otherwise. [pre_commands] is a
-    string of dot-separated Coq commands that will be executed before the proof
-    starts. *)
+    The idea is that the types of the functions here have a direct translation
+    to the JSON-RPC (or any other) protocol.
+
+    Thus, types here correspond to types in the wire, except for cases where the
+    protocol layer performs an implicit mapping on types.
+
+    So far, the mappings are:
+
+    - [uri] <-> [Doc.t]
+    - [int] <-> [State.t]
+
+    The [State.t] mapping is easy to do at the protocol level with a simple
+    mapping, however [uri -> Doc.t] may need to yield to the document manager to
+    build the corresponding [doc]. This is very convenient for users, but
+    introduces a little bit more machinery.
+
+    We could imagine a future where [State.t] need to be managed asynchronously,
+    then the same approach that we use for [Doc.t] could happen. *)
+
+(** [start ~token ~doc ~pre_commands ~thm] start a new proof for theorem [thm]
+    in file [uri] under [fn]. [token] can be used to interrupt the computation.
+    Returns the proof state or error otherwise. [pre_commands] is a string of
+    dot-separated Coq commands that will be executed before the proof starts. *)
 val start :
      token:Coq.Limits.Token.t
-  -> uri:Lang.LUri.File.t
+  -> doc:Fleche.Doc.t
   -> ?pre_commands:string
   -> thm:string
   -> unit

--- a/petanque/json_shell/interp.ml
+++ b/petanque/json_shell/interp.ml
@@ -2,47 +2,83 @@ open Protocol
 open Protocol_shell
 module A = Petanque.Agent
 
-let do_request ~token (module R : Protocol.Request.S) ~params =
-  match R.Handler.Params.of_yojson (`Assoc params) with
-  | Ok params -> (
-    match R.Handler.handler ~token params with
-    | Ok result -> Ok (R.Handler.Response.to_yojson result)
-    | Error err ->
+(* These types ares basically duplicated with controller/request.ml; move to a
+   common lib (lsp?) *)
+type r = (Yojson.Safe.t, int * string) Result.t
+
+module Action = struct
+  type 'a t =
+    | Now of (token:Coq.Limits.Token.t -> r)
+    | Doc of
+        { uri : Lang.LUri.File.t
+        ; handler : token:Coq.Limits.Token.t -> doc:Fleche.Doc.t -> r
+        }
+end
+(* End of controller/request.ml *)
+
+let of_pet_err res =
+  Result.map_error
+    (fun err ->
       let message = Petanque.Agent.Error.to_string err in
       let code = Petanque.Agent.Error.to_code err in
-      Error (code, message))
+      (code, message))
+    res
+
+(* Basically a functor from R.Handler.t to Action.t, but closing over params *)
+let do_request (module R : Protocol.Request.S) ~params =
+  let of_pet res = Result.map R.Handler.Response.to_yojson res |> of_pet_err in
+  let handler params =
+    match R.Handler.handler with
+    | Immediate handler ->
+      Action.Now (fun ~token -> handler ~token params |> of_pet)
+    | FullDoc { uri_fn; handler } ->
+      let uri = uri_fn params in
+      let handler ~token ~doc = handler ~token ~doc params |> of_pet in
+      Action.Doc { uri; handler }
+  in
+  match R.Handler.Params.of_yojson (`Assoc params) with
+  | Ok params -> handler params
   | Error message ->
     (* JSON-RPC Parse error *)
     let code = -32700 in
-    Error (code, message)
+    Action.Now (fun ~token:_ -> Error (code, message))
+
+let do_handle ~fn ~token (module R : Protocol.Request.S) ~params =
+  match do_request (module R) ~params with
+  | Action.Now handler -> handler ~token
+  | Action.Doc { uri; handler } ->
+    let open Coq.Compat.Result.O in
+    let* doc = fn ~token ~uri |> of_pet_err in
+    handler ~token ~doc
 
 let handle_request ~token ~method_ ~params =
   match method_ with
   | s when String.equal SetWorkspace.method_ s ->
-    do_request ~token (module SetWorkspace) ~params
+    do_handle ~token (module SetWorkspace) ~params
   | s when String.equal Start.method_ s ->
-    do_request ~token (module Start) ~params
+    do_handle ~token (module Start) ~params
   | s when String.equal RunTac.method_ s ->
-    do_request ~token (module RunTac) ~params
+    do_handle ~token (module RunTac) ~params
   | s when String.equal Goals.method_ s ->
-    do_request ~token (module Goals) ~params
+    do_handle ~token (module Goals) ~params
   | s when String.equal Premises.method_ s ->
-    do_request ~token (module Premises) ~params
+    do_handle ~token (module Premises) ~params
   | _ ->
-    (* JSON-RPC method not found *)
-    let code = -32601 in
-    let message = "method not found" in
-    Error (code, message)
+    fun ~fn:_ ->
+      (* JSON-RPC method not found *)
+      let code = -32601 in
+      let message = "method not found" in
+      Error (code, message)
 
-let request ~token ~id ~method_ ~params =
-  match handle_request ~token ~method_ ~params with
+let request ~fn ~token ~id ~method_ ~params =
+  match handle_request ~fn ~token ~method_ ~params with
   | Ok result -> Lsp.Base.Response.mk_ok ~id ~result
   | Error (code, message) -> Lsp.Base.Response.mk_error ~id ~code ~message
 
-let interp ~token (r : Lsp.Base.Message.t) : Lsp.Base.Message.t option =
+let interp ~fn ~token (r : Lsp.Base.Message.t) : Lsp.Base.Message.t option =
   match r with
   | Request { id; method_; params } ->
-    let response = request ~token ~id ~method_ ~params in
+    let response = request ~fn ~token ~id ~method_ ~params in
     Some (Lsp.Base.Message.response response)
   | Notification { method_; params = _ } ->
     let message = "unhandled notification: " ^ method_ in

--- a/petanque/json_shell/interp.ml
+++ b/petanque/json_shell/interp.ml
@@ -2,44 +2,47 @@ open Protocol
 open Protocol_shell
 module A = Petanque.Agent
 
-let do_request ~token (module R : Request.S) ~id ~params =
+let do_request ~token (module R : Protocol.Request.S) ~params =
   match R.Handler.Params.of_yojson (`Assoc params) with
   | Ok params -> (
     match R.Handler.handler ~token params with
-    | Ok result ->
-      let result = R.Handler.Response.to_yojson result in
-      Lsp.Base.Response.mk_ok ~id ~result
+    | Ok result -> Ok (R.Handler.Response.to_yojson result)
     | Error err ->
-      let message = A.Error.to_string err in
-      let code = A.Error.to_code err in
-      Lsp.Base.Response.mk_error ~id ~code ~message)
+      let message = Petanque.Agent.Error.to_string err in
+      let code = Petanque.Agent.Error.to_code err in
+      Error (code, message))
   | Error message ->
     (* JSON-RPC Parse error *)
     let code = -32700 in
-    Lsp.Base.Response.mk_error ~id ~code ~message
+    Error (code, message)
 
-let handle_request ~token ~id ~method_ ~params =
+let handle_request ~token ~method_ ~params =
   match method_ with
   | s when String.equal SetWorkspace.method_ s ->
-    do_request ~token (module SetWorkspace) ~id ~params
+    do_request ~token (module SetWorkspace) ~params
   | s when String.equal Start.method_ s ->
-    do_request ~token (module Start) ~id ~params
+    do_request ~token (module Start) ~params
   | s when String.equal RunTac.method_ s ->
-    do_request ~token (module RunTac) ~id ~params
+    do_request ~token (module RunTac) ~params
   | s when String.equal Goals.method_ s ->
-    do_request ~token (module Goals) ~id ~params
+    do_request ~token (module Goals) ~params
   | s when String.equal Premises.method_ s ->
-    do_request ~token (module Premises) ~id ~params
+    do_request ~token (module Premises) ~params
   | _ ->
     (* JSON-RPC method not found *)
     let code = -32601 in
     let message = "method not found" in
-    Lsp.Base.Response.mk_error ~id ~code ~message
+    Error (code, message)
+
+let request ~token ~id ~method_ ~params =
+  match handle_request ~token ~method_ ~params with
+  | Ok result -> Lsp.Base.Response.mk_ok ~id ~result
+  | Error (code, message) -> Lsp.Base.Response.mk_error ~id ~code ~message
 
 let interp ~token (r : Lsp.Base.Message.t) : Lsp.Base.Message.t option =
   match r with
   | Request { id; method_; params } ->
-    let response = handle_request ~token ~id ~method_ ~params in
+    let response = request ~token ~id ~method_ ~params in
     Some (Lsp.Base.Message.response response)
   | Notification { method_; params = _ } ->
     let message = "unhandled notification: " ^ method_ in

--- a/petanque/json_shell/pet.ml
+++ b/petanque/json_shell/pet.ml
@@ -28,8 +28,10 @@ let send_message msg =
 (* Format.fprintf Format.std_formatter "@[%a@]@\n%!" Yojson.Safe.pretty_print
    msg *)
 
+let fn = Petanque.Shell.build_doc
+
 let interp ~token request =
-  match Interp.interp ~token request with
+  match Interp.interp ~fn ~token request with
   | None -> ()
   | Some message -> send_message message
 

--- a/petanque/json_shell/protocol_shell.ml
+++ b/petanque/json_shell/protocol_shell.ml
@@ -21,7 +21,9 @@ module SetWorkspace = struct
       type t = unit [@@deriving yojson]
     end
 
-    let handler ~token { Params.debug; root } =
-      Petanque.Shell.set_workspace ~token ~debug ~root
+    let handler =
+      Protocol.HType.Immediate
+        (fun ~token { Params.debug; root } ->
+          Petanque.Shell.set_workspace ~token ~debug ~root)
   end
 end

--- a/petanque/json_shell/server.ml
+++ b/petanque/json_shell/server.ml
@@ -9,6 +9,8 @@ let rq_info (r : Lsp.Base.Message.t) =
   | Response (Ok { id; _ } | Error { id; _ }) ->
     Format.asprintf "response for: %d" id
 
+let fn = Petanque.Shell.build_doc
+
 let rec handle_connection ~token ic oc () =
   try
     let* request = Lwt_io.read_line ic in
@@ -23,7 +25,7 @@ let rec handle_connection ~token ic oc () =
       let* () = Logs_lwt.info (fun m -> m "Received: %s" (rq_info request)) in
       (* request could be a notification, so maybe we don't have to do a
          reply! *)
-      match Interp.interp ~token request with
+      match Interp.interp ~fn ~token request with
       | None -> handle_connection ~token ic oc ()
       | Some reply ->
         let* () = Logs_lwt.info (fun m -> m "Sent reply") in

--- a/petanque/shell.ml
+++ b/petanque/shell.ml
@@ -79,9 +79,7 @@ let setup_doc ~token env uri =
     Ok (Fleche.Doc.check ~io ~token ~target ~doc ())
   | Error err -> Error err
 
-let fn ~token uri =
-  let env = Option.get !env in
-  setup_doc ~token env uri
+let build_doc ~token ~uri = setup_doc ~token (Option.get !env) uri
 
 (* Flèche LSP backend handles the conversion at the protocol level *)
 let to_uri uri = Lang.LUri.of_string uri |> Lang.LUri.File.of_uri
@@ -97,5 +95,4 @@ let set_roots ~token ~debug ~roots =
 let init_agent ~token ~debug ~roots =
   init_st := Some (init_coq ~debug);
   Fleche.Io.CallBack.set io;
-  Agent.fn := fn;
   set_roots ~token ~debug ~roots

--- a/petanque/shell.mli
+++ b/petanque/shell.mli
@@ -18,3 +18,8 @@ val set_workspace :
   -> debug:bool
   -> root:Lang.LUri.File.t
   -> unit Agent.R.t
+
+val build_doc :
+     token:Coq.Limits.Token.t
+  -> uri:Lang.LUri.File.t
+  -> (Fleche.Doc.t, Agent.Error.t) Result.t

--- a/petanque/test/basic_api.ml
+++ b/petanque/test/basic_api.ml
@@ -27,7 +27,10 @@ let start ~token =
   let root, uri = prepare_paths () in
   let* () = Petanque.Shell.set_workspace ~token ~debug ~root in
   let* () = Petanque.Shell.set_workspace ~token ~debug ~root in
-  Agent.start ~token ~uri ~thm:"rev_snoc_cons" ()
+  (* Careful to call [build_doc] before we have set an environment! [pet] and
+     [pet-server] are careful to always set a default one *)
+  let* doc = Petanque.Shell.build_doc ~token ~uri in
+  Agent.start ~token ~doc ~thm:"rev_snoc_cons" ()
 
 let extract_st (st : _ Agent.Run_result.t) =
   match st with


### PR DESCRIPTION
This will be very useful for quite a few users, in particular those
willing to interact with Coq from an editor context.

Things integrate pretty well, and `petanque` can demand `Flèche` to
build documents, etc...

Note that we can still improve the codebase a bit, in particular:

- we should share the generic handling code between `controller` and
  `petanque`.

- note also the lack of uniformity w.r.t. the cancellation token and
  Rq.serve, in particular `Rq.Immediate` and `Rq.query` with result
  `Now` should do the same.
