### PR TITLE
[coq] [workspace] Remove machinery for old-style manual ML path handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,11 @@
    `Fleche_lsp`; this should help avoiding conflicts with the OCaml
    `lsp` library (@ejgallego, reported by @blackbird1128, #912, fixes
    #861)
+ - [workspace] Remove support legacy ML-search path semantics. These
+   were basically unused since Coq 8.16. As a consequence, `coq-lsp` /
+   `fcc` don't accept the `-I` flag anymore, use `OCAMLPATH` or the
+   `--ocamlpath=` option to pass extra `findlib` paths. We still
+   respect the -I flag in `_CoqMakefile` (@ejgallego, #916)
 
 # coq-lsp 0.2.2: To Virtual or not To Virtual
 ---------------------------------------------

--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -16,6 +16,7 @@ let sanitize_paths message =
   | None -> message
   | Some _ ->
     message
+    |> replace_test_path "findlib: "
     |> replace_test_path "coqlib is at: "
     |> replace_test_path "coqcorelib is at: "
     |> replace_test_path "findlib config: "

--- a/compiler/fcc.ml
+++ b/compiler/fcc.ml
@@ -2,19 +2,16 @@
 open Cmdliner
 open Fcc_lib
 
-let fcc_main int_backend roots display debug plugins files coqlib coqcorelib
-    findlib_config ocamlpath rload_path load_path require_libraries no_vo
-    max_errors coq_diags_level =
+let fcc_main int_backend roots display debug plugins files coqlib findlib_config
+    ocamlpath rload_path load_path require_libraries no_vo max_errors
+    coq_diags_level =
   let vo_load_path = rload_path @ load_path in
-  let ml_include_path = [] in
   let args = [] in
   let cmdline =
     { Coq.Workspace.CmdLine.coqlib
-    ; coqcorelib
     ; findlib_config
     ; ocamlpath
     ; vo_load_path
-    ; ml_include_path
     ; args
     ; require_libraries
     }
@@ -101,8 +98,8 @@ let fcc_cmd : int Cmd.t =
     let open Coq.Args in
     Term.(
       const fcc_main $ int_backend $ roots $ display $ debug $ plugins $ file
-      $ coqlib $ coqcorelib $ findlib_config $ ocamlpath $ rload_paths
-      $ qload_paths $ ri_from $ no_vo $ max_errors $ coq_diags_level)
+      $ coqlib $ findlib_config $ ocamlpath $ rload_paths $ qload_paths
+      $ ri_from $ no_vo $ max_errors $ coq_diags_level)
   in
   let exits = Exit_codes.[ fatal; stopped; scheduled; uri_failed ] in
   Cmd.(v (Cmd.info "fcc" ~exits ~version ~doc ~man) fcc_term)

--- a/controller-js/coq_lsp_worker.ml
+++ b/controller-js/coq_lsp_worker.ml
@@ -171,11 +171,9 @@ let main () =
     let vo_load_path = List.map (fun f -> f coqlib) [ stdlib; user_contrib ] in
     Coq.Workspace.CmdLine.
       { coqlib
-      ; coqcorelib = "/static/lib/rocq-runtime" (* deprecated upstream *)
       ; findlib_config
       ; ocamlpath
       ; vo_load_path
-      ; ml_include_path = []
       ; require_libraries = [ (None, "Corelib.Init.Prelude") ]
       ; args = [ "-noinit"; "-boot" ]
       }

--- a/controller/coq_lsp.ml
+++ b/controller/coq_lsp.ml
@@ -81,8 +81,8 @@ let rec lsp_init_loop ~io ~ifn ~ofn ~cmdline ~debug =
     L.trace "read_request" "error: %s" err;
     lsp_init_loop ~io ~ifn ~ofn ~cmdline ~debug
 
-let lsp_main bt coqcorelib coqlib findlib_config ocamlpath vo_load_path
-    ml_include_path require_libraries delay int_backend =
+let lsp_main bt coqlib findlib_config ocamlpath vo_load_path require_libraries
+    delay int_backend =
   Coq.Limits.select_best int_backend;
   Coq.Limits.start ();
 
@@ -112,12 +112,10 @@ let lsp_main bt coqcorelib coqlib findlib_config ocamlpath vo_load_path
   let debug = bt || Fleche.Debug.backtraces in
   let root_state = coq_init ~debug in
   let cmdline =
-    { Coq.Workspace.CmdLine.coqcorelib
-    ; coqlib
+    { Coq.Workspace.CmdLine.coqlib
     ; findlib_config
     ; ocamlpath
     ; vo_load_path
-    ; ml_include_path
     ; args = []
     ; require_libraries
     }
@@ -201,8 +199,8 @@ let lsp_cmd : unit Cmd.t =
     v
       (Cmd.info "coq-lsp" ~version:Fleche.Version.server ~doc ~man)
       Term.(
-        const lsp_main $ bt $ coqcorelib $ coqlib $ findlib_config $ ocamlpath
-        $ vo_load_path $ ml_include_path $ ri_from $ delay $ int_backend))
+        const lsp_main $ bt $ coqlib $ findlib_config $ ocamlpath $ vo_load_path
+        $ ri_from $ delay $ int_backend))
 
 let main () =
   let ecode = Cmd.eval lsp_cmd in

