### PR TITLE
Adapt to rocq-prover/rocq#20506

### DIFF
--- a/serlib/ser_sorts.ml
+++ b/serlib/ser_sorts.ml
@@ -74,14 +74,14 @@ type pattern =
   [%import: Sorts.pattern]
   [@@deriving sexp,yojson,hash,compare]
 
-module QConstraint = struct
+module ElimConstraint = struct
   type kind =
-    [%import: Sorts.QConstraint.kind]
+    [%import: Sorts.ElimConstraint.kind]
     [@@deriving sexp,yojson,hash,compare]
 
   type t =
-    [%import: Sorts.QConstraint.t]
+    [%import: Sorts.ElimConstraint.t]
     [@@deriving sexp,yojson,hash,compare]
 end
 
-module QConstraints = Ser_cSet.Make(Sorts.QConstraints)(QConstraint)
+module ElimConstraints = Ser_cSet.Make(Sorts.ElimConstraints)(ElimConstraint)

--- a/serlib/ser_sorts.mli
+++ b/serlib/ser_sorts.mli
@@ -35,4 +35,4 @@ module Quality : sig
   type pattern = Sorts.Quality.pattern [@@deriving sexp,yojson,hash,compare]
 end
 
-module QConstraints : SerType.SJHC with type t = Sorts.QConstraints.t
+module ElimConstraints : SerType.SJHC with type t = Sorts.ElimConstraints.t


### PR DESCRIPTION
Renamed `QConstraint` to `ElimConstraint`.