### PR TITLE
[js worker] Update js_of_ocaml to 5.9.1 and Coq -> Roqc / stdlib split

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,9 +115,10 @@ jobs:
 
       - name: 🐫🐪🐫 Get dependencies
         run: |
+          opam update
           opam exec -- make opam-deps
-          opam pin add js_of_ocaml-compiler --dev -y
-          opam pin add js_of_ocaml --dev -y
+          opam pin add js_of_ocaml-compiler -k version 5.9.1 -y
+          opam pin add js_of_ocaml -k version 5.9.1 -y
           opam install zarith_stubs_js js_of_ocaml-ppx -y
 
       - name: 💉💉💉 Patch Coq

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
    Heuzard for longstanding continued support of the jsCoq and coq-lsp
    projects (@ejgallego, @hhugo, #881)
  - [js worker] Update stubs (@ejgallego, @hhugo, #881)
+ - [js worker] Fix build for Coq -> Rocq renaming and stdlib split
+   (@ejgallego, #881)
 
 # coq-lsp 0.2.2: To Virtual or not To Virtual
 ---------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,11 @@
  - [fleche] fix quick fixes for errors being lost due to incorrect
    handling of `send_diags_extra_data` (@ejgallego, #850)
  - [vscode] Syntax highlighting for Coq 8.17-8.20 (@4ever2, #872)
+ - [build] Adapt to Coq -> Rocq renaming (@ejgallego, @proux, #879)
  - [js worker] Update js_of_ocaml to 5.9.1 , thanks a lot to Hugo
    Heuzard for longstanding continued support of the jsCoq and coq-lsp
    projects (@ejgallego, @hhugo, #881)
+ - [js worker] Update stubs (@ejgallego, @hhugo, #881)
 
 # coq-lsp 0.2.2: To Virtual or not To Virtual
 ---------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
  - [fleche] fix quick fixes for errors being lost due to incorrect
    handling of `send_diags_extra_data` (@ejgallego, #850)
  - [vscode] Syntax highlighting for Coq 8.17-8.20 (@4ever2, #872)
+ - [js worker] Update js_of_ocaml to 5.9.1 , thanks a lot to Hugo
+   Heuzard for longstanding continued support of the jsCoq and coq-lsp
+   projects (@ejgallego, @hhugo, #881)
 
 # coq-lsp 0.2.2: To Virtual or not To Virtual
 ---------------------------------------------

--- a/controller-js/coq_lsp_worker.ml
+++ b/controller-js/coq_lsp_worker.ml
@@ -154,7 +154,7 @@ let main () =
 
   let stdlib coqlib =
     let unix_path = Filename.concat coqlib "theories" in
-    let coq_path = Names.(DirPath.make [ Id.of_string "Stdlib" ]) in
+    let coq_path = Names.(DirPath.make [ Id.of_string "Corelib" ]) in
     Loadpath.{ unix_path; coq_path; implicit = true; recursive = true }
   in
 
@@ -176,7 +176,7 @@ let main () =
       ; ocamlpath
       ; vo_load_path
       ; ml_include_path = []
-      ; require_libraries = [ (None, "Stdlib.Init.Prelude") ]
+      ; require_libraries = [ (None, "Corelib.Init.Prelude") ]
       ; args = [ "-noinit"; "-boot" ]
       }
   in

--- a/controller-js/coq_lsp_worker.ml
+++ b/controller-js/coq_lsp_worker.ml
@@ -132,7 +132,7 @@ let coq_init ~debug =
   let vm, warnings = (false, Some "-vm-compute-disabled") in
   Coq.Init.(coq_init { debug; load_module; load_plugin; vm; warnings })
 
-external coq_vm_trap : unit -> unit = "coq_vm_trap"
+external rocq_vm_trap : unit -> unit = "rocq_vm_trap"
 
 (* This code is executed on Worker initialization *)
 let main () =
@@ -146,7 +146,7 @@ let main () =
   setup_std_printers ();
 
   (* setup_interp (); *)
-  coq_vm_trap ();
+  rocq_vm_trap ();
 
   Lsp.Io.set_log_fn (fun n -> Lsp.Base.Message.notification n |> post_message);
   let io = CB.cb in

--- a/controller-js/dune
+++ b/controller-js/dune
@@ -30,7 +30,7 @@
    ; --file=%{dep:coq-fs}
    --setenv
    PATH=/bin))
- (link_flags -linkall -no-check-prims)
+ (link_flags -no-check-prims)
  ; The old makefile set: -noautolink -no-check-prims
  (libraries
   zarith_stubs_js

--- a/controller-js/js_stub/coq_vm.js
+++ b/controller-js/js_stub/coq_vm.js
@@ -7,19 +7,19 @@ function vm_ll(s, args) {
 vm_ll.log = false;     // whether to log calls
 vm_ll.trap = false;    // whether to halt on calls
 
-// Provides: init_coq_vm
+// Provides: init_rocq_vm
 // Requires: vm_ll
-function init_coq_vm() {
-  vm_ll('init_coq_vm', arguments);
+function init_rocq_vm() {
+  vm_ll('init_rocq_vm', arguments);
   return;
 }
 
 // EG: Coq VM's code is evil and performs static initialization... the
 // best option would be to disable the VM code entirely as before.
 
-// Provides: coq_vm_trap
+// Provides: rocq_vm_trap
 // Requires: vm_ll
-function coq_vm_trap() {    // will cause future calls to vm code to fault
+function rocq_vm_trap() {    // will cause future calls to vm code to fault
   vm_ll.log = vm_ll.trap = true;  // (called after initialization)
 }
 
@@ -31,266 +31,266 @@ function accumulate_code() {
   return [];
 }
 
-// Provides: coq_pushpop
+// Provides: rocq_pushpop
 // Requires: vm_ll
-function coq_pushpop() {
-  vm_ll('coq_pushpop', arguments);
+function rocq_pushpop() {
+  vm_ll('rocq_pushpop', arguments);
   return [];
 }
 
-// Provides: coq_closure_arity
+// Provides: rocq_closure_arity
 // Requires: vm_ll
-function coq_closure_arity() {
-  vm_ll('coq_closure_arity', arguments);
+function rocq_closure_arity() {
+  vm_ll('rocq_closure_arity', arguments);
   return [];
 }
 
-// Provides: coq_eval_tcode
+// Provides: rocq_eval_tcode
 // Requires: vm_ll
-function coq_eval_tcode() {
-  vm_ll('coq_eval_tcode', arguments);
+function rocq_eval_tcode() {
+  vm_ll('rocq_eval_tcode', arguments);
   return [];
 }
 
-// Provides: coq_int_tcode
+// Provides: rocq_int_tcode
 // Requires: vm_ll
-function coq_int_tcode() {
-  vm_ll('coq_int_tcode', arguments);
+function rocq_int_tcode() {
+  vm_ll('rocq_int_tcode', arguments);
   return [];
 }
 
-// Provides: coq_interprete_ml
+// Provides: rocq_interprete_ml
 // Requires: vm_ll
-function coq_interprete_ml() {
-  vm_ll('coq_interprete_ml', arguments);
+function rocq_interprete_ml() {
+  vm_ll('rocq_interprete_ml', arguments);
   return [];
 }
 
-// Provides: coq_is_accumulate_code
+// Provides: rocq_is_accumulate_code
 // Requires: vm_ll
-function coq_is_accumulate_code() {
-  vm_ll('coq_is_accumulate_code', arguments);
+function rocq_is_accumulate_code() {
+  vm_ll('rocq_is_accumulate_code', arguments);
   return [];
 }
 
-// Provides: coq_kind_of_closure
+// Provides: rocq_kind_of_closure
 // Requires: vm_ll
-function coq_kind_of_closure() {
-  vm_ll('coq_kind_of_closure', arguments);
+function rocq_kind_of_closure() {
+  vm_ll('rocq_kind_of_closure', arguments);
   return [];
 }
 
-// Provides: coq_makeaccu
+// Provides: rocq_makeaccu
 // Requires: vm_ll
-function coq_makeaccu() {
-  vm_ll('coq_makeaccu', arguments);
+function rocq_makeaccu() {
+  vm_ll('rocq_makeaccu', arguments);
   return [];
 }
 
-// Provides: coq_offset
+// Provides: rocq_offset
 // Requires: vm_ll
-function coq_offset() {
-  vm_ll('coq_offset', arguments);
+function rocq_offset() {
+  vm_ll('rocq_offset', arguments);
   return [];
 }
 
-// Provides: coq_offset_closure
+// Provides: rocq_offset_closure
 // Requires: vm_ll
-function coq_offset_closure() {
-  vm_ll('coq_offset_closure', arguments);
+function rocq_offset_closure() {
+  vm_ll('rocq_offset_closure', arguments);
   return [];
 }
 
-// Provides: coq_offset_tcode
+// Provides: rocq_offset_tcode
 // Requires: vm_ll
-function coq_offset_tcode() {
-  vm_ll('coq_offset_tcode', arguments);
+function rocq_offset_tcode() {
+  vm_ll('rocq_offset_tcode', arguments);
   return [];
 }
 
-// Provides: coq_push_arguments
+// Provides: rocq_push_arguments
 // Requires: vm_ll
-function coq_push_arguments() {
-  vm_ll('coq_push_arguments', arguments);
+function rocq_push_arguments() {
+  vm_ll('rocq_push_arguments', arguments);
   return [];
 }
 
-// Provides: coq_push_ra
+// Provides: rocq_push_ra
 // Requires: vm_ll
-function coq_push_ra() {
-  vm_ll('coq_push_ra', arguments);
+function rocq_push_ra() {
+  vm_ll('rocq_push_ra', arguments);
   return [];
 }
 
-// Provides: coq_push_val
+// Provides: rocq_push_val
 // Requires: vm_ll
-function coq_push_val() {
-  vm_ll('coq_push_val', arguments);
+function rocq_push_val() {
+  vm_ll('rocq_push_val', arguments);
   return [];
 }
 
-// Provides: coq_push_vstack
+// Provides: rocq_push_vstack
 // Requires: vm_ll
-function coq_push_vstack() {
-  vm_ll('coq_push_vstack', arguments);
+function rocq_push_vstack() {
+  vm_ll('rocq_push_vstack', arguments);
   return [];
 }
 
-// Provides: coq_set_transp_value
+// Provides: rocq_set_transp_value
 // Requires: vm_ll
-function coq_set_transp_value() {
-  vm_ll('coq_set_transp_value', arguments);
+function rocq_set_transp_value() {
+  vm_ll('rocq_set_transp_value', arguments);
   return [];
 }
 
-// Provides: coq_set_bytecode_field
+// Provides: rocq_set_bytecode_field
 // Requires: vm_ll
-function coq_set_bytecode_field() {
-  vm_ll('coq_set_bytecode_field', arguments);
+function rocq_set_bytecode_field() {
+  vm_ll('rocq_set_bytecode_field', arguments);
   return [0];
 }
 
-// Provides: coq_tcode_of_code
+// Provides: rocq_tcode_of_code
 // Requires: vm_ll
-function coq_tcode_of_code() {
-  vm_ll('coq_tcode_of_code', arguments);
+function rocq_tcode_of_code() {
+  vm_ll('rocq_tcode_of_code', arguments);
   return [];
 }
 
-// Provides: coq_accumulate
+// Provides: rocq_accumulate
 // Requires: vm_ll
-function coq_accumulate() {
+function rocq_accumulate() {
   // This is called on init, so let's be more lenient
-  // vm_ll('coq_accumulate', arguments);
+  // vm_ll('rocq_accumulate', arguments);
   return [];
 }
 
-// Provides: coq_obj_set_tag
+// Provides: rocq_obj_set_tag
 // Requires: vm_ll
-function coq_obj_set_tag() {
-  vm_ll('coq_obj_set_tag', arguments);
+function rocq_obj_set_tag() {
+  vm_ll('rocq_obj_set_tag', arguments);
   return [];
 }
 
-// Provides: coq_uint63_to_float_byte
+// Provides: rocq_uint63_to_float_byte
 // Requires: vm_ll
-function coq_uint63_to_float_byte() {
+function rocq_uint63_to_float_byte() {
   // First element of the array is the length!
-  vm_ll('coq_uint63_to_float_byte', arguments);
+  vm_ll('rocq_uint63_to_float_byte', arguments);
   return [0];
 }
 
-// Provides: get_coq_atom_tbl
+// Provides: get_rocq_atom_tbl
 // Requires: vm_ll
-function get_coq_atom_tbl() {
+function get_rocq_atom_tbl() {
   // First element of the array is the length!
-  vm_ll('get_coq_atom_tbl', arguments);
+  vm_ll('get_rocq_atom_tbl', arguments);
   return [0];
 }
 
-// Provides: get_coq_global_data
+// Provides: get_rocq_global_data
 // Requires: vm_ll
-function get_coq_global_data() {
-  vm_ll('get_coq_global_data', arguments);
+function get_rocq_global_data() {
+  vm_ll('get_rocq_global_data', arguments);
   return [];
 }
 
-// Provides: get_coq_transp_value
+// Provides: get_rocq_transp_value
 // Requires: vm_ll
-function get_coq_transp_value() {
-  vm_ll('get_coq_transp_value', arguments);
+function get_rocq_transp_value() {
+  vm_ll('get_rocq_transp_value', arguments);
   return [];
 }
 
-// Provides: realloc_coq_atom_tbl
+// Provides: realloc_rocq_atom_tbl
 // Requires: vm_ll
-function realloc_coq_atom_tbl() {
-  vm_ll('realloc_coq_atom_tbl', arguments);
+function realloc_rocq_atom_tbl() {
+  vm_ll('realloc_rocq_atom_tbl', arguments);
   return;
 }
 
-// Provides: realloc_coq_global_data
+// Provides: realloc_rocq_global_data
 // Requires: vm_ll
-function realloc_coq_global_data() {
-  vm_ll('realloc_coq_global_data', arguments);
+function realloc_rocq_global_data() {
+  vm_ll('realloc_rocq_global_data', arguments);
   return;
 }
 
-// Provides: coq_interprete_byte
+// Provides: rocq_interprete_byte
 // Requires: vm_ll
-function coq_interprete_byte()    { vm_ll('coq_interprete_byte', arguments); }
-// Provides: coq_set_drawinstr
+function rocq_interprete_byte()    { vm_ll('rocq_interprete_byte', arguments); }
+// Provides: rocq_set_drawinstr
 // Requires: vm_ll
-function coq_set_drawinstr()      { vm_ll('coq_set_drawinstr', arguments); }
-// Provides: coq_tcode_array
+function rocq_set_drawinstr()      { vm_ll('rocq_set_drawinstr', arguments); }
+// Provides: rocq_tcode_array
 // Requires: vm_ll
-function coq_tcode_array()        { vm_ll('coq_tcode_array', arguments); }
+function rocq_tcode_array()        { vm_ll('rocq_tcode_array', arguments); }
 
-// Provides: coq_fadd_byte
-function coq_fadd_byte(r1, r2) {
+// Provides: rocq_fadd_byte
+function rocq_fadd_byte(r1, r2) {
   return r1 + r2;
 }
 
-// Provides: coq_fsub_byte
-function coq_fsub_byte(r1, r2) {
+// Provides: rocq_fsub_byte
+function rocq_fsub_byte(r1, r2) {
   return r1 - r2;
 }
 
-// Provides: coq_fmul_byte
-function coq_fmul_byte(r1, r2) {
+// Provides: rocq_fmul_byte
+function rocq_fmul_byte(r1, r2) {
   return r1 * r2;
 }
 
-// Provides: coq_fdiv_byte
-function coq_fdiv_byte(r1, r2) {
+// Provides: rocq_fdiv_byte
+function rocq_fdiv_byte(r1, r2) {
   return r1 / r2;
 }
 
-// Provides: coq_fsqrt_byte
+// Provides: rocq_fsqrt_byte
 // Requires: vm_ll
-function coq_fsqrt_byte() {
-  vm_ll('coq_fsqrt_byte', arguments);
+function rocq_fsqrt_byte() {
+  vm_ll('rocq_fsqrt_byte', arguments);
   return;
 }
 
-// Provides: coq_is_double
+// Provides: rocq_is_double
 // Requires: vm_ll
-  function coq_is_double() {
-    vm_ll('coq_is_double', arguments);
+  function rocq_is_double() {
+    vm_ll('rocq_is_double', arguments);
   return;
 }
 
-// Provides: coq_next_down_byte
+// Provides: rocq_next_down_byte
 // Requires: vm_ll
-  function coq_next_down_byte() {
-    vm_ll('coq_next_down_byte', arguments);
+  function rocq_next_down_byte() {
+    vm_ll('rocq_next_down_byte', arguments);
   return;
 }
 
-// Provides: coq_next_up_byte
+// Provides: rocq_next_up_byte
 // Requires: vm_ll
-  function coq_next_up_byte() {
-    vm_ll('coq_next_up_byte', arguments);
+  function rocq_next_up_byte() {
+    vm_ll('rocq_next_up_byte', arguments);
   return;
 }
 
-// Provides: coq_current_fix
+// Provides: rocq_current_fix
 // Requires: vm_ll
-function coq_current_fix() {
-  vm_ll('coq_current_fix', arguments);
+function rocq_current_fix() {
+  vm_ll('rocq_current_fix', arguments);
   return [];
 }
 
-// Provides: coq_last_fix
+// Provides: rocq_last_fix
 // Requires: vm_ll
-function coq_last_fix() {
-  vm_ll('coq_last_fix', arguments);
+function rocq_last_fix() {
+  vm_ll('rocq_last_fix', arguments);
   return [];
 }
 
-// Provides: coq_shift_fix
+// Provides: rocq_shift_fix
 // Requires: vm_ll
-function coq_shift_fix() {
-  vm_ll('coq_shift_fix', arguments);
+function rocq_shift_fix() {
+  vm_ll('rocq_shift_fix', arguments);
   return [];
 }

--- a/controller-js/js_stub/coq_vm.js
+++ b/controller-js/js_stub/coq_vm.js
@@ -1,6 +1,6 @@
 // Provides: vm_ll
 function vm_ll(s, args) { 
-  if (vm_ll.log) joo_global_object.console.warn(s, args); 
+  if (vm_ll.log) globalThis.console.warn(s, args); 
   if (vm_ll.trap) throw new Error("vm trap: '"+ s + "' not implemented");
 }
 

--- a/controller-js/js_stub/interrupt.js
+++ b/controller-js/js_stub/interrupt.js
@@ -1,7 +1,7 @@
 // Provides: interrupt_setup
 function interrupt_setup(shmem) {
-    var Int32Array = joo_global_object.Int32Array,
-        SharedArrayBuffer = joo_global_object.SharedArrayBuffer;
+    var Int32Array = globalThis.Int32Array,
+        SharedArrayBuffer = globalThis.SharedArrayBuffer;
 
     if (Int32Array && SharedArrayBuffer) {
         shmem = shmem || new Int32Array(new SharedArrayBuffer(4));
@@ -14,7 +14,7 @@ function interrupt_setup(shmem) {
 // Provides: interrupt_pending
 // Requires: interrupt_setup
 function interrupt_pending() {
-    var Atomics = joo_global_object.Atomics;
+    var Atomics = globalThis.Atomics;
 
     if (Atomics && interrupt_setup.vec) {
         var ld = Atomics.load(interrupt_setup.vec, 0);

--- a/controller-js/js_stub/unix.js
+++ b/controller-js/js_stub/unix.js
@@ -1,6 +1,6 @@
 //Provides: unix_ll
-function unix_ll(s, args) { 
-  if (unix_ll.log) joo_global_object.console.warn(s, args); 
+function unix_ll(s, args) {
+  if (unix_ll.log) globalThis.console.warn(s, args);
   if (unix_ll.trap) throw new Error("unix trap: '"+ s + "' not implemented");
 }
 unix_ll.log = true;       // whether to log calls


### PR DESCRIPTION
Thanks a lot to Hugo Heuzard for longstanding continued support of the
jsCoq and coq-lsp projects. Without their support these projects would
have never existed.

We also update some other bits to fully account for https://github.com/coq/coq/pull/19530 , worker fully functional again on Coq `master`