--- a/coq/args.ml
+++ b/coq/args.ml
@@ -17,13 +17,6 @@ let coqlib =
   Arg.(
     value & opt string Coq_config.coqlib & info [ "coqlib" ] ~docv:"COQLIB" ~doc)
 
-let coqcorelib =
-  let doc = "Path to Coq plugin directories." in
-  Arg.(
-    value
-    & opt string (Filename.concat Coq_config.coqlib "../rocq-runtime/")
-    & info [ "rocqcorelib" ] ~docv:"COQCORELIB" ~doc)
-
 let findlib_config =
   let doc = "Override findlib's config file" in
   Arg.(
@@ -71,11 +64,6 @@ let debug : bool Term.t =
 let bt =
   let doc = "Enable backtraces" in
   Cmdliner.Arg.(value & flag & info [ "bt" ] ~doc)
-
-let ml_include_path : string list Term.t =
-  let doc = "Include DIR in default loadpath, for locating ML files" in
-  Arg.(
-    value & opt_all dir [] & info [ "I"; "ml-include-path" ] ~docv:"DIR" ~doc)
 
 let ri_from : (string option * string) list Term.t =
   let doc =

--- a/coq/args.mli
+++ b/coq/args.mli
@@ -8,14 +8,12 @@
 open Cmdliner
 
 val coqlib : String.t Term.t
-val coqcorelib : String.t Term.t
 val findlib_config : String.t option Term.t
 val ocamlpath : String.t list Term.t
 val rload_paths : Loadpath.vo_path List.t Term.t
 val qload_paths : Loadpath.vo_path List.t Term.t
 val debug : Bool.t Term.t
 val bt : Bool.t Term.t
-val ml_include_path : string list Term.t
 val ri_from : (string option * string) list Term.t
 val int_backend : Limits.backend option Term.t
 val roots : string list Term.t

--- a/coq/workspace.mli
+++ b/coq/workspace.mli
@@ -44,11 +44,11 @@ end
 
 (* Generated from a _CoqProject, dune (in the future) or command line args *)
 type t = private
-  { coqlib : string
-  ; findlib_config :
-      string option (* Path to findlib config file, if [None], default *)
-  ; ocamlpath :
-      string list (* extra ocamlpath paths, for example for local plugins *)
+  { coqlib : string  (** Path to coqlib *)
+  ; findlib_config : string option
+        (** Path to findlib config file, if [None], default *)
+  ; ocamlpath : string list
+        (** extra ocamlpath paths, for example for local plugins *)
   ; vo_load_path : Loadpath.vo_path list
         (** List of -R / -Q flags passed to Coq, usually theories we depend on *)
   ; require_libs : Require.t list
@@ -68,7 +68,9 @@ val compare : t -> t -> int
 (** hash *)
 val hash : t -> int
 
-(** user message, debug extra data *)
+(** [describe w] return [user, extra], where [user] is the relevant user
+    message, and [extra] contains lower-level debug data such as all findlib
+    packages in scope, etc... data *)
 val describe : t -> string * string
 
 val describe_guess : (t, string) Result.t -> string * string

--- a/coq/workspace.mli
+++ b/coq/workspace.mli
@@ -45,16 +45,12 @@ end
 (* Generated from a _CoqProject, dune (in the future) or command line args *)
 type t = private
   { coqlib : string
-  ; coqcorelib : string
   ; findlib_config :
       string option (* Path to findlib config file, if [None], default *)
   ; ocamlpath :
       string list (* extra ocamlpath paths, for example for local plugins *)
   ; vo_load_path : Loadpath.vo_path list
         (** List of -R / -Q flags passed to Coq, usually theories we depend on *)
-  ; ml_include_path : string list
-        (** List of paths to look for Coq plugins, deprecated in favor of
-            findlib *)
   ; require_libs : Require.t list
         (** Modules to preload, usually Coq.Init.Prelude *)
   ; flags : Flags.t  (** Coq-specific flags *)
@@ -80,11 +76,9 @@ val describe_guess : (t, string) Result.t -> string * string
 module CmdLine : sig
   type t =
     { coqlib : string
-    ; coqcorelib : string
     ; findlib_config : string option
     ; ocamlpath : string list
     ; vo_load_path : Loadpath.vo_path list
-    ; ml_include_path : string list
     ; args : string list
     ; require_libraries : (string option * string) list  (** Library, From *)
     }

--- a/petanque/json_shell/shell.ml
+++ b/petanque/json_shell/shell.ml
@@ -6,11 +6,9 @@ let init_coq ~debug =
 
 let cmdline : Coq.Workspace.CmdLine.t =
   { coqlib = Coq_config.coqlib
-  ; coqcorelib = Filename.concat Coq_config.coqlib "../rocq-runtime"
   ; findlib_config = None
   ; ocamlpath = []
   ; vo_load_path = []
-  ; ml_include_path = []
   ; args = []
   ; require_libraries = []
   }

--- a/test/compiler/basic/run.t
+++ b/test/compiler/basic/run.t
@@ -5,9 +5,8 @@ Describe the project
   $ fcc --root proj1
   [message] Configuration loaded from Command-line arguments
    - coqlib is at: [TEST_PATH]
-     + coqcorelib is at: [TEST_PATH]
    - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 2 Coq path directory bindings in scope; 27 Coq plugin directory bindings in scope
+   - 2 Coq path directory bindings in scope
    - ocamlpath added paths: []
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]
@@ -16,9 +15,8 @@ Compile a single file, don't generate a `.vo` file:
   $ fcc --no_vo --root proj1 proj1/a.v
   [message] Configuration loaded from Command-line arguments
    - coqlib is at: [TEST_PATH]
-     + coqcorelib is at: [TEST_PATH]
    - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 2 Coq path directory bindings in scope; 27 Coq plugin directory bindings in scope
+   - 2 Coq path directory bindings in scope
    - ocamlpath added paths: []
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]
@@ -32,9 +30,8 @@ Compile a single file, generate a .vo file
   $ fcc --root proj1 proj1/a.v
   [message] Configuration loaded from Command-line arguments
    - coqlib is at: [TEST_PATH]
-     + coqcorelib is at: [TEST_PATH]
    - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 2 Coq path directory bindings in scope; 27 Coq plugin directory bindings in scope
+   - 2 Coq path directory bindings in scope
    - ocamlpath added paths: []
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]
@@ -52,9 +49,8 @@ Compile a dependent file
   $ fcc --root proj1 proj1/b.v
   [message] Configuration loaded from Command-line arguments
    - coqlib is at: [TEST_PATH]
-     + coqcorelib is at: [TEST_PATH]
    - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 2 Coq path directory bindings in scope; 27 Coq plugin directory bindings in scope
+   - 2 Coq path directory bindings in scope
    - ocamlpath added paths: []
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]
@@ -72,9 +68,8 @@ Compile both files
   $ fcc --root proj1 proj1/a.v proj1/b.v
   [message] Configuration loaded from Command-line arguments
    - coqlib is at: [TEST_PATH]
