### PR TITLE
VSCode extension keybindings shouldn't conflict with editor defaults.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,9 @@
  - [doc] [faq] Updated FAQ to account for VSCoq 2 release in 2023,
    thanks to Patrick Nicodemus for pointing out the outdated
    documentation (@ejgallego, #846, fixes #817)
+ - [vscode] [macos] Resolve keybinding conflict with Cmd+N and
+   Cmd+Enter, we now use Alt+N and Alt+Shift+Enter, (Andrei
+   Listochkin, #926)
 
 # coq-lsp 0.2.2: To Virtual or not To Virtual
 ---------------------------------------------

--- a/editor/code/package.json
+++ b/editor/code/package.json
@@ -151,20 +151,20 @@
     "keybindings": [
       {
         "command": "coq-lsp.goals",
-        "key": "alt+enter",
-        "mac": "meta+enter",
+        "key": "Alt+enter",
+        "mac": "Alt+Shift+enter",
         "when": "editorTextFocus && (editorLangId == coq || editorTextFocus && editorLangId == markdown)"
       },
       {
         "command": "coq-lsp.sentenceNext",
         "key": "Alt+N",
-        "mac": "cmd+N",
+        "mac": "Alt+N",
         "when": "editorTextFocus && (editorLangId == coq || editorTextFocus && editorLangId == markdown)"
       },
       {
         "command": "coq-lsp.sentencePrevious",
         "key": "Alt+P",
-        "mac": "cmd+P",
+        "mac": "Alt+P",
         "when": "editorTextFocus && (editorLangId == coq || editorTextFocus && editorLangId == markdown)"
       }
     ],


### PR DESCRIPTION
On macOS `Cmd+N` is used for creating a new file, `Cmd+P` is "Go to file ..." - both are fundamental editor features, - that this extension breaks by introducing conflicting key binds.

macOS doesn't have a `Meta+` key prefix [(You can see the available prefixes here)](https://code.visualstudio.com/docs/editor/keybindings#_accepted-keys). `Alt+Enter` is used for "select all" during search and for other cases here and there. In addition, it's used by a popular GitLens extension. I propose `Alt+Shift+enter` as a new key combination, at least on macOS.