### PR TITLE
[lsp] Cleanup of LSP IO

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,9 @@
    `fcc` don't accept the `-I` flag anymore, use `OCAMLPATH` or the
    `--ocamlpath=` option to pass extra `findlib` paths. We still
    respect the -I flag in `_CoqMakefile` (@ejgallego, #916)
+ - [lsp] [debug] Respect `$/setTrace` call , refactor logging system,
+   and allow file logging of protocol traces again (@ejgallego, #919,
+   fixes #868)
 
 # coq-lsp 0.2.2: To Virtual or not To Virtual
 ---------------------------------------------

--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -23,8 +23,8 @@ let sanitize_paths message =
     |> replace_test_path "findlib default location: "
 
 let log_workspace ~io (dir, w) =
-  let message, extra = Coq.Workspace.describe_guess w in
-  Fleche.Io.Log.trace "workspace" ~extra "initialized %s" dir;
+  let message, verbose = Coq.Workspace.describe_guess w in
+  Fleche.Io.Log.trace "workspace" ~verbose "initialized %s" dir;
   Fleche.Io.Report.msg ~io ~lvl:Info "%s" (sanitize_paths message)
 
 let load_plugin plugin_name = Fl_dynload.load_packages [ plugin_name ]

--- a/compiler/output.ml
+++ b/compiler/output.ml
@@ -14,11 +14,11 @@ let fileProgress ~uri:_ ~version:_ _progress = ()
 
 (* We print trace and messages, and perfData summary *)
 module Fcc_verbose = struct
-  let trace hdr ?extra message =
+  let trace hdr ?verbose message =
     Format.(
       eprintf "[trace] {%s} %s %a@\n%!" hdr message
         (pp_print_option pp_print_string)
-        extra)
+        verbose)
 
   let message ~lvl:_ ~message = Format.(eprintf "[message] %s@\n%!" message)
 
@@ -40,9 +40,9 @@ module Fcc_verbose = struct
       }
 end
 
-(* We print trace, messages *)
+(* We don't print trace messages, we could also use set_trace_value *)
 module Fcc_normal = struct
-  let trace _ ?extra:_ _ = ()
+  let trace _ ?verbose:_ _ = ()
   let cb = { Fcc_verbose.cb with trace }
 end
 

--- a/controller/coq_lsp.ml
+++ b/controller/coq_lsp.ml
@@ -72,8 +72,43 @@ let rec lsp_init_loop ~io ~ifn ~ofn ~cmdline ~debug =
     L.trace "read_request" "error: %s" err;
     lsp_init_loop ~io ~ifn ~ofn ~cmdline ~debug
 
+(* File *)
+module Trace : sig
+  val setup : string -> unit
+  val cleanup : unit -> unit
+end = struct
+  let trace_oc = ref None
+
+  (* This is already called under a Mutex, so no need to care about sync here,
+     but beware *)
+  let log_fn oc hdr obj =
+    Format.fprintf oc "[%s] @[%a@]@\n%!" hdr
+      (Yojson.Safe.pretty_print ~std:false)
+      obj
+
+  let setup file =
+    try
+      let oc = open_out file in
+      let oc_fmt = Format.formatter_of_out_channel oc in
+      trace_oc := Some (oc, oc_fmt);
+      Lsp.Io.set_log_fn (log_fn oc_fmt)
+    with err ->
+      let msg = Printexc.to_string err in
+      Fleche.Io.Log.trace "Trace.setup"
+        "creation of server log file %s failed: @[%s@]" file msg
+
+  (* At exit cleanup *)
+  let cleanup () =
+    match !trace_oc with
+    | None -> ()
+    | Some (oc, oc_fmt) ->
+      Format.pp_print_flush oc_fmt ();
+      Stdlib.flush oc;
+      close_out oc
+end
+
 let lsp_main bt coqlib findlib_config ocamlpath vo_load_path require_libraries
-    delay int_backend =
+    delay int_backend lsp_trace lsp_trace_file =
   Coq.Limits.select_best int_backend;
   Coq.Limits.start ();
 
@@ -94,8 +129,11 @@ let lsp_main bt coqlib findlib_config ocamlpath vo_load_path require_libraries
   let io = CB.cb in
   Fleche.Io.CallBack.set io;
 
+  if lsp_trace then Trace.setup lsp_trace_file;
+
   (* IMPORTANT: LSP spec forbids any message from server to client before
-     initialize is received *)
+     initialize is received, [Trace.setup] violates that if there is an error
+     when creating the log file. *)
 
   (* Core Coq initialization *)
   let debug = bt || Fleche.Debug.backtraces in
@@ -150,7 +188,9 @@ let lsp_main bt coqlib findlib_config ocamlpath vo_load_path require_libraries
 
     read_loop ()
   with