-     + coqcorelib is at: [TEST_PATH]
    - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 2 Coq path directory bindings in scope; 27 Coq plugin directory bindings in scope
+   - 2 Coq path directory bindings in scope
    - ocamlpath added paths: []
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]
@@ -93,9 +88,8 @@ Compile a dependent file without the dep being built
   $ fcc --root proj1 proj1/b.v
   [message] Configuration loaded from Command-line arguments
    - coqlib is at: [TEST_PATH]
-     + coqcorelib is at: [TEST_PATH]
    - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 2 Coq path directory bindings in scope; 27 Coq plugin directory bindings in scope
+   - 2 Coq path directory bindings in scope
    - ocamlpath added paths: []
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]
@@ -130,9 +124,8 @@ Compile a file with all messages:
   $ fcc --root proj1 --diags_level=1 proj1/a.v
   [message] Configuration loaded from Command-line arguments
    - coqlib is at: [TEST_PATH]
-     + coqcorelib is at: [TEST_PATH]
    - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 2 Coq path directory bindings in scope; 27 Coq plugin directory bindings in scope
+   - 2 Coq path directory bindings in scope
    - ocamlpath added paths: []
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]
@@ -141,9 +134,8 @@ Compile a file with all messages:
   $ fcc --root proj1 --diags_level=2 proj1/a.v
   [message] Configuration loaded from Command-line arguments
    - coqlib is at: [TEST_PATH]
