### PR TITLE
Adapt to rocq-prover/rocq#20397

### DIFF
--- a/serlib/plugins/funind/ser_g_indfun.ml
+++ b/serlib/plugins/funind/ser_g_indfun.ml
@@ -21,6 +21,7 @@ module Tactypes   = Ser_tactypes
 module Genintern  = Ser_genintern
 module EConstr    = Ser_eConstr
 module Tacexpr    = Serlib_ltac.Ser_tacexpr
+module UnivGen    = Ser_univGen
 
 module A1 = struct
 
@@ -64,7 +65,7 @@ end
 let ser_wit_fun_ind_using = let module M = Ser_genarg.GS(WitFI) in M.genser
 
 module WitFS = struct
-  type t = Names.lident * Libnames.qualid * Sorts.family
+  type t = Names.lident * Libnames.qualid * UnivGen.QualityOrSet.t
   [@@deriving sexp,hash,compare]
 end
 

--- a/serlib/ser_constr.ml
+++ b/serlib/ser_constr.ml
@@ -238,10 +238,6 @@ type existential =
   [%import: Constr.existential]
   [@@deriving sexp]
 
-type sorts_family = Sorts.family
-let sorts_family_of_sexp = Sorts.family_of_sexp
-let sexp_of_sorts_family = Sorts.sexp_of_family
-
 type named_declaration =
   [%import: Constr.named_declaration]
   [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_constr.mli
+++ b/serlib/ser_constr.mli
@@ -113,10 +113,6 @@ type existential = Constr.existential
 val existential_of_sexp : Sexp.t -> existential
 val sexp_of_existential : existential -> Sexp.t
 
-type sorts_family = Sorts.family
-val sorts_family_of_sexp : Sexp.t -> sorts_family
-val sexp_of_sorts_family : sorts_family -> Sexp.t
-
 type named_declaration = Constr.named_declaration
 val named_declaration_of_sexp : Sexp.t -> named_declaration
 val sexp_of_named_declaration : named_declaration -> Sexp.t

--- a/serlib/ser_pattern.ml
+++ b/serlib/ser_pattern.ml
@@ -29,6 +29,7 @@ module Constr    = Ser_constr
 module Evar      = Ser_evar
 module EConstr   = Ser_eConstr
 module Glob_term = Ser_glob_term
+module UnivGen   = Ser_univGen
 
 type patvar =
   [%import: Pattern.patvar]

--- a/serlib/ser_sorts.ml
+++ b/serlib/ser_sorts.ml
@@ -22,10 +22,6 @@ open Ppx_compare_lib.Builtin
 
 module Univ = Ser_univ
 
-type family =
-  [%import: Sorts.family]
-  [@@deriving sexp,yojson,hash,compare]
-
 module BijectQVar = struct
   open Sexplib.Std
   open Ppx_hash_lib.Std.Hash.Builtin

--- a/serlib/ser_stdarg.ml
+++ b/serlib/ser_stdarg.ml
@@ -105,20 +105,20 @@ let ser_wit_ref = Ser_genarg.{
 
   }
 
-let ser_wit_sort_family = Ser_genarg.{
-    raw_ser = Ser_sorts.sexp_of_family
+let ser_wit_sort_quality_or_set = Ser_genarg.{
+    raw_ser = Ser_univGen.QualityOrSet.sexp_of_t
   ; glb_ser = sexp_of_unit
   ; top_ser = sexp_of_unit
 
-  ; raw_des = Ser_sorts.family_of_sexp
+  ; raw_des = Ser_univGen.QualityOrSet.t_of_sexp
   ; glb_des = unit_of_sexp
   ; top_des = unit_of_sexp
 
-  ; raw_hash = Ser_sorts.hash_fold_family
+  ; raw_hash = Ser_univGen.QualityOrSet.hash_fold_t
   ; glb_hash = Ppx_hash_lib.Std.Hash.Builtin.hash_fold_unit
   ; top_hash = Ppx_hash_lib.Std.Hash.Builtin.hash_fold_unit
 
-  ; raw_compare = Ser_sorts.compare_family
+  ; raw_compare = Ser_univGen.QualityOrSet.compare
   ; glb_compare = Ppx_compare_lib.Builtin.compare_unit
   ; top_compare = Ppx_compare_lib.Builtin.compare_unit
   }
@@ -194,7 +194,7 @@ let register () =
   Ser_genarg.register_genser Stdarg.wit_open_constr ser_wit_constr;
   Ser_genarg.register_genser Stdarg.wit_pre_ident ser_wit_pre_ident;
   Ser_genarg.register_genser Stdarg.wit_ref ser_wit_ref;
-  Ser_genarg.register_genser Stdarg.wit_sort_family ser_wit_sort_family;
+  Ser_genarg.register_genser Stdarg.wit_sort_quality_or_set ser_wit_sort_quality_or_set;
   Ser_genarg.register_genser Stdarg.wit_string ser_wit_string;
   Ser_genarg.register_genser Stdarg.wit_uconstr ser_wit_uconstr;
   Ser_genarg.register_genser Stdarg.wit_unit ser_wit_unit;

--- a/serlib/ser_univGen.ml
+++ b/serlib/ser_univGen.ml
@@ -16,23 +16,10 @@
 (* Written by: Emilio J. Gallego Arias and others                       *)
 (************************************************************************)
 
-include SerType.SJHC with type t = Sorts.t
+module Sorts = Ser_sorts
 
-type relevance = Sorts.relevance [@@deriving sexp,yojson,hash,compare]
-type pattern = Sorts.pattern [@@deriving sexp,yojson,hash,compare]
-
-module QVar : sig
-  include SerType.SJHC with type t = Sorts.QVar.t
-  module Set : SerType.SJHC with type t = Sorts.QVar.Set.t
+module QualityOrSet = struct
+  type t =
+    [%import: UnivGen.QualityOrSet.t]
+    [@@deriving sexp,yojson,hash,compare]
 end
-
-module Quality : sig
-  type constant = Sorts.Quality.constant [@@deriving sexp,yojson,hash,compare]
-
-  include SerType.SJHC with type t = Sorts.Quality.t
-  module Set : SerType.SJHC with type t = Sorts.Quality.Set.t
-
-  type pattern = Sorts.Quality.pattern [@@deriving sexp,yojson,hash,compare]
-end
-
-module QConstraints : SerType.SJHC with type t = Sorts.QConstraints.t

--- a/serlib/ser_univGen.mli
+++ b/serlib/ser_univGen.mli
@@ -16,23 +16,6 @@
 (* Written by: Emilio J. Gallego Arias and others                       *)
 (************************************************************************)
 
-include SerType.SJHC with type t = Sorts.t
-
-type relevance = Sorts.relevance [@@deriving sexp,yojson,hash,compare]
-type pattern = Sorts.pattern [@@deriving sexp,yojson,hash,compare]
-
-module QVar : sig
-  include SerType.SJHC with type t = Sorts.QVar.t
-  module Set : SerType.SJHC with type t = Sorts.QVar.Set.t
+module QualityOrSet : sig
+  type t = UnivGen.QualityOrSet.t [@@deriving sexp,yojson,hash,compare]
 end
-
-module Quality : sig
-  type constant = Sorts.Quality.constant [@@deriving sexp,yojson,hash,compare]
-
-  include SerType.SJHC with type t = Sorts.Quality.t
-  module Set : SerType.SJHC with type t = Sorts.Quality.Set.t
-
-  type pattern = Sorts.Quality.pattern [@@deriving sexp,yojson,hash,compare]
-end
-
-module QConstraints : SerType.SJHC with type t = Sorts.QConstraints.t

--- a/serlib/ser_vernacexpr.ml
+++ b/serlib/ser_vernacexpr.ml
@@ -29,6 +29,7 @@ module Sorts       = Ser_sorts
 module CPrimitives = Ser_cPrimitives
 module Univ        = Ser_univ
 module UnivNames   = Ser_univNames
+module UnivGen   = Ser_univGen
 module Conv_oracle = Ser_conv_oracle
 module Declarations= Ser_declarations
 module Decls       = Ser_decls


### PR DESCRIPTION
Remove `Sorts.family` and serialize `QualityOrSet` that replace the `Sorts.family` during schemes generation.