-  | Lsp_exit -> Fleche.Io.Report.msg ~io ~lvl:Error "[LSP shutdown] EOF\n"
+  | Lsp_exit ->
+    Trace.cleanup ();
+    Fleche.Io.Report.msg ~io ~lvl:Error "[LSP shutdown] EOF\n"
   | exn ->
     let bt = Printexc.get_backtrace () in
     let exn, info = Exninfo.capture exn in
@@ -168,6 +208,17 @@ open Cmdliner
 let delay : float Term.t =
   let doc = "Delay value in seconds when server is idle" in
   Arg.(value & opt float 0.1 & info [ "D"; "idle-delay" ] ~docv:"DELAY" ~doc)
+
+let lsp_trace : bool Term.t =
+  let doc = "Trace LSP input / output" in
+  Arg.(value & flag & info [ "lsp_trace" ] ~docv:"ENABLED" ~doc)
+
+let lsp_trace_file : string Term.t =
+  let doc = "Name of the LSP log file $(docv)" in
+  let default_file = Format.asprintf "coq_lsp_log_%d.txt" (Unix.getpid ()) in
+  Arg.(
+    value & opt string default_file
+    & info [ "lsp_trace_file" ] ~docv:"TRACE_FILE" ~doc)
 
 let term_append l =
   Term.(List.(fold_right (fun t l -> const append $ t $ l) l (const [])))
@@ -188,7 +239,7 @@ let lsp_cmd : unit Cmd.t =
       (Cmd.info "coq-lsp" ~version:Fleche.Version.server ~doc ~man)
       Term.(
         const lsp_main $ bt $ coqlib $ findlib_config $ ocamlpath $ vo_load_path
-        $ ri_from $ delay $ int_backend))
+        $ ri_from $ delay $ int_backend $ lsp_trace $ lsp_trace_file))
 
 let main () =
   let ecode = Cmd.eval lsp_cmd in

--- a/controller/coq_lsp.ml
+++ b/controller/coq_lsp.ml
@@ -1,17 +1,8 @@
 (************************************************************************)
