### PR TITLE
[build] [general] Rename our internal `Lsp` library to `Fleche_lsp`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,10 @@
  - [vscode] [web] Fix web extension not exporting the coq-lsp
    extension API (@ejgallego, reported by @amblafont, #911, fixes
    #877)
+ - [build] [general] Rename our internal `Lsp` library to
+   `Fleche_lsp`; this should help avoiding conflicts with the OCaml
+   `lsp` library (@ejgallego, reported by @blackbird1128, #912, fixes
+   #861)
 
 # coq-lsp 0.2.2: To Virtual or not To Virtual
 ---------------------------------------------

--- a/compiler/dune
+++ b/compiler/dune
@@ -2,7 +2,7 @@
  (name fcc_lib)
  (modules :standard \ fcc)
  ; LSP is used to print diagnostics, etc...
- (libraries fleche lsp))
+ (libraries fleche fleche_lsp))
 
 (executable
  (public_name fcc)

--- a/compiler/output.ml
+++ b/compiler/output.ml
@@ -1,3 +1,5 @@
+module Lsp = Fleche_lsp
+
 let pp_diag fmt (d : Lang.Diagnostic.t) =
   Format.fprintf fmt "@[%a@]"
     (Yojson.Safe.pretty_print ~std:true)

--- a/controller-js/coq_lsp_worker.ml
+++ b/controller-js/coq_lsp_worker.ml
@@ -10,7 +10,7 @@
  *)
 
 module U = Yojson.Safe.Util
-module LSP = Lsp.Base
+module Lsp = Fleche_lsp
 open Js_of_ocaml
 open Controller
 

--- a/controller/dune
+++ b/controller/dune
@@ -1,7 +1,7 @@
 (library
  (name controller)
  (modules :standard \ coq_lsp)
- (libraries coq fleche petanque petanque_json lsp dune-build-info))
+ (libraries coq fleche petanque petanque_json fleche_lsp dune-build-info))
 
 (executable
  (name coq_lsp)

--- a/controller/lsp_core.mli
+++ b/controller/lsp_core.mli
@@ -15,6 +15,8 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
+module Lsp = Fleche_lsp
+
 (** This is the platform-independent code for the implementation of the Flèche
     LSP interface, BEWARE of deps, this must be able to run in a Web Worker
     context *)

--- a/controller/rq_action.ml
+++ b/controller/rq_action.ml
@@ -1,3 +1,13 @@
+(************************************************************************)
+(* Coq Language Server Protocol -- Requests                             *)
+(* Copyright 2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2019-2024 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2024-2025 Emilio J. Gallego Arias -- LGPL 2.1 / GPL3+      *)
+(* Written by: Emilio J. Gallego Arias                                  *)
+(************************************************************************)
+
+module Lsp = Fleche_lsp
+
 let point_lt { Lang.Point.line = l1; Lang.Point.character = c1; offset = _ }
     { Lang.Point.line = l2; Lang.Point.character = c2; offset = _ } =
   l1 < l2 || (l1 = l2 && c1 < c2)

--- a/controller/rq_completion.ml
+++ b/controller/rq_completion.ml
@@ -15,7 +15,7 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-open Lsp.Core
+open Fleche_lsp.Core
 
 let mk_completion ~label ?insertText ?labelDetails ?textEdit ?commitCharacters
     () =

--- a/controller/rq_definition.ml
+++ b/controller/rq_definition.ml
@@ -5,6 +5,8 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
+open Fleche_lsp.Core
+
 let get_from_toc ~doc id_at_point =
   let { Fleche.Doc.toc; _ } = doc in
   Fleche.Io.Log.trace "rq_definition" "get_from_toc";
@@ -12,7 +14,7 @@ let get_from_toc ~doc id_at_point =
   | Some node ->
     let uri = doc.uri in
     let range = node.range in
-    Some Lsp.Core.Location.{ uri; range }
+    Some Location.{ uri; range }
   | None -> None
 
 let lp_to_string = function
@@ -31,8 +33,7 @@ let find_name_in dp name =
     let uri = Coq.Module.uri mod_ in
     match Coq.Module.find mod_ name with
     | Error err -> Error (err_code, err)
-    | Ok range ->
-      Ok (Option.map (fun range -> Lsp.Core.Location.{ uri; range }) range))
+    | Ok range -> Ok (Option.map (fun range -> Location.{ uri; range }) range))
 
 let get_from_file id_at_point =
   Fleche.Io.Log.trace "rq_definition" "get_from_file";
@@ -63,7 +64,7 @@ let get_from_import require_at_point =
       let uri = Coq.Module.uri mod_ in
       let start = Lang.Point.{ line = 0; character = 0; offset = 0 } in
       let range = Lang.Range.{ start; end_ = start } in
-      Some Lsp.Core.Location.{ uri; range })
+      Some Location.{ uri; range })
   | Error _ -> None
 
 let get_from_file_or_import ~token ~st id_at_point =
