### PR TITLE
[petanque] Always initialize default workspace.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,6 +58,9 @@
    parameter `memo` (@ejgallego, #780)
  - [lsp] [petanque] Allow acces to `petanque` protocol from the lsp
    server (@ejgallego, #778)
+ - [petanque] Always initialize a workspace. This made `pet` crash if
+   `--root` was not used and client didn't issue the optimal
+   `setWorkspace` call (#782, @ejgallego, @gbdrt)
 
 # coq-lsp 0.1.10: Hasta el 40 de Mayo _en effect_...
 ----------------------------------------------------

--- a/petanque/agent.ml
+++ b/petanque/agent.ml
@@ -41,6 +41,9 @@ module Error = struct
     | Anomaly _ -> -32004
     | System _ -> -32005
     | Theorem_not_found _ -> -32006
+
+  let coq e = Coq e
+  let system e = System e
 end
 
 module R = struct

--- a/petanque/agent.mli
+++ b/petanque/agent.mli
@@ -27,6 +27,8 @@ module Error : sig
 
   val to_string : t -> string
   val to_code : t -> int
+  val coq : string -> t
+  val system : string -> t
 end
 
 (** Petanque results *)


### PR DESCRIPTION
This fixes a bug if `pet-server` was initialized without `--root`