-     + coqcorelib is at: [TEST_PATH]
    - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 2 Coq path directory bindings in scope; 27 Coq plugin directory bindings in scope
+   - 2 Coq path directory bindings in scope
    - ocamlpath added paths: []
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]
@@ -171,17 +163,15 @@ Use two workspaces
   $ fcc --root proj1 --root proj2 proj1/a.v proj2/b.v
   [message] Configuration loaded from Command-line arguments
    - coqlib is at: [TEST_PATH]
-     + coqcorelib is at: [TEST_PATH]
    - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 2 Coq path directory bindings in scope; 27 Coq plugin directory bindings in scope
+   - 2 Coq path directory bindings in scope
    - ocamlpath added paths: []
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]
   [message] Configuration loaded from Command-line arguments
    - coqlib is at: [TEST_PATH]
-     + coqcorelib is at: [TEST_PATH]
    - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 2 Coq path directory bindings in scope; 27 Coq plugin directory bindings in scope
+   - 2 Coq path directory bindings in scope
    - ocamlpath added paths: []
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]
@@ -196,9 +186,8 @@ Load the example plugin
   $ fcc --plugin=coq-lsp.plugin.example --root proj1 proj1/a.v
   [message] Configuration loaded from Command-line arguments
    - coqlib is at: [TEST_PATH]
-     + coqcorelib is at: [TEST_PATH]
    - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 2 Coq path directory bindings in scope; 27 Coq plugin directory bindings in scope
+   - 2 Coq path directory bindings in scope
    - ocamlpath added paths: []
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]
@@ -209,9 +198,8 @@ Load the astdump plugin
   $ fcc --plugin=coq-lsp.plugin.astdump --root proj1 proj1/a.v
   [message] Configuration loaded from Command-line arguments
    - coqlib is at: [TEST_PATH]
-     + coqcorelib is at: [TEST_PATH]
    - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 2 Coq path directory bindings in scope; 27 Coq plugin directory bindings in scope