@@ -94,8 +95,7 @@ let request ~token ~(doc : Fleche.Doc.t) ~point =
                get_from_file_or_import ~token ~st idp)
              (ok None))
     (ok None) idp
-  |> Coq.Protect.E.map
-       ~f:(Result.map (Option.cata Lsp.Core.Location.to_yojson `Null))
+  |> Coq.Protect.E.map ~f:(Result.map (Option.cata Location.to_yojson `Null))
 
 let request ~token ~doc ~point =
   let name = "textDocument/definition" in

--- a/controller/rq_document.ml
+++ b/controller/rq_document.ml
@@ -5,13 +5,15 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
+module JFleche = Fleche_lsp.JFleche
+
 let to_span { Fleche.Doc.Node.range; ast; _ } =
   let span = Option.map (fun { Fleche.Doc.Node.Ast.v; _ } -> v) ast in
-  Lsp.JFleche.RangedSpan.{ range; span }
+  JFleche.RangedSpan.{ range; span }
 
 let to_completed = function
   | Fleche.Doc.Completion.Yes range ->
-    { Lsp.JFleche.CompletionStatus.status = `Yes; range }
+    { JFleche.CompletionStatus.status = `Yes; range }
   | Stopped range -> { status = `Stopped; range }
   | Failed range -> { status = `Failed; range }
 
@@ -19,4 +21,4 @@ let request ~token:_ ~doc =
   let { Fleche.Doc.nodes; completed; _ } = doc in
   let spans = List.map to_span nodes in
   let completed = to_completed completed in
-  Lsp.JFleche.FlecheDocument.({ spans; completed } |> to_yojson) |> Result.ok
+  JFleche.FlecheDocument.({ spans; completed } |> to_yojson) |> Result.ok

--- a/controller/rq_goals.ml
+++ b/controller/rq_goals.ml
@@ -5,6 +5,8 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
+module Lsp = Fleche_lsp
+
 (* Replace by ppx when we can print goals properly in the client *)
 let mk_message (level, { Coq.Message.Payload.range; msg; quickFix = _ }) =
   Lsp.JFleche.Message.{ range; level; text = msg }

