### PR TITLE
[goals] Allow `command` to process several Coq commands.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,12 @@
    support Coq's 8.21 `quickFix` data (@ejgallego, #840, #843, #845)
  - [petanque] Fix bug for detection of proof finished in deep stacks
    (@ejgallego, @gbdrt, #847)
+ - [goals request] allow multiple Coq sentences in `command`. This is
+   backwards compatible in the case that commands do not error, and
+   users were sending just one command. (@ejgallego, #823, thanks to
+   CoqPilot devs and G. Baudart for feedback)
+ - [goals request] (! breaking) fail the request if the commands in
+   `command` fail (@ejgallego, #823)
 
 # coq-lsp 0.2.0: From Green to Blue
 -----------------------------------

--- a/controller/rq_goals.ml
+++ b/controller/rq_goals.ml
@@ -31,25 +31,10 @@ let pp ~pp_format pp =
   | Pp -> Lsp.JCoq.Pp.to_yojson pp
   | Str -> `String (Pp.string_of_ppcmds pp)
 
-let parse ~token ~loc tac st =
-  let str = Gramlib.Stream.of_string tac in
-  let str = Coq.Parsing.Parsable.make ?loc str in
-  Coq.Parsing.parse ~token ~st str
-
-let parse_and_execute_in ~token ~loc tac st =
-  let open Coq.Protect.E.O in
-  let* ast = parse ~token ~loc tac st in
-  match ast with
-  | Some ast -> Fleche.Memo.Interp.eval ~token (st, ast)
-  (* On EOF we return the previous state, the command was the empty string or a
-     comment *)
-  | None -> Coq.Protect.E.ok st
-
 let run_pretac ~token ~loc ~st pretac =
   match pretac with
   | None -> Coq.Protect.E.ok st
-  | Some tac ->
-    Coq.State.in_stateM ~token ~st ~f:(parse_and_execute_in ~token ~loc tac) st
+  | Some tac -> Fleche.Doc.run ~token ?loc ~st tac
 
 let get_goal_info ~token ~doc ~point ~mode ~pretac () =
   let open Fleche in

--- a/etc/doc/PROTOCOL.md
+++ b/etc/doc/PROTOCOL.md
@@ -187,11 +187,18 @@ interface GoalRequest {
     textDocument: VersionedTextDocumentIdentifier;
     position: Position;
     pp_format?: 'Pp' | 'Str';
-    pretac?: string;
     command?: string;
     mode?: 'Prev' | 'After';
 }
 ```
+
+The first parameters are standard, `pp_format` controls the pretty
+printing format used in the results.
+
+The `command` parameter (experimental), is a list of Coq commands that
+will be run just _after_ `position` in `textDocument`, but _before_
+goals are sent to the user. This is often useful for ephemeral
+post-processing.
 
 Answer to the request is a `Goal[]` object, where
 

--- a/fleche/doc.mli
+++ b/fleche/doc.mli
@@ -137,3 +137,21 @@ val check :
 (** [save ~doc] will save [doc] .vo file. It will fail if proofs are open, or if
     the document completion status is not [Yes] *)
 val save : token:Coq.Limits.Token.t -> doc:t -> (unit, Loc.t) Coq.Protect.E.t
+
+(** [run ~token ?loc ?memo ~st cmds] run commands [cmds] starting on state [st],
+    without commiting changes to the document. [loc] can be used to seed an
+    initial location if desired, if not the locations will be considered
+    relative to the initial location. [memo] controls if the execution is
+    memoized, by default [true].
+
+    This API is experimental, used for speculative execution
+    [petanque
+    and goals], the API is expected to change as to better adapt
+    to users. *)
+val run :
+     token:Coq.Limits.Token.t
+  -> ?loc:Loc.t
+  -> ?memo:bool
+  -> st:Coq.State.t
+  -> string
+  -> (Coq.State.t, Loc.t) Coq.Protect.E.t

--- a/petanque/agent.ml
+++ b/petanque/agent.ml
@@ -106,30 +106,12 @@ let find_thm ~(doc : Fleche.Doc.t) ~thm =
     (* let point = (range.start.line, range.start.character) in *)
     Ok node
 
-let parse ~loc tac st =
-  let str = Gramlib.Stream.of_string tac in
-  let str = Coq.Parsing.Parsable.make ?loc str in
-  Coq.Parsing.parse ~st str
-
-(* Adaptor, should be supported in memo directly *)
-let eval_no_memo ~token (st, cmd) =
-  Coq.Interp.interp ~token ~intern:Vernacinterp.fs_intern ~st cmd
-
-let parse_and_execute_in ~token ~loc ~memo tac st =
-  (* To improve in memo *)
-  let eval = if memo then Fleche.Memo.Interp.eval else eval_no_memo in
-  let open Coq.Protect.E.O in
-  let* ast = parse ~token ~loc tac st in
-  match ast with
-  | Some ast -> eval ~token (st, ast)
-  | None -> Coq.Protect.E.ok st
-
 let execute_precommands ~token ~memo ~pre_commands ~(node : Fleche.Doc.Node.t) =
   match (pre_commands, node.prev, node.ast) with
   | Some pre_commands, Some prev, Some ast ->
     let st = prev.state in
     let open Coq.Protect.E.O in
-    let* st = parse_and_execute_in ~token ~memo ~loc:None pre_commands st in
+    let* st = Fleche.Doc.run ~token ~memo ?loc:None ~st pre_commands in
     (* We re-interpret the lemma statement *)
     Fleche.Memo.Interp.eval ~token (st, ast.v)
   | _, _, _ -> Coq.Protect.E.ok node.state
@@ -180,32 +162,31 @@ let default_opts = function
   | None -> { Run_opts.memo = true; hash = true }
   | Some opts -> opts
 
-(* XXX: EJGA, we should not need the [Coq.State.in_stateM] here and in run *)
 let start ~token ~doc ?opts ?pre_commands ~thm () =
   let open Coq.Compat.Result.O in
   let* node = find_thm ~doc ~thm in
   (* Usually single shot, so we don't memoize *)
-  let f () =
-    let opts = default_opts opts in
-    let memo, hash = (opts.memo, opts.hash) in
+  let opts = default_opts opts in
+  let memo, hash = (opts.memo, opts.hash) in
+  let execution =
     let open Coq.Protect.E.O in
     let+ st = execute_precommands ~token ~memo ~pre_commands ~node in
+    (* Note this runs on the resulting state, anyways it is purely functional *)
     analyze_after_run ~hash st
   in
-  let st = node.state in
-  Coq.State.in_stateM ~token ~st ~f () |> protect_to_result
+  protect_to_result execution
 
 let run ~token ?opts ~st ~tac () : (_ Run_result.t, Error.t) Result.t =
   let opts = default_opts opts in
   (* Improve with thm? *)
-  let loc = None in
   let memo, hash = (opts.memo, opts.hash) in
-  let f st =
+  let execution =
     let open Coq.Protect.E.O in
-    let+ st = parse_and_execute_in ~token ~memo ~loc tac st in
+    let+ st = Fleche.Doc.run ~token ~memo ?loc:None ~st tac in
+    (* Note this runs on the resulting state, anyways it is purely functional *)
     analyze_after_run ~hash st
   in
-  Coq.State.in_stateM ~token ~st ~f st |> protect_to_result
+  protect_to_result execution
 
 let goals ~token ~st =
   let f goals =


### PR DESCRIPTION
This is a prototype extension.

Note the important change here in behavior here, but IMHO it is
needed: if the commands in `command` fail, we will now fail the
request.

I think in general we may allow some form of error recovery here, but
for now we just let clients recover.

It does seem that CoqPilot / Pytanque do need even a more powerful
interface, but this will allow the them to make some progress for nwo.

Thanks to CoqPilot devs for feedback on this.