+   - 2 Coq path directory bindings in scope
    - ocamlpath added paths: []
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]
@@ -234,9 +222,8 @@ We do the same for the goaldump plugin:
   $ fcc --plugin=coq-lsp.plugin.goaldump --root proj1 proj1/a.v
   [message] Configuration loaded from Command-line arguments
    - coqlib is at: [TEST_PATH]
-     + coqcorelib is at: [TEST_PATH]
    - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 2 Coq path directory bindings in scope; 27 Coq plugin directory bindings in scope
+   - 2 Coq path directory bindings in scope
    - ocamlpath added paths: []
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]

--- a/test/compiler/basic/run.t
+++ b/test/compiler/basic/run.t
@@ -4,22 +4,22 @@ Describe the project
   $ export FCC_TEST=true
   $ fcc --root proj1
   [message] Configuration loaded from Command-line arguments
-   - coqlib is at: [TEST_PATH]
-   - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 2 Coq path directory bindings in scope
-   - ocamlpath added paths: []
+   - findlib: [TEST_PATH]
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]
+   - coqlib is at: [TEST_PATH]
+     + 2 Coq path directory bindings in scope
+     + Modules [Corelib.Init.Prelude] will be loaded by default
 
 Compile a single file, don't generate a `.vo` file:
   $ fcc --no_vo --root proj1 proj1/a.v
   [message] Configuration loaded from Command-line arguments
-   - coqlib is at: [TEST_PATH]
-   - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 2 Coq path directory bindings in scope
-   - ocamlpath added paths: []
+   - findlib: [TEST_PATH]
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]
+   - coqlib is at: [TEST_PATH]
+     + 2 Coq path directory bindings in scope
+     + Modules [Corelib.Init.Prelude] will be loaded by default
   [message] compiling file proj1/a.v
   $ ls proj1
   a.diags
@@ -29,12 +29,12 @@ Compile a single file, don't generate a `.vo` file:
 Compile a single file, generate a .vo file
   $ fcc --root proj1 proj1/a.v
   [message] Configuration loaded from Command-line arguments
-   - coqlib is at: [TEST_PATH]
-   - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 2 Coq path directory bindings in scope
-   - ocamlpath added paths: []
+   - findlib: [TEST_PATH]
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]
+   - coqlib is at: [TEST_PATH]
+     + 2 Coq path directory bindings in scope
+     + Modules [Corelib.Init.Prelude] will be loaded by default
   [message] compiling file proj1/a.v
   $ ls proj1
   a.diags
@@ -48,12 +48,12 @@ Compile a single file, silent
 Compile a dependent file
   $ fcc --root proj1 proj1/b.v
   [message] Configuration loaded from Command-line arguments
-   - coqlib is at: [TEST_PATH]
-   - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 2 Coq path directory bindings in scope
-   - ocamlpath added paths: []
+   - findlib: [TEST_PATH]
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]
+   - coqlib is at: [TEST_PATH]
+     + 2 Coq path directory bindings in scope
+     + Modules [Corelib.Init.Prelude] will be loaded by default
   [message] compiling file proj1/b.v
   $ ls proj1
   a.diags