--- a/controller/rq_hover.ml
+++ b/controller/rq_hover.ml
@@ -1,11 +1,11 @@
 (************************************************************************)
 (* Coq Language Server Protocol -- Requests                             *)
 (* Copyright 2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
-(* Copyright 2019-2023 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2019-2024 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-open Lsp.Core
+open Fleche_lsp.Core
 
 (* Taken from printmod.ml, funny stuff! *)
 let build_ind_type mip = Inductive.type_of_inductive mip

--- a/controller/rq_init.ml
+++ b/controller/rq_init.ml
@@ -7,6 +7,7 @@
 
 module U = Yojson.Safe.Util
 module L = Fleche.Io.Log
+module Lsp = Fleche_lsp
 
 (* Conditionals *)
 let option_default x d =

--- a/controller/rq_lens.ml
+++ b/controller/rq_lens.ml
@@ -5,6 +5,8 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
+module Lsp = Fleche_lsp
+
 let command ~point =
   let arguments = Some [ Lsp.JLang.Point.to_yojson point ] in
   Lsp.Core.Command.

--- a/controller/rq_selectionRange.ml
+++ b/controller/rq_selectionRange.ml
@@ -15,6 +15,8 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
+module Lsp = Fleche_lsp
+
 let point_to_result ~doc ((line, character) as point) =
   let approx = Fleche.Info.Exact in
   let range =

--- a/controller/rq_symbols.ml
+++ b/controller/rq_symbols.ml
@@ -5,6 +5,8 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
+module Lsp = Fleche_lsp
+
 let rec mk_syminfo info =
   let Lang.Ast.Info.{ range; name; kind; detail; children } = info in
   let { Lang.With_range.range = selectionRange; v = name } = name in

--- a/fleche/doc.ml
+++ b/fleche/doc.ml
@@ -2,6 +2,7 @@
 (* Flèche => document manager: Document                                 *)
 (* Copyright 2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
 (* Copyright 2019-2023 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2024-2025 Emilio J. Gallego Arias -- LGPL 2.1 / GPL3+      *)
 (* Written by: Emilio J. Gallego Arias & coq-lsp contributors           *)
 (************************************************************************)
 

--- a/fleche/doc.mli
+++ b/fleche/doc.mli
@@ -2,6 +2,7 @@
 (* Flèche => document manager: Document                                 *)
 (* Copyright 2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
 (* Copyright 2019-2024 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2024-2025 Emilio J. Gallego Arias -- LGPL 2.1 / GPL3+      *)
 (* Written by: Emilio J. Gallego Arias & coq-lsp contributors           *)
 (************************************************************************)
 

--- a/lsp/dune
+++ b/lsp/dune
@@ -1,5 +1,5 @@
 (library
- (name lsp)
+ (name fleche_lsp)
  (public_name coq-lsp.lsp)
  (preprocess
   (staged_pps ppx_import ppx_deriving_yojson))

--- a/petanque/json/dune
+++ b/petanque/json/dune
@@ -3,4 +3,4 @@
  (public_name coq-lsp.petanque.json)
  (preprocess
   (staged_pps ppx_import ppx_deriving_yojson))
- (libraries lsp petanque))
+ (libraries fleche_lsp petanque))

--- a/petanque/json/jAgent.ml
+++ b/petanque/json/jAgent.ml
@@ -1,4 +1,5 @@
 (* Serialization for agent types *)
+module Lsp = Fleche_lsp
 
 (* Implement State.t and Env.t serialization methods *)
 module State = Obj_map.Make (Petanque.Agent.State)

--- a/petanque/json/protocol.ml
+++ b/petanque/json/protocol.ml
@@ -2,6 +2,7 @@ open Lang
 open Petanque
 
 (* Serialization for agent types *)
+module Lsp = Fleche_lsp
 open JAgent
 
 (* RPC-side server mappings, internal; we could split this in a different module

--- a/petanque/json_shell/client.ml
+++ b/petanque/json_shell/client.ml
@@ -1,3 +1,4 @@
+module Lsp = Fleche_lsp
 open Petanque_json
 
 (* Client wrap *)

--- a/petanque/json_shell/dune
+++ b/petanque/json_shell/dune
@@ -4,7 +4,7 @@
  (modules :standard \ pet server)
  (preprocess
   (staged_pps ppx_import ppx_deriving_yojson))
- (libraries lsp petanque petanque_json))
+ (libraries petanque petanque_json))
 
 (executable
  (name pet)

--- a/petanque/json_shell/interp_shell.ml
+++ b/petanque/json_shell/interp_shell.ml
@@ -4,6 +4,7 @@
 (* Copyright 2019-2024 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
 (************************************************************************)
 
+module Lsp = Fleche_lsp
 open Petanque_json.Interp
 open Protocol_shell
 

--- a/petanque/json_shell/interp_shell.mli
+++ b/petanque/json_shell/interp_shell.mli
@@ -4,6 +4,8 @@
 (* Copyright 2019-2024 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
 (************************************************************************)
 
+module Lsp = Fleche_lsp
+
 (* API for regular pet-server style shells *)
 type doc_handler =
      token:Coq.Limits.Token.t

--- a/petanque/json_shell/pet.ml
+++ b/petanque/json_shell/pet.ml
@@ -1,4 +1,5 @@
 (* json rpc server *)
+module Lsp = Fleche_lsp
 open Petanque_shell
 
 let use_http_headers = ref true

--- a/petanque/json_shell/protocol_shell.ml
+++ b/petanque/json_shell/protocol_shell.ml
@@ -5,6 +5,7 @@
 (* Written by: Emilio J. Gallego Arias & coq-lsp contributors           *)
 (************************************************************************)
 
+module Lsp = Fleche_lsp
 open Petanque_json
 
 (** [set_workspace { debug; root }] sets the current workspace to the directory

--- a/petanque/json_shell/server.ml
+++ b/petanque/json_shell/server.ml
@@ -1,6 +1,7 @@
 open Lwt
 open Lwt.Syntax
 open Petanque_shell
+module Lsp = Fleche_lsp
 
 let rq_info (r : Lsp.Base.Message.t) =
   match r with

--- a/petanque/test/dune
+++ b/petanque/test/dune
@@ -17,7 +17,7 @@
   %{bin:pet})
  (enabled_if
   (<> %{os_type} "Win32"))
- (libraries petanque petanque_shell lsp))
+ (libraries petanque petanque_shell fleche_lsp))
 
 (test
  (name json_api_failure)
@@ -29,4 +29,4 @@
   %{bin:pet})
  (enabled_if
   (<> %{os_type} "Win32"))
- (libraries petanque petanque_shell lsp))
+ (libraries petanque petanque_shell fleche_lsp))

--- a/plugins/astdump/main.ml
+++ b/plugins/astdump/main.ml
@@ -1,3 +1,12 @@
+(************************************************************************)
+(* Flèche / coq-lsp                                                     *)
+(* Copyright 2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2019-2024 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2024-2025 Emilio J. Gallego Arias -- LGPL 2.1 / GPL3+      *)
+(* Written by: Emilio J. Gallego Arias & coq-lsp contributors           *)
+(************************************************************************)
+
+module Lsp = Fleche_lsp
 open Fleche
 
 let pp_json fmt (ast : Doc.Node.Ast.t) =

--- a/plugins/goaldump/main.ml
+++ b/plugins/goaldump/main.ml
@@ -1,3 +1,4 @@
+module Lsp = Fleche_lsp
 open Fleche
 
 (* Put these in an utility function for plugins *)


### PR DESCRIPTION
This should help avoiding conflicts with the OCaml `lsp` library

Fixes #861 , reported by @blackbird1128 (thanks!!)