### PR TITLE
Adapt to Coq PR #19301: towards ceps #42, unify the syntax of definition and theorem

### DIFF
--- a/serlib/ser_vernacexpr.ml
+++ b/serlib/ser_vernacexpr.ml
@@ -132,6 +132,10 @@ type option_setting =
  *   [%import: Vernacexpr.sort_expr]
  *   [@@deriving sexp,yojson,hash,compare] *)
 
+type body_expr =
+  [%import: Vernacexpr.body_expr]
+  [@@deriving sexp,yojson,hash,compare]
+
 type definition_expr =
   [%import: Vernacexpr.definition_expr]
   [@@deriving sexp,yojson,hash,compare]
@@ -158,10 +162,6 @@ type notation_declaration =
 
 type recursion_order_expr =
   [%import: Vernacexpr.recursion_order_expr]
-  [@@deriving sexp,yojson,hash,compare]
-
-type recursive_expr_gen =
-  [%import: Vernacexpr.recursive_expr_gen]
   [@@deriving sexp,yojson,hash,compare]
 
 type fixpoint_expr =
@@ -243,10 +243,6 @@ type inductive_expr =
 
 type one_inductive_expr =
   [%import: Vernacexpr.one_inductive_expr]
-  [@@deriving sexp,yojson,hash,compare]
-
-type proof_expr =
-  [%import: Vernacexpr.proof_expr]
   [@@deriving sexp,yojson,hash,compare]
 
 type opacity_flag =

--- a/serlib/ser_vernacexpr.mli
+++ b/serlib/ser_vernacexpr.mli
@@ -104,6 +104,10 @@ type locality_flag =
   [%import: Vernacexpr.locality_flag]
   [@@deriving sexp,yojson,hash,compare]
 
+type body_expr =
+  [%import: Vernacexpr.body_expr]
+  [@@deriving sexp,yojson,hash,compare]
+
 type definition_expr =
   [%import: Vernacexpr.definition_expr]
   [@@deriving sexp,yojson,hash,compare]
@@ -114,10 +118,6 @@ type notation_declaration =
 
 type recursion_order_expr =
   [%import: Vernacexpr.recursion_order_expr]
-  [@@deriving sexp,yojson,hash,compare]
-
-type recursive_expr_gen =
-  [%import: Vernacexpr.recursive_expr_gen]
   [@@deriving sexp,yojson,hash,compare]
 
 type fixpoint_expr =
@@ -182,10 +182,6 @@ type inductive_expr =
 
 type one_inductive_expr =
   [%import: Vernacexpr.one_inductive_expr]
-  [@@deriving sexp,yojson,hash,compare]
-
-type proof_expr =
-  [%import: Vernacexpr.proof_expr]
   [@@deriving sexp,yojson,hash,compare]
 
 type proof_end =


### PR DESCRIPTION
Beside a reworking of the AST, the changes in types are:
- proof_expr is generalized into body_expr
- definition_expr subsumes fixpoint_expr_gen

To be merged synchronously with coq/coq#19301.