@@ -67,12 +67,12 @@ Compile both files
   $ rm proj1/*.vo
   $ fcc --root proj1 proj1/a.v proj1/b.v
   [message] Configuration loaded from Command-line arguments
-   - coqlib is at: [TEST_PATH]
-   - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 2 Coq path directory bindings in scope
-   - ocamlpath added paths: []
+   - findlib: [TEST_PATH]
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]
+   - coqlib is at: [TEST_PATH]
+     + 2 Coq path directory bindings in scope
+     + Modules [Corelib.Init.Prelude] will be loaded by default
   [message] compiling file proj1/a.v
   [message] compiling file proj1/b.v
   $ ls proj1
@@ -87,12 +87,12 @@ Compile a dependent file without the dep being built
   $ rm proj1/*.vo
   $ fcc --root proj1 proj1/b.v
   [message] Configuration loaded from Command-line arguments
-   - coqlib is at: [TEST_PATH]
-   - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 2 Coq path directory bindings in scope
-   - ocamlpath added paths: []
+   - findlib: [TEST_PATH]
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]
+   - coqlib is at: [TEST_PATH]
+     + 2 Coq path directory bindings in scope
+     + Modules [Corelib.Init.Prelude] will be loaded by default
   [message] compiling file proj1/b.v
   $ ls proj1
   a.diags
@@ -123,22 +123,22 @@ Compile a file with all messages:
   $ rm -f proj1/a.{diags,vo}
   $ fcc --root proj1 --diags_level=1 proj1/a.v
   [message] Configuration loaded from Command-line arguments
-   - coqlib is at: [TEST_PATH]
-   - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 2 Coq path directory bindings in scope
-   - ocamlpath added paths: []
+   - findlib: [TEST_PATH]
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]
+   - coqlib is at: [TEST_PATH]
+     + 2 Coq path directory bindings in scope
+     + Modules [Corelib.Init.Prelude] will be loaded by default
   [message] compiling file proj1/a.v
   $ cat proj1/a.diags
   $ fcc --root proj1 --diags_level=2 proj1/a.v
   [message] Configuration loaded from Command-line arguments
-   - coqlib is at: [TEST_PATH]
-   - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 2 Coq path directory bindings in scope
-   - ocamlpath added paths: []
+   - findlib: [TEST_PATH]
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]
+   - coqlib is at: [TEST_PATH]
+     + 2 Coq path directory bindings in scope
+     + Modules [Corelib.Init.Prelude] will be loaded by default
   [message] compiling file proj1/a.v
   $ cat proj1/a.diags
   {
@@ -162,19 +162,19 @@ Use two workspaces
   $ rm proj1/*.vo
   $ fcc --root proj1 --root proj2 proj1/a.v proj2/b.v
   [message] Configuration loaded from Command-line arguments
-   - coqlib is at: [TEST_PATH]
-   - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 2 Coq path directory bindings in scope
-   - ocamlpath added paths: []
+   - findlib: [TEST_PATH]
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]
+   - coqlib is at: [TEST_PATH]
+     + 2 Coq path directory bindings in scope
+     + Modules [Corelib.Init.Prelude] will be loaded by default
   [message] Configuration loaded from Command-line arguments
-   - coqlib is at: [TEST_PATH]
-   - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 2 Coq path directory bindings in scope
-   - ocamlpath added paths: []
+   - findlib: [TEST_PATH]
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]
+   - coqlib is at: [TEST_PATH]
+     + 2 Coq path directory bindings in scope
+     + Modules [Corelib.Init.Prelude] will be loaded by default
   [message] compiling file proj1/a.v
   [message] compiling file proj2/b.v
   fcc: internal error, uncaught exception:
@@ -185,24 +185,24 @@ Use two workspaces
 Load the example plugin
   $ fcc --plugin=coq-lsp.plugin.example --root proj1 proj1/a.v
   [message] Configuration loaded from Command-line arguments
-   - coqlib is at: [TEST_PATH]
-   - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 2 Coq path directory bindings in scope
-   - ocamlpath added paths: []
+   - findlib: [TEST_PATH]
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]
+   - coqlib is at: [TEST_PATH]
+     + 2 Coq path directory bindings in scope
+     + Modules [Corelib.Init.Prelude] will be loaded by default
   [message] compiling file proj1/a.v
   [message] [example plugin] file checking for proj1/a.v was completed
 
 Load the astdump plugin
   $ fcc --plugin=coq-lsp.plugin.astdump --root proj1 proj1/a.v
   [message] Configuration loaded from Command-line arguments
-   - coqlib is at: [TEST_PATH]
-   - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 2 Coq path directory bindings in scope
-   - ocamlpath added paths: []
+   - findlib: [TEST_PATH]
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]
+   - coqlib is at: [TEST_PATH]
+     + 2 Coq path directory bindings in scope
+     + Modules [Corelib.Init.Prelude] will be loaded by default
   [message] compiling file proj1/a.v
   [message] [ast plugin] dumping ast for proj1/a.v ...
   [message] [ast plugin] dumping ast for proj1/a.v was completed!
@@ -221,12 +221,12 @@ de-serialize the document back and check.
 We do the same for the goaldump plugin:
   $ fcc --plugin=coq-lsp.plugin.goaldump --root proj1 proj1/a.v
   [message] Configuration loaded from Command-line arguments
-   - coqlib is at: [TEST_PATH]
-   - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 2 Coq path directory bindings in scope
-   - ocamlpath added paths: []
+   - findlib: [TEST_PATH]
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]
+   - coqlib is at: [TEST_PATH]
+     + 2 Coq path directory bindings in scope
+     + Modules [Corelib.Init.Prelude] will be loaded by default
   [message] compiling file proj1/a.v
   [message] [goaldump plugin] dumping goals for proj1/a.v ...
   [message] [goaldump plugin] dumping ast for proj1/a.v was completed!

--- a/test/compiler/exit_code/run.t
+++ b/test/compiler/exit_code/run.t
@@ -5,12 +5,12 @@ Describe the environment:
   $ export FCC_ROOT=./
   $ fcc --root $FCC_ROOT
   [message] Configuration loaded from ./_CoqProject
-   - coqlib is at: [TEST_PATH]
-   - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 3 Coq path directory bindings in scope
-   - ocamlpath added paths: []
+   - findlib: [TEST_PATH]
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]
+   - coqlib is at: [TEST_PATH]
+     + 3 Coq path directory bindings in scope
+     + Modules [Corelib.Init.Prelude] will be loaded by default
 
 Compile normally, even with errors, we exit 0:
   $ fcc --display=quiet --no_vo --root $FCC_ROOT Demo.v

--- a/test/compiler/exit_code/run.t
+++ b/test/compiler/exit_code/run.t
@@ -6,9 +6,8 @@ Describe the environment:
   $ fcc --root $FCC_ROOT
   [message] Configuration loaded from ./_CoqProject
    - coqlib is at: [TEST_PATH]
-     + coqcorelib is at: [TEST_PATH]
    - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 3 Coq path directory bindings in scope; 27 Coq plugin directory bindings in scope
+   - 3 Coq path directory bindings in scope
    - ocamlpath added paths: []
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]

--- a/test/compiler/long_file/run.t
+++ b/test/compiler/long_file/run.t
@@ -8,10 +8,10 @@ Generate the test file (example by G. Gilbert)
 We now compile the challenging file:
   $ fcc --root . ./test.v
   [message] Configuration loaded from Command-line arguments
-   - coqlib is at: [TEST_PATH]
-   - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 2 Coq path directory bindings in scope
-   - ocamlpath added paths: []
+   - findlib: [TEST_PATH]
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]
+   - coqlib is at: [TEST_PATH]
+     + 2 Coq path directory bindings in scope
+     + Modules [Corelib.Init.Prelude] will be loaded by default
   [message] compiling file ./test.v

--- a/test/compiler/long_file/run.t
+++ b/test/compiler/long_file/run.t
@@ -9,9 +9,8 @@ We now compile the challenging file:
   $ fcc --root . ./test.v
   [message] Configuration loaded from Command-line arguments
    - coqlib is at: [TEST_PATH]
-     + coqcorelib is at: [TEST_PATH]
    - Modules [Corelib.Init.Prelude] will be loaded by default
-   - 2 Coq path directory bindings in scope; 27 Coq plugin directory bindings in scope
+   - 2 Coq path directory bindings in scope
    - ocamlpath added paths: []
      + findlib config: [TEST_PATH]
      + findlib default location: [TEST_PATH]


### PR DESCRIPTION
This is not needed since Coq 8.16, tho the old method wasn't removed until Rocq 9.