### PR TITLE
[petanque] New methods `state/eq` and `state/hash`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,8 +62,10 @@
    `--root` was not used and client didn't issue the optimal
    `setWorkspace` call (#782, @ejgallego, @gbdrt)
  - [lsp] [petanque] New methods `state/eq` and `state/hash`; this
-   allows clients to implement a client-side hash (@ejgallego @gbdrt,
-   #779)
+   allows clients to implement a client-side hash; equality is
+   configurable with different methods; moreover, `petanque/run` can
+   compute some extra data like state hashing without a round-trip
+   (@ejgallego @gbdrt, #779)
 
 # coq-lsp 0.1.10: Hasta el 40 de Mayo _en effect_...
 ----------------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,6 +61,9 @@
  - [petanque] Always initialize a workspace. This made `pet` crash if
    `--root` was not used and client didn't issue the optimal
    `setWorkspace` call (#782, @ejgallego, @gbdrt)
+ - [lsp] [petanque] New methods `state/eq` and `state/hash`; this
+   allows clients to implement a client-side hash (@ejgallego @gbdrt,
+   #779)
 
 # coq-lsp 0.1.10: Hasta el 40 de Mayo _en effect_...
 ----------------------------------------------------

--- a/coq/goals.mli
+++ b/coq/goals.mli
@@ -34,6 +34,10 @@ type 'a reified_goal =
 
 val map_reified_goal : f:('a -> 'b) -> 'a reified_goal -> 'b reified_goal
 
+val equal_reified_goal :
+  ('a -> 'a -> bool) -> 'a reified_goal -> 'a reified_goal -> bool
+
+(* XXX: Put into a module *)
 type ('a, 'pp) goals =
   { goals : 'a list
   ; stack : ('a list * 'a list) list
@@ -41,6 +45,13 @@ type ('a, 'pp) goals =
   ; shelf : 'a list
   ; given_up : 'a list
   }
+
+val equal_goals :
+     ('a -> 'a -> bool)
+  -> ('pp -> 'pp -> bool)
+  -> ('a, 'pp) goals
+  -> ('a, 'pp) goals
+  -> bool
 
 val map_goals :
   f:('a -> 'b) -> g:('pp -> 'pp') -> ('a, 'pp) goals -> ('b, 'pp') goals
@@ -52,3 +63,10 @@ val reify :
      ppx:(Environ.env -> Evd.evar_map -> EConstr.t -> 'pp)
   -> State.Proof.t
   -> ('pp reified_goal, Pp.t) goals
+
+(* equality functions with heuristics *)
+module Equality : sig
+  (** Goal-based eq heuristic, will return [true] when goals are "equal", in a
+      proof search sense *)
+  val equal_goals : State.Proof.t -> State.Proof.t -> bool
+end

--- a/petanque/agent.ml
+++ b/petanque/agent.ml
@@ -11,8 +11,17 @@ module State = struct
   type t = Coq.State.t
 
   let hash = Coq.State.hash
-  let equal = Coq.State.equal
   let name = "state"
+
+  module Inspect = struct
+    type t = Physical  (** Flèche-based "almost physical" state eq *)
+    (* | Goals *)
+    (* For Next PR*)
+  end
+
+  let equal ?(kind = Inspect.Physical) =
+    match kind with
+    | Physical -> Coq.State.equal
 end
 
 (** Petanque errors *)

--- a/petanque/agent.ml
+++ b/petanque/agent.ml
@@ -14,14 +14,22 @@ module State = struct
   let name = "state"
 
   module Inspect = struct
-    type t = Physical  (** Flèche-based "almost physical" state eq *)
-    (* | Goals *)
-    (* For Next PR*)
+    type t =
+      | Physical  (** Flèche-based "almost physical" state eq *)
+      | Goals
+          (** Full goal equality; must faster than calling goals as it won't
+              unelaborate them. Note that this may not fully capture proof state
+              equality (it is possible to have similar goals but different
+              evar_maps, but should be enough for all practical users. *)
   end
 
   let equal ?(kind = Inspect.Physical) =
     match kind with
     | Physical -> Coq.State.equal
+    | Goals ->
+      fun st1 st2 ->
+        let st1, st2 = (Coq.State.lemmas ~st:st1, Coq.State.lemmas ~st:st2) in
+        Option.equal Coq.Goals.Equality.equal_goals st1 st2
 end
 
 (** Petanque errors *)

--- a/petanque/agent.mli
+++ b/petanque/agent.mli
@@ -11,8 +11,19 @@ module State : sig
   type t
 
   val name : string
+
+  (** Fleche-based Coq state hash; it has been designed for interactive use, so
+      please report back *)
   val hash : t -> int
-  val equal : t -> t -> bool
+
+  module Inspect : sig
+    type t = Physical  (** Flèche-based "almost physical" state eq *)
+    (* | Goals *)
+    (* For Next PR*)
+  end
+
+  (** [equal ?kind st1 st2] [kind] defaults to [Inspect.Physical] *)
+  val equal : ?kind:Inspect.t -> t -> t -> bool
 end
 
 (** Petanque errors *)

--- a/petanque/agent.mli
+++ b/petanque/agent.mli
@@ -17,9 +17,13 @@ module State : sig
   val hash : t -> int
 
   module Inspect : sig
-    type t = Physical  (** Flèche-based "almost physical" state eq *)
-    (* | Goals *)
-    (* For Next PR*)
+    type t =
+      | Physical  (** Flèche-based "almost physical" state eq *)
+      | Goals
+          (** Full goal equality; must faster than calling goals as it won't
+              unelaborate them. Note that this may not fully capture proof state
+              equality (it is possible to have similar goals but different
+              evar_maps, but should be enough for all practical users. *)
   end
 
   (** [equal ?kind st1 st2] [kind] defaults to [Inspect.Physical] *)

--- a/petanque/agent.mli
+++ b/petanque/agent.mli
@@ -47,10 +47,19 @@ module R : sig
   type 'a t = ('a, Error.t) Result.t
 end
 
+module Run_opts : sig
+  type t =
+    { memo : bool [@default true]
+    ; hash : bool [@default true]
+    }
+end
+
 module Run_result : sig
   type 'a t =
-    | Proof_finished of 'a
-    | Current_state of 'a
+    { st : 'a
+    ; hash : int option [@default None]
+    ; proof_finished : bool
+    }
 end
 
 (** Protocol notes:
@@ -91,7 +100,7 @@ val start :
     Flèche incremental engine. *)
 val run :
      token:Coq.Limits.Token.t
-  -> ?memo:bool
+  -> ?opts:Run_opts.t
   -> st:State.t
   -> tac:string
   -> unit

--- a/petanque/json_shell/interp.ml
+++ b/petanque/json_shell/interp.ml
@@ -62,6 +62,10 @@ let handle_request ~(do_handle : 'a handle) ~unhandled ~token ~method_ ~params =
     do_handle ~token (module Goals) ~params
   | s when String.equal Premises.method_ s ->
     do_handle ~token (module Premises) ~params
+  | s when String.equal Premises.method_ s ->
+    do_handle ~token (module StateEqual) ~params
+  | s when String.equal Premises.method_ s ->
+    do_handle ~token (module StateHash) ~params
   | _ -> unhandled ()
 
 let do_handle ~fn ~token (module R : Protocol.Request.S) ~params =

--- a/petanque/json_shell/jAgent.ml
+++ b/petanque/json_shell/jAgent.ml
@@ -3,6 +3,10 @@
 (* Implement State.t and Env.t serialization methods *)
 module State = Obj_map.Make (Petanque.Agent.State)
 
+module Inspect = struct
+  type t = [%import: Petanque.Agent.State.Inspect.t] [@@deriving yojson]
+end
+
 (* The typical protocol dance *)
 
 (* What a mess result stuff is, we need this in case result is installed, as

--- a/petanque/json_shell/jAgent.ml
+++ b/petanque/json_shell/jAgent.ml
@@ -28,6 +28,10 @@ module Error = struct
   type t = [%import: Petanque.Agent.Error.t] [@@deriving yojson]
 end
 
+module Run_opts = struct
+  type t = [%import: Petanque.Agent.Run_opts.t] [@@deriving yojson]
+end
+
 module Run_result = struct
   type 'a t = [%import: 'a Petanque.Agent.Run_result.t] [@@deriving yojson]
 end

--- a/petanque/json_shell/protocol.ml
+++ b/petanque/json_shell/protocol.ml
@@ -95,7 +95,7 @@ module RunTac = struct
 
   module Params = struct
     type t =
-      { memo : bool option
+      { opts : Run_opts.t option
             [@default None] (* Whether to memoize the execution, server-side *)
       ; st : int
       ; tac : string
@@ -110,7 +110,7 @@ module RunTac = struct
   module Handler = struct
     module Params = struct
       type t =
-        { memo : bool option
+        { opts : Run_opts.t option
               [@default None] (* Whether to memoize the execution *)
         ; st : State.t
         ; tac : string
@@ -124,8 +124,8 @@ module RunTac = struct
 
     let handler =
       HType.Immediate
-        (fun ~token { Params.memo; st; tac } ->
-          Agent.run ~token ?memo ~st ~tac ())
+        (fun ~token { Params.opts; st; tac } ->
+          Agent.run ~token ?opts ~st ~tac ())
   end
 end
 

--- a/petanque/json_shell/protocol.ml
+++ b/petanque/json_shell/protocol.ml
@@ -176,3 +176,62 @@ module Premises = struct
       HType.Immediate (fun ~token { Params.st } -> Agent.premises ~token ~st)
   end
 end
+
+(* StateEqual *)
+module StateEqual = struct
+  let method_ = "petanque/state/eq"
+
+  module Params = struct
+    type t =
+      { kind : Inspect.t option [@default None]
+      ; st1 : int
+      ; st2 : int
+      }
+    [@@deriving yojson]
+  end
+
+  module Response = struct
+    type t = bool [@@deriving yojson]
+  end
+
+  module Handler = struct
+    module Params = struct
+      type t =
+        { kind : Inspect.t option
+        ; st1 : State.t
+        ; st2 : State.t
+        }
+      [@@deriving yojson]
+    end
+
+    module Response = Response
+
+    let handler =
+      HType.Immediate
+        (fun ~token:_ { Params.kind; st1; st2 } ->
+          Ok (Agent.State.equal ?kind st1 st2))
+  end
+end
+
+module StateHash = struct
+  let method_ = "petanque/state/hash"
+
+  module Params = struct
+    type t = { st : int } [@@deriving yojson]
+  end
+
+  module Response = struct
+    type t = int [@@deriving yojson]
+  end
+
+  module Handler = struct
+    module Params = struct
+      type t = { st : State.t } [@@deriving yojson]
+    end
+
+    module Response = Response
+
+    let handler =
+      HType.Immediate (fun ~token:_ { Params.st } -> Ok (Agent.State.hash st))
+  end
+end

--- a/petanque/test/basic_api.ml
+++ b/petanque/test/basic_api.ml
@@ -44,8 +44,14 @@ let main () =
   let* st = start ~token in
   let* _premises = Agent.premises ~token ~st in
   let* st = Agent.run ~token ~st ~tac:"induction l." () in
+  let h1 = Agent.State.hash st.st in
+  let* st = r ~st ~tac:"idtac." in
+  let h2 = Agent.State.hash st.st in
+  assert (Int.equal h1 h2);
   let* st = r ~st ~tac:"-" in
   let* st = r ~st ~tac:"reflexivity." in
+  let h3 = Agent.State.hash st.st in
+  assert (not (Int.equal h1 h3));
   let* st = r ~st ~tac:"-" in
   let* st = r ~st ~tac:"now simpl; rewrite IHl." in
   let* st = r ~st ~tac:"Qed." in

--- a/petanque/test/basic_api.ml
+++ b/petanque/test/basic_api.ml
@@ -32,9 +32,7 @@ let start ~token =
   let* doc = Petanque.Shell.build_doc ~token ~uri in
   Agent.start ~token ~doc ~thm:"rev_snoc_cons" ()
 
-let extract_st (st : _ Agent.Run_result.t) =
-  match st with
-  | Proof_finished st | Current_state st -> st
+let extract_st { Agent.Run_result.st; _ } = st
 
 let main () =
   let open Coq.Compat.Result.O in

--- a/petanque/test/json_api.ml
+++ b/petanque/test/json_api.ml
@@ -12,11 +12,7 @@ let msgs = ref []
 let trace ?verbose:_ msg = msgs := Format.asprintf "[trace] %s" msg :: !msgs
 let message ~lvl:_ ~message = msgs := message :: !msgs
 let dump_msgs () = List.iter (Format.eprintf "%s@\n") (List.rev !msgs)
-
-let extract_st (st : Protocol.RunTac.Response.t) =
-  match st with
-  | Proof_finished st | Current_state st -> st
-
+let extract_st { JAgent.Run_result.st; _ } = st
 let pp_offset fmt (bp, ep) = Format.fprintf fmt "(%d,%d)" bp ep
 
 let pp_res_str =
@@ -47,9 +43,9 @@ let run (ic, oc) =
     let message = message
   end) in
   let r ~st ~tac =
-    let memo = None in
+    let opts = None in
     let st = extract_st st in
-    S.run_tac { memo; st; tac }
+    S.run_tac { opts; st; tac }
   in
   (* Will this work on Windows? *)
   let root, uri = prepare_paths () in
@@ -58,7 +54,7 @@ let run (ic, oc) =
   let* premises = S.premises { st } in
   (if print_premises then
      Format.(eprintf "@[%a@]@\n%!" (pp_print_list pp_premise) premises));
-  let* st = S.run_tac { memo = None; st; tac = "induction l." } in
+  let* st = S.run_tac { opts = None; st; tac = "induction l." } in
   let* st = r ~st ~tac:"-" in
   let* st = r ~st ~tac:"reflexivity." in
   let* st = r ~st ~tac:"-" in

--- a/petanque/test/json_api_failure.ml
+++ b/petanque/test/json_api_failure.ml
@@ -12,10 +12,7 @@ let msgs = ref []
 let trace ?verbose:_ msg = msgs := Format.asprintf "[trace] %s" msg :: !msgs
 let message ~lvl:_ ~message = msgs := message :: !msgs
 let dump_msgs () = List.iter (Format.eprintf "%s@\n") (List.rev !msgs)
-
-let extract_st (st : Protocol.RunTac.Response.t) =
-  match st with
-  | Proof_finished st | Current_state st -> st
+let extract_st { JAgent.Run_result.st; _ } = st
 
 let run (ic, oc) =
   let open Coq.Compat.Result.O in
@@ -27,16 +24,16 @@ let run (ic, oc) =
     let message = message
   end) in
   let r ~st ~tac =
-    let memo = None in
+    let opts = None in
     let st = extract_st st in
-    S.run_tac { memo; st; tac }
+    S.run_tac { opts; st; tac }
   in
   (* Will this work on Windows? *)
   let root, uri = prepare_paths () in
   let* _env = S.set_workspace { debug; root } in
   let* st = S.start { uri; pre_commands = None; thm = "rev_snoc_cons" } in
   let* _premises = S.premises { st } in
-  let* st = S.run_tac { memo = None; st; tac = "induction l." } in
+  let* st = S.run_tac { opts = None; st; tac = "induction l." } in
   let* st = r ~st ~tac:"-" in
   (* Introduce an error *)
   (* let* st = r ~st ~tac:"reflexivity." in *)


### PR DESCRIPTION
This allows the client to implement a state hashtable; see the
comments on the API for low-level details.

Note the changes in `run` result type. I have actually slightly refactored the type; @gbdrt please let me know if that's OK for you, or you would prefer the older type?