-(*         *   The Coq Proof Assistant / The Coq Development Team       *)
-(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
-(* <O___,, *       (see CREDITS file for the list of authors)           *)
-(*   \VV/  **************************************************************)
-(*    //   *    This file is distributed under the terms of the         *)
-(*         *     GNU Lesser General Public License Version 2.1          *)
-(*         *     (see LICENSE file for the text of the license)         *)
-(************************************************************************)
-
-(************************************************************************)
-(* Coq Language Server Protocol                                         *)
+(* Rocq Language Server Protocol                                        *)
 (* Copyright 2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
-(* Copyright 2019-2023 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2019-2024 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2024-2025 EJGA       -- Dual License LGPL 2.1 / GPL3+      *)
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
@@ -50,7 +41,7 @@ let concise_cb ofn =
       Lsp.Core.mk_diagnostics ~uri ~version diags |> ofn
   in
   Fleche.Io.CallBack.
-    { trace = (fun _hdr ?extra:_ _msg -> ())
+    { trace = (fun _hdr ?verbose:_ _msg -> ())
     ; message = (fun ~lvl:_ ~message:_ -> ())
     ; diagnostics
     ; fileProgress = (fun ~uri:_ ~version:_ _progress -> ())
@@ -97,8 +88,6 @@ let lsp_main bt coqlib findlib_config ocamlpath vo_load_path require_libraries
   let ofn message = Lsp.Io.send_message Format.std_formatter message in
   let ofn_ntn not = Lsp.Base.Message.notification not |> ofn in
 
-  Lsp.Io.set_log_fn ofn_ntn;
-
   let module CB = Lsp_core.CB (struct
     let ofn = ofn_ntn
   end) in
@@ -143,7 +132,6 @@ let lsp_main bt coqlib findlib_config ocamlpath vo_load_path require_libraries
       if !Fleche.Config.v.verbosity < 2 then (
         Fleche.Config.(
           v := { !v with send_diags = false; send_perf_data = false });
-        Lsp.Io.set_log_fn (fun _obj -> ());
         let io = concise_cb ofn_ntn in
         Fleche.Io.CallBack.set io;
         io)

--- a/controller/rq_init.ml
+++ b/controller/rq_init.ml
@@ -95,18 +95,18 @@ let determine_workspace_root ~io ~params =
 
 let get_trace ~params =
   match ostring_field "trace" params with
-  | None -> Lsp.Io.TraceValue.Off
+  | None -> Fleche.Io.TraceValue.Off
   | Some v -> (
-    match Lsp.Io.TraceValue.of_string v with
+    match Fleche.Io.TraceValue.of_string v with
     | Ok t -> t
     | Error e ->
       L.trace "trace" "invalid value: %s" e;
-      Lsp.Io.TraceValue.Off)
+      Fleche.Io.TraceValue.Off)
 
 let do_initialize ~io ~params =
   let dir = determine_workspace_root ~io ~params in
   let trace = get_trace ~params in
-  Lsp.Io.set_trace_value trace;
+  Fleche.Io.Log.set_trace_value trace;
   let coq_lsp_settings = odict_field "initializationOptions" params in
   do_settings coq_lsp_settings;
   check_client_version ~io !Fleche.Config.v.client_version;

--- a/fleche/debug.ml
+++ b/fleche/debug.ml
@@ -1,16 +1,20 @@
+(* This file controls what to trace, we need a better system. As of today, we
+   trace using LSP logging facilities, however this is not enough in two cases:
+
+   - logging of the raw protocol itself
+
+   - we don't have a way to filter what we log *)
+
 (* Enable all debug flags *)
 let all = false
 
-(* Enable LSP debug flags *)
+(* LSP trace flags are now controlled by an option that installs a logger, the
+   lsp_init flag should be removed *)
 let lsp = false
+let lsp_init = false || all || lsp
 
 (* cache *)
 let cache = false || all
-
-(* LSP messages: Send and receive *)
-let send = false || all || lsp
-let read = false || all || lsp
-let lsp_init = false || all || lsp
 
 (* Parsing (this is a bit expensive as it will call the printer *)
 let parsing = false || all

--- a/fleche/io.mli
+++ b/fleche/io.mli
@@ -1,3 +1,11 @@
+(************************************************************************)
+(* Rocq Language Server Protocol                                        *)
+(* Copyright 2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2019-2024 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2024-2025 EJGA       -- Dual License LGPL 2.1 / GPL3+      *)
+(* Written by: Emilio J. Gallego Arias                                  *)
+(************************************************************************)
+
 module Level : sig
   type t =
     | Error
@@ -9,9 +17,9 @@ end
 
 module CallBack : sig
   type t =
-    { trace : string -> ?extra:string -> string -> unit
-          (** Send a log message, [extra] may contain information to be shown in
-              verbose mode *)
+    { trace : string -> ?verbose:string -> string -> unit
+          (** Send a log message, [verbose] may contain information to be shown
+              in verbose mode *)
     ; message : lvl:Level.t -> message:string -> unit
           (** Send a user-visible message *)
     ; diagnostics :
@@ -26,13 +34,29 @@ module CallBack : sig
   val set : t -> unit
 end
 
-module Log : sig
-  (** Debug trace *)
-  val trace :
-    string -> ?extra:string -> ('a, Format.formatter, unit) format -> 'a
+(** {1 Imperative Tracing using a global [trace_fn]} *)
 
-  (** Raw LSP method *)
-  val trace_ : string -> ?extra:string -> string -> unit
+(** Trace values *)
+module TraceValue : sig
+  type t =
+    | Off
+    | Messages
+    | Verbose
+
+  val of_string : string -> (t, string) Result.t
+  val to_string : t -> string
+end
+
+module Log : sig
+  (** Set the trace value *)
+  val set_trace_value : TraceValue.t -> unit
+
+  (** [trace component ?verbose params] Debug trace, using printf *)
+  val trace :
+    string -> ?verbose:string -> ('a, Format.formatter, unit) format -> 'a
+
+  (** Direct string-based method *)
+  val trace_ : string -> ?verbose:string -> string -> unit
 
   (** Log JSON object to server info log *)
   val trace_object : string -> Yojson.Safe.t -> unit

--- a/lsp/base.ml
+++ b/lsp/base.ml
@@ -213,13 +213,25 @@ module MessageParams = struct
   [@@deriving yojson]
 end
 
-let mk_logMessage ~type_ ~message =
+let mk_logMessage_ ~type_ ~message =
   let module M = MessageParams in
   let method_ = M.method_ in
   let params =
     M.({ type_; message } |> to_yojson |> Yojson.Safe.Util.to_assoc)
   in
   Notification.make ~method_ ~params ()
+
+let lvl_to_int (lvl : Fleche.Io.Level.t) =
+  match lvl with
+  | Error -> 1
+  | Warning -> 2
+  | Info -> 3
+  | Log -> 4
+  | Debug -> 5
+
+let mk_logMessage ~lvl ~message =
+  let type_ = lvl_to_int lvl in
+  mk_logMessage_ ~type_ ~message
 
 module TraceParams = struct
   let method_ = "$/logTrace"

--- a/lsp/base.ml
+++ b/lsp/base.ml
@@ -201,3 +201,40 @@ end
 module WorkDoneProgressEnd = struct
   type t = { kind : string } [@@deriving to_yojson]
 end
+
+(* Messages *)
+module MessageParams = struct
+  let method_ = "window/logMessage"
+
+  type t =
+    { type_ : int [@key "type"]
+    ; message : string
+    }
+  [@@deriving yojson]
+end
+
+let mk_logMessage ~type_ ~message =
+  let module M = MessageParams in
+  let method_ = M.method_ in
+  let params =
+    M.({ type_; message } |> to_yojson |> Yojson.Safe.Util.to_assoc)
+  in
+  Notification.make ~method_ ~params ()
+
+module TraceParams = struct
+  let method_ = "$/logTrace"
+
+  type t =
+    { message : string
+    ; verbose : string option [@default None]
+    }
+  [@@deriving yojson]
+end
+
+let mk_logTrace ~message ~verbose =
+  let module M = TraceParams in
+  let method_ = M.method_ in
+  let params =
+    M.({ message; verbose } |> to_yojson |> Yojson.Safe.Util.to_assoc)
+  in
+  Notification.make ~method_ ~params ()

--- a/lsp/base.mli
+++ b/lsp/base.mli
@@ -135,8 +135,10 @@ module MessageParams : sig
   [@@deriving yojson]
 end
 
-(** Create a logMessage notification *)
-val mk_logMessage : type_:int -> message:string -> Notification.t
+(** Create a [logMessage] LSP notification *)
+val mk_logMessage_ : type_:int -> message:string -> Notification.t
+
+val mk_logMessage : lvl:Fleche.Io.Level.t -> message:string -> Notification.t
 
 module TraceParams : sig
   val method_ : string

--- a/lsp/base.mli
+++ b/lsp/base.mli
@@ -15,7 +15,8 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-(* XXX: EJGA This should be an structured value (object or array) *)
+(* XXX: EJGA In the LSP spec Params are either an structured value (object or
+   array) *)
 module Params : sig
   type t = (string * Yojson.Safe.t) list
 end
@@ -122,3 +123,30 @@ end
 module WorkDoneProgressEnd : sig
   type t = { kind : string } [@@deriving to_yojson]
 end
+
+(* Messages and Traces *)
+module MessageParams : sig
+  val method_ : string
+
+  type t =
+    { type_ : int [@key "type"]
+    ; message : string
+    }
+  [@@deriving yojson]
+end
+
+(** Create a logMessage notification *)
+val mk_logMessage : type_:int -> message:string -> Notification.t
+
+module TraceParams : sig
+  val method_ : string
+
+  type t =
+    { message : string
+    ; verbose : string option [@default None]
+    }
+  [@@deriving yojson]
+end
+
+(** Create a logTrace notification *)
+val mk_logTrace : message:string -> verbose:string option -> Notification.t

--- a/lsp/io.ml
+++ b/lsp/io.ml
@@ -1,24 +1,15 @@
 (************************************************************************)
-(*         *   The Coq Proof Assistant / The Coq Development Team       *)
-(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
-(* <O___,, *       (see CREDITS file for the list of authors)           *)
-(*   \VV/  **************************************************************)
-(*    //   *    This file is distributed under the terms of the         *)
-(*         *     GNU Lesser General Public License Version 2.1          *)
-(*         *     (see LICENSE file for the text of the license)         *)
-(************************************************************************)
-
-(************************************************************************)
-(* Coq Language Server Protocol                                         *)
+(* Rocq Language Server Protocol                                        *)
 (* Copyright 2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
-(* Copyright 2019-2022 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2019-2024 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2024-2025 EJGA       -- Dual License LGPL 2.1 / GPL3+      *)
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
 module F = Format
 module J = Yojson.Safe
 
-(** {1} JSON-RPC input/output *)
+(** {1 JSON-RPC input/output} *)
 
 (* This needs a fix as to log protocol stuff not using the protocol *)
 let log_protocol = ref (fun _ _ -> ())
@@ -78,62 +69,3 @@ let send_json fmt obj =
   Mutex.unlock mut
 
 let send_message fmt message = send_json fmt (Base.Message.to_yojson message)
-
-(** Logging *)
-let fn = ref (fun _ -> ())
-
-let set_log_fn f = fn := f
-
-module Lvl = struct
-  (* 1-5 *)
-  type t = Fleche.Io.Level.t =
-    | Error
-    | Warning
-    | Info
-    | Log
-    | Debug
-
-  let to_int = function
-    | Error -> 1
-    | Warning -> 2
-    | Info -> 3
-    | Log -> 4
-    | Debug -> 5
-end
-
-let logMessage ~lvl ~message =
-  let type_ = Lvl.to_int lvl in
-  Base.mk_logMessage ~type_ ~message |> !fn
-
-let logMessageInt ~lvl ~message = Base.mk_logMessage ~type_:lvl ~message |> !fn
-
-(** Trace *)
-module TraceValue = struct
-  type t =
-    | Off
-    | Messages
-    | Verbose
-
-  let of_string = function
-    | "messages" -> Ok Messages
-    | "verbose" -> Ok Verbose
-    | "off" -> Ok Off
-    | v -> Error ("TraceValue.parse: " ^ v)
-
-  let to_string = function
-    | Off -> "off"
-    | Messages -> "messages"
-    | Verbose -> "verbose"
-end
-
-let trace_value = ref TraceValue.Off
-let set_trace_value value = trace_value := value
-
-let logTrace ~message ~extra =
-  (* XXX Fix: respect trace_value = Off !! *)
-  let verbose =
-    match (!trace_value, extra) with
-    | Verbose, Some extra -> Some extra
-    | _ -> None
-  in
-  Base.mk_logTrace ~message ~verbose |> !fn

--- a/lsp/io.ml
+++ b/lsp/io.ml
@@ -18,8 +18,10 @@
 module F = Format
 module J = Yojson.Safe
 
-let fn = ref (fun _ -> ())
-let set_log_fn f = fn := f
+(** {1} JSON-RPC input/output *)
+
+(* This needs a fix as to log protocol stuff not using the protocol *)
+let log_protocol = ref (fun _ _ -> ())
 
 let read_raw_message ic =
   let cl = input_line ic in
@@ -53,14 +55,19 @@ let read_raw_message ic =
   (* if the format string is invalid. *)
   | Invalid_argument msg -> Some (Error msg)
 
-let mut = Mutex.create ()
+let read_message ic =
+  match read_raw_message ic with
+  | None -> None (* EOF *)
+  | Some (Ok com) ->
+    if Fleche.Debug.read then !log_protocol "read" com;
+    Some (Base.Message.of_yojson com)
+  | Some (Error err) -> Some (Error err)
 
-(* This needs a fix as to log protocol stuff not using the protocol *)
-let log = ref (fun _ _ -> ())
+let mut = Mutex.create ()
 
 let send_json fmt obj =
   Mutex.lock mut;
-  if Fleche.Debug.send then !log "send" obj;
+  if Fleche.Debug.send then !log_protocol "send" obj;
   let msg =
     if !Fleche.Config.v.pp_json then
       F.asprintf "%a" J.(pretty_print ~std:true) obj
@@ -73,7 +80,34 @@ let send_json fmt obj =
 let send_message fmt message = send_json fmt (Base.Message.to_yojson message)
 
 (** Logging *)
+let fn = ref (fun _ -> ())
 
+let set_log_fn f = fn := f
+
+module Lvl = struct
+  (* 1-5 *)
+  type t = Fleche.Io.Level.t =
+    | Error
+    | Warning
+    | Info
+    | Log
+    | Debug
+
+  let to_int = function
+    | Error -> 1
+    | Warning -> 2
+    | Info -> 3
+    | Log -> 4
+    | Debug -> 5
+end
+
+let logMessage ~lvl ~message =
+  let type_ = Lvl.to_int lvl in
+  Base.mk_logMessage ~type_ ~message |> !fn
+
+let logMessageInt ~lvl ~message = Base.mk_logMessage ~type_:lvl ~message |> !fn
+
+(** Trace *)
 module TraceValue = struct
   type t =
     | Off
@@ -95,80 +129,11 @@ end
 let trace_value = ref TraceValue.Off
 let set_trace_value value = trace_value := value
 
-module Lvl = struct
-  (* 1-5 *)
-  type t = Fleche.Io.Level.t =
-    | Error
-    | Warning
-    | Info
-    | Log
-    | Debug
-
-  let to_int = function
-    | Error -> 1
-    | Warning -> 2
-    | Info -> 3
-    | Log -> 4
-    | Debug -> 5
-end
-
-module MessageParams = struct
-  let method_ = "window/logMessage"
-
-  type t =
-    { type_ : int [@key "type"]
-    ; message : string
-    }
-  [@@deriving yojson]
-end
-
-let mk_logMessage ~type_ ~message =
-  let module M = MessageParams in
-  let method_ = M.method_ in
-  let params =
-    M.({ type_; message } |> to_yojson |> Yojson.Safe.Util.to_assoc)
-  in
-  Base.Notification.make ~method_ ~params ()
-
-let logMessage ~lvl ~message =
-  let type_ = Lvl.to_int lvl in
-  mk_logMessage ~type_ ~message |> !fn
-
-let logMessageInt ~lvl ~message = mk_logMessage ~type_:lvl ~message |> !fn
-
-module TraceParams = struct
-  let method_ = "$/logTrace"
-
-  type t =
-    { message : string
-    ; verbose : string option [@default None]
-    }
-  [@@deriving yojson]
-end
-
-let mk_logTrace ~message ~extra =
-  let module M = TraceParams in
-  let method_ = M.method_ in
+let logTrace ~message ~extra =
+  (* XXX Fix: respect trace_value = Off !! *)
   let verbose =
     match (!trace_value, extra) with
     | Verbose, Some extra -> Some extra
     | _ -> None
   in
-  let params =
-    M.({ message; verbose } |> to_yojson |> Yojson.Safe.Util.to_assoc)
-  in
-  Base.Notification.make ~method_ ~params ()
-
-let logTrace ~message ~extra = mk_logTrace ~message ~extra |> !fn
-
-(* Disabled for now, see comment above *)
-(* let () = log := trace_object *)
-
-(** Misc helpers *)
-let read_message ic =
-  match read_raw_message ic with
-  | None -> None (* EOF *)
-  | Some (Ok com) ->
-    if Fleche.Debug.read then !log "read" com;
-    Some (Base.Message.of_yojson com)
-  | Some (Error err) -> Some (Error err)
+  Base.mk_logTrace ~message ~verbose |> !fn

--- a/lsp/io.ml
+++ b/lsp/io.ml
@@ -13,6 +13,7 @@ module J = Yojson.Safe
 
 (* This needs a fix as to log protocol stuff not using the protocol *)
 let log_protocol = ref (fun _ _ -> ())
+let set_log_fn fn = log_protocol := fn
 
 let read_raw_message ic =
   let cl = input_line ic in
@@ -50,7 +51,7 @@ let read_message ic =
   match read_raw_message ic with
   | None -> None (* EOF *)
   | Some (Ok com) ->
-    if Fleche.Debug.read then !log_protocol "read" com;
+    !log_protocol "read" com;
     Some (Base.Message.of_yojson com)
   | Some (Error err) -> Some (Error err)
 
@@ -58,7 +59,7 @@ let mut = Mutex.create ()
 
 let send_json fmt obj =
   Mutex.lock mut;
-  if Fleche.Debug.send then !log_protocol "send" obj;
+  !log_protocol "send" obj;
   let msg =
     if !Fleche.Config.v.pp_json then
       F.asprintf "%a" J.(pretty_print ~std:true) obj

--- a/lsp/io.mli
+++ b/lsp/io.mli
@@ -15,10 +15,7 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-(** JSON-RPC input/output *)
-
-(** Set the log output function *)
-val set_log_fn : (Base.Notification.t -> unit) -> unit
+(** {1} JSON-RPC input/output *)
 
 (** Read a JSON-RPC message from channel; [None] signals [EOF] *)
 val read_message : in_channel -> (Base.Message.t, string) Result.t option
@@ -26,24 +23,15 @@ val read_message : in_channel -> (Base.Message.t, string) Result.t option
 (** Send a JSON-RPC message to channel *)
 val send_message : Format.formatter -> Base.Message.t -> unit
 
-(** Logging *)
+(** {1} Imperative Logging and Tracing using [log_fn] *)
 
-(** Trace values *)
-module TraceValue : sig
-  type t =
-    | Off
-    | Messages
-    | Verbose
+(** Set the log output function *)
+val set_log_fn : (Base.Notification.t -> unit) -> unit
 
-  val of_string : string -> (t, string) result
-  val to_string : t -> string
-end
-
-(** Set the trace value *)
-val set_trace_value : TraceValue.t -> unit
+(** Send a [window/logMessage] notification to the client using [log_fn] *)
+val logMessageInt : lvl:int -> message:string -> unit
 
 module Lvl : sig
-  (* 1-5 *)
   type t = Fleche.Io.Level.t =
     | Error
     | Warning
@@ -54,37 +42,22 @@ module Lvl : sig
   val to_int : t -> int
 end
 
-module MessageParams : sig
-  val method_ : string
-
-  type t =
-    { type_ : int [@key "type"]
-    ; message : string
-    }
-  [@@deriving yojson]
-end
-
-(** Create a logMessage notification *)
-val mk_logMessage : type_:int -> message:string -> Base.Notification.t
-
-(** Send a [window/logMessage] notification to the client *)
+(** Send a [window/logMessage] notification to the client using [log_fn] *)
 val logMessage : lvl:Lvl.t -> message:string -> unit
 
-(** Send a [window/logMessage] notification to the client *)
-val logMessageInt : lvl:int -> message:string -> unit
-
-module TraceParams : sig
-  val method_ : string
-
+(** Trace values *)
+module TraceValue : sig
   type t =
-    { message : string
-    ; verbose : string option [@default None]
-    }
-  [@@deriving yojson]
+    | Off
+    | Messages
+    | Verbose
+
+  val of_string : string -> (t, string) Result.t
+  val to_string : t -> string
 end
 
-(** Create a logTrace notification *)
-val mk_logTrace : message:string -> extra:string option -> Base.Notification.t
+(** Set the trace value *)
+val set_trace_value : TraceValue.t -> unit
 
 (** Send a [$/logTrace] notification to the client *)
 val logTrace : message:string -> extra:string option -> unit

--- a/lsp/io.mli
+++ b/lsp/io.mli
@@ -13,3 +13,7 @@ val read_message : in_channel -> (Base.Message.t, string) Result.t option
 
 (** Send a JSON-RPC message to channel *)
 val send_message : Format.formatter -> Base.Message.t -> unit
+
+(** Set a debug function [log action object] which is called for read and send,
+    useful to do low-level protocol debug *)
+val set_log_fn : (string -> Yojson.Safe.t -> unit) -> unit

--- a/lsp/io.mli
+++ b/lsp/io.mli
@@ -1,63 +1,15 @@
 (************************************************************************)
-(*         *   The Coq Proof Assistant / The Coq Development Team       *)
-(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
-(* <O___,, *       (see CREDITS file for the list of authors)           *)
-(*   \VV/  **************************************************************)
-(*    //   *    This file is distributed under the terms of the         *)
-(*         *     GNU Lesser General Public License Version 2.1          *)
-(*         *     (see LICENSE file for the text of the license)         *)
-(************************************************************************)
-
-(************************************************************************)
-(* Coq Language Server Protocol                                         *)
+(* Rocq Language Server Protocol                                        *)
 (* Copyright 2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
-(* Copyright 2019-2022 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2019-2024 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2024-2025 EJGA       -- Dual License LGPL 2.1 / GPL3+      *)
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-(** {1} JSON-RPC input/output *)
+(** {1 JSON-RPC input/output} *)
 
 (** Read a JSON-RPC message from channel; [None] signals [EOF] *)
 val read_message : in_channel -> (Base.Message.t, string) Result.t option
 
 (** Send a JSON-RPC message to channel *)
 val send_message : Format.formatter -> Base.Message.t -> unit
-
-(** {1} Imperative Logging and Tracing using [log_fn] *)
-
-(** Set the log output function *)
-val set_log_fn : (Base.Notification.t -> unit) -> unit
-
-(** Send a [window/logMessage] notification to the client using [log_fn] *)
-val logMessageInt : lvl:int -> message:string -> unit
-
-module Lvl : sig
-  type t = Fleche.Io.Level.t =
-    | Error
-    | Warning
-    | Info
-    | Log
-    | Debug
-
-  val to_int : t -> int
-end
-
-(** Send a [window/logMessage] notification to the client using [log_fn] *)
-val logMessage : lvl:Lvl.t -> message:string -> unit
-
-(** Trace values *)
-module TraceValue : sig
-  type t =
-    | Off
-    | Messages
-    | Verbose
-
-  val of_string : string -> (t, string) Result.t
-  val to_string : t -> string
-end
-
-(** Set the trace value *)
-val set_trace_value : TraceValue.t -> unit
-
-(** Send a [$/logTrace] notification to the client *)
-val logTrace : message:string -> extra:string option -> unit

--- a/petanque/json_shell/client.ml
+++ b/petanque/json_shell/client.ml
@@ -16,12 +16,12 @@ let maybe_display_request method_ =
   if display_requests then Format.eprintf "received request: %s@\n%!" method_
 
 let do_trace ~trace params =
-  match Lsp.Io.TraceParams.of_yojson (`Assoc params) with
+  match Lsp.Base.TraceParams.of_yojson (`Assoc params) with
   | Ok { message; verbose } -> trace ?verbose message
   | Error _ -> ()
 
 let do_message ~message params =
-  match Lsp.Io.MessageParams.of_yojson (`Assoc params) with
+  match Lsp.Base.MessageParams.of_yojson (`Assoc params) with
   | Ok { type_; message = msg } -> message ~lvl:type_ ~message:msg
   | Error _ -> ()
 
@@ -30,11 +30,11 @@ let rec read_response ~trace ~message ic =
   match Lsp.Io.read_message ic with
   | Some (Ok (Lsp.Base.Message.Response r)) -> Ok r
   | Some (Ok (Notification { method_; params }))
-    when String.equal method_ Lsp.Io.TraceParams.method_ ->
+    when String.equal method_ Lsp.Base.TraceParams.method_ ->
     do_trace ~trace params;
     read_response ~trace ~message ic
   | Some (Ok (Notification { method_; params }))
-    when String.equal method_ Lsp.Io.MessageParams.method_ ->
+    when String.equal method_ Lsp.Base.MessageParams.method_ ->
     do_message ~message params;
     read_response ~trace ~message ic
   | Some (Ok (Request { method_; _ })) | Some (Ok (Notification { method_; _ }))

--- a/petanque/json_shell/interp_shell.ml
+++ b/petanque/json_shell/interp_shell.ml
@@ -46,9 +46,9 @@ let interp ~fn ~token (r : Lsp.Base.Message.t) : Lsp.Base.Message.t option =
     Some (Lsp.Base.Message.response response)
   | Notification { method_; params = _ } ->
     let message = "unhandled notification: " ^ method_ in
-    let log = Lsp.Io.mk_logTrace ~message ~extra:None in
+    let log = Lsp.Base.mk_logTrace ~message ~verbose:None in
     Some (Lsp.Base.Message.Notification log)
   | Response (Ok { id; _ }) | Response (Error { id; _ }) ->
     let message = "unhandled response: " ^ string_of_int id in
-    let log = Lsp.Io.mk_logTrace ~message ~extra:None in
+    let log = Lsp.Base.mk_logTrace ~message ~verbose:None in
     Some (Lsp.Base.Message.Notification log)

--- a/petanque/json_shell/pet.ml
+++ b/petanque/json_shell/pet.ml
@@ -46,14 +46,14 @@ let rec loop ~token : unit =
     Format.eprintf "@[error: %s@\n@]%!" err;
     loop ~token
 
-let trace_notification hdr ?extra msg =
+let trace_notification hdr ?verbose msg =
   let message = Format.asprintf "[%s] %s" hdr msg in
-  let notification = Lsp.Io.mk_logTrace ~message ~extra in
+  let notification = Lsp.Base.mk_logTrace ~message ~verbose in
   send_message (Lsp.Base.Message.Notification notification)
 
 let message_notification ~lvl ~message =
   let type_ = Lsp.Io.Lvl.to_int lvl in
-  let notification = Lsp.Io.mk_logMessage ~type_ ~message in
+  let notification = Lsp.Base.mk_logMessage ~type_ ~message in
   send_message (Lsp.Base.Message.Notification notification)
 
 let trace_enabled = true

--- a/petanque/json_shell/pet.ml
+++ b/petanque/json_shell/pet.ml
@@ -52,15 +52,14 @@ let trace_notification hdr ?verbose msg =
   send_message (Lsp.Base.Message.Notification notification)
 
 let message_notification ~lvl ~message =
-  let type_ = Lsp.Io.Lvl.to_int lvl in
-  let notification = Lsp.Base.mk_logMessage ~type_ ~message in
+  let notification = Lsp.Base.mk_logMessage ~lvl ~message in
   send_message (Lsp.Base.Message.Notification notification)
 
 let trace_enabled = true
 
 let log_error err =
   let message = Petanque.Agent.Error.to_string err in
-  message_notification ~lvl:Lsp.Io.Lvl.Error ~message
+  message_notification ~lvl:Fleche.Io.Level.Error ~message
 
 let pet_main debug roots http_headers =
   Coq.Limits.start ();

--- a/petanque/json_shell/shell.ml
+++ b/petanque/json_shell/shell.ml
@@ -32,7 +32,7 @@ let message_stderr ~lvl:_ ~message =
 let message_ref = ref message_stderr
 
 let io =
-  let trace hdr ?extra msg = !trace_ref hdr ?verbose:extra msg in
+  let trace hdr ?verbose msg = !trace_ref hdr ?verbose msg in
   let message ~lvl ~message = !message_ref ~lvl ~message in
   let diagnostics ~uri:_ ~version:_ _diags = () in
   let fileProgress ~uri:_ ~version:_ _pinfo = () in

--- a/petanque/json_shell/shell.ml
+++ b/petanque/json_shell/shell.ml
@@ -21,7 +21,7 @@ let setup_workspace ~token ~init ~debug ~root =
    Fleche.Doc.Env.make ~init ~workspace ~files)
   |> Result.map_error Petanque.Agent.Error.coq
 
-let trace_stderr hdr ?extra:_ msg =
+let trace_stderr hdr ?verbose:_ msg =
   Format.eprintf "@[[trace] %s | %s @]@\n%!" hdr msg
 
 let trace_ref = ref trace_stderr
@@ -32,7 +32,7 @@ let message_stderr ~lvl:_ ~message =
 let message_ref = ref message_stderr
 
 let io =
-  let trace hdr ?extra msg = !trace_ref hdr ?extra msg in
+  let trace hdr ?extra msg = !trace_ref hdr ?verbose:extra msg in
   let message ~lvl ~message = !message_ref ~lvl ~message in
   let diagnostics ~uri:_ ~version:_ _diags = () in
   let fileProgress ~uri:_ ~version:_ _pinfo = () in

--- a/petanque/json_shell/shell.mli
+++ b/petanque/json_shell/shell.mli
@@ -3,7 +3,7 @@ open Petanque
 (** I/O handling, by default, print to stderr *)
 
 (** [trace header extra message] *)
-val trace_ref : (string -> ?extra:string -> string -> unit) ref
+val trace_ref : (string -> ?verbose:string -> string -> unit) ref
 
 (** [message level message] *)
 val message_ref : (lvl:Fleche.Io.Level.t -> message:string -> unit) ref

--- a/petanque/test/basic_api.ml
+++ b/petanque/test/basic_api.ml
@@ -11,7 +11,7 @@ let prepare_paths () =
 
 let msgs = ref []
 
-let trace hdr ?extra:_ msg =
+let trace hdr ?verbose:_ msg =
   msgs := Format.asprintf "[trace] %s | %s" hdr msg :: !msgs
 
 let message ~lvl:_ ~message = msgs := message :: !msgs


### PR DESCRIPTION
This is a step towards fixing an apparent bug in coq-lsp not respecting `$/setTrace("off")`.

We consolidate tracing in `Fleche.Io` as tracing is really a Flèche facility.

We add a way to log to a file (as to help with #868 ), so we can see the low-level protocol format better. This corrects a minor regression from #130.