### PR TITLE
[petanque] Allow memoization control on `petanque/run`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,8 @@
    `Qed` time (@ejgallego, #773)
  - [fleche] Support meta-command `Abort All` (@ejgallego, #774, fixes
    #550)
+ - [petanque] Allow memoization control on `petanque/run` via a new
+   parameter `memo` (@ejgallego, #780)
 
 # coq-lsp 0.1.10: Hasta el 40 de Mayo _en effect_...
 ----------------------------------------------------

--- a/petanque/agent.mli
+++ b/petanque/agent.mli
@@ -55,11 +55,15 @@ val start :
   -> unit
   -> State.t R.t
 
-(** [run_tac ~token ~st ~tac] tries to run [tac] over state [st] *)
-val run_tac :
+(** [run ~token ?memo ~st ~tac] tries to run [tac] over state [st]. [memo] (by
+    default true) controls whether the command execution will be memoized in
+    Flèche incremental engine. *)
+val run :
      token:Coq.Limits.Token.t
+  -> ?memo:bool
   -> st:State.t
   -> tac:string
+  -> unit
   -> State.t Run_result.t R.t
 
 (** [goals ~token ~st] return the list of goals for a given [st] *)

--- a/petanque/json_shell/protocol.ml
+++ b/petanque/json_shell/protocol.ml
@@ -80,7 +80,9 @@ module RunTac = struct
 
   module Params = struct
     type t =
-      { st : int
+      { memo : bool option
+            [@default None] (* Whether to memoize the execution, server-side *)
+      ; st : int
       ; tac : string
       }
     [@@deriving yojson]
@@ -93,7 +95,9 @@ module RunTac = struct
   module Handler = struct
     module Params = struct
       type t =
-        { st : State.t
+        { memo : bool option
+              [@default None] (* Whether to memoize the execution *)
+        ; st : State.t
         ; tac : string
         }
       [@@deriving yojson]
@@ -103,7 +107,8 @@ module RunTac = struct
       type t = State.t Run_result.t [@@deriving yojson]
     end
 
-    let handler ~token { Params.st; tac } = Agent.run_tac ~token ~st ~tac
+    let handler ~token { Params.memo; st; tac } =
+      Agent.run ~token ?memo ~st ~tac ()
   end
 end
 

--- a/petanque/test/basic_api.ml
+++ b/petanque/test/basic_api.ml
@@ -38,11 +38,11 @@ let main () =
   let token = Coq.Limits.create_atomic () in
   let r ~st ~tac =
     let st = extract_st st in
-    Agent.run_tac ~token ~st ~tac
+    Agent.run ~token ~st ~tac ()
   in
   let* st = start ~token in
   let* _premises = Agent.premises ~token ~st in
-  let* st = Agent.run_tac ~token ~st ~tac:"induction l." in
+  let* st = Agent.run ~token ~st ~tac:"induction l." () in
   let* st = r ~st ~tac:"-" in
   let* st = r ~st ~tac:"reflexivity." in
   let* st = r ~st ~tac:"-" in

--- a/petanque/test/json_api.ml
+++ b/petanque/test/json_api.ml
@@ -47,8 +47,9 @@ let run (ic, oc) =
     let message = message
   end) in
   let r ~st ~tac =
+    let memo = None in
     let st = extract_st st in
-    S.run_tac { st; tac }
+    S.run_tac { memo; st; tac }
   in
   (* Will this work on Windows? *)
   let root, uri = prepare_paths () in
@@ -57,7 +58,7 @@ let run (ic, oc) =
   let* premises = S.premises { st } in
   (if print_premises then
      Format.(eprintf "@[%a@]@\n%!" (pp_print_list pp_premise) premises));
-  let* st = S.run_tac { st; tac = "induction l." } in
+  let* st = S.run_tac { memo = None; st; tac = "induction l." } in
   let* st = r ~st ~tac:"-" in
   let* st = r ~st ~tac:"reflexivity." in
   let* st = r ~st ~tac:"-" in

--- a/petanque/test/json_api_failure.ml
+++ b/petanque/test/json_api_failure.ml
@@ -27,15 +27,16 @@ let run (ic, oc) =
     let message = message
   end) in
   let r ~st ~tac =
+    let memo = None in
     let st = extract_st st in
-    S.run_tac { st; tac }
+    S.run_tac { memo; st; tac }
   in
   (* Will this work on Windows? *)
   let root, uri = prepare_paths () in
   let* _env = S.set_workspace { debug; root } in
   let* st = S.start { uri; pre_commands = None; thm = "rev_snoc_cons" } in
   let* _premises = S.premises { st } in
-  let* st = S.run_tac { st; tac = "induction l." } in
+  let* st = S.run_tac { memo = None; st; tac = "induction l." } in
   let* st = r ~st ~tac:"-" in
   (* Introduce an error *)
   (* let* st = r ~st ~tac:"reflexivity." in *)


### PR DESCRIPTION
A new parameter `memo` to `petanque/run` controls whether the execution is memoized server-side.

`true` by default.

We also rename `run_tac` -> `run` as to be more consistent.