### PR TITLE
[rocq] Disable memprof-limits interruption backend by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,11 @@
  - [vscode] [macos] Resolve keybinding conflict with Cmd+N and
    Cmd+Enter, we now use Alt+N and Alt+Shift+Enter, (Andrei
    Listochkin, #926)
+ - [rocq] [fleche] Disable memprof-limits interruption backend by
+   default, as released Rocq versions are not safe yet. If you want to
+   enable it, you can still do it with the `--int_backend=Mp` command
+   line option (@ejgallego, #957, fixes #857, reported by @dariusf,
+   cc: rocq-prover/rocq#19177)
 
 # coq-lsp 0.2.2: To Virtual or not To Virtual
 ---------------------------------------------

--- a/controller/lsp_core.ml
+++ b/controller/lsp_core.ml
@@ -528,6 +528,8 @@ let lsp_init_process ~ofn ~io ~cmdline ~debug msg : Init_effect.t =
     let result, dirs = Rq_init.do_initialize ~io ~params in
     Rq.Action.now (Ok result) |> Rq.serve ~ofn_rq ~token ~id;
     Lsp.JFleche.mk_serverVersion serverInfo |> ofn_nt;
+    Fleche.Io.Report.msg ~io ~lvl:Info "Rocq features: %s"
+      Coq.Version.quirks_message;
     Fleche.Io.Report.msg ~io ~lvl:Info "Server initializing (int_backend: %s)"
       (Coq.Limits.name ());
     (* Workspace initialization *)

--- a/coq/limits.ml
+++ b/coq/limits.ml
@@ -58,15 +58,9 @@ let select = function
   | Mp -> backend := (module Mp)
 
 (* Set this to false for 8.19 and lower *)
-let sane_coq_base_version = true
-
-let sane_coq_branch =
-  CString.string_contains ~where:Coq_config.version ~what:"+lsp"
-
-let safe_coq = sane_coq_base_version || sane_coq_branch
-
 let select_best = function
-  | None -> if Mp.available && safe_coq then select Mp else select Coq
+  | None ->
+    if Mp.available && Version.safe_for_memprof then select Mp else select Coq
   | Some backend -> select backend
 
 module Token = struct

--- a/coq/version.ml
+++ b/coq/version.ml
@@ -1,0 +1,22 @@
+(************************************************************************)
+(* Flèche => document manager: Document                                 *)
+(* Copyright 2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2019-2024 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2024-2025 Emilio J. Gallego Arias -- LGPL 2.1 / GPL3+      *)
+(* Copyright 2025      CNRS                    -- LGPL 2.1 / GPL3+      *)
+(* Written by: Emilio J. Gallego Arias & coq-lsp contributors           *)
+(************************************************************************)
+
+(** Abstraction module over Rocq versions and their characteristics *)
+
+(* Not safe until we merge PR upstream #19177 *)
+let sane_coq_base_version = false
+
+let is_lsp_branch =
+  CString.string_contains ~where:Coq_config.version ~what:"+lsp"
+
+let safe_coq = sane_coq_base_version || is_lsp_branch
+let safe_for_memprof = safe_coq
+
+let quirks_message =
+  Format.asprintf "Rocq safe for memprof-limits: %b" safe_for_memprof

--- a/coq/version.mli
+++ b/coq/version.mli
@@ -1,0 +1,13 @@
+(************************************************************************)
+(* Flèche => document manager: Document                                 *)
+(* Copyright 2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2019-2024 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2024-2025 Emilio J. Gallego Arias -- LGPL 2.1 / GPL3+      *)
+(* Copyright 2025      CNRS                    -- LGPL 2.1 / GPL3+      *)
+(* Written by: Emilio J. Gallego Arias & coq-lsp contributors           *)
+(************************************************************************)
+
+(** Abstraction module over Rocq versions and their characteristics *)
+
+val safe_for_memprof : bool
+val quirks_message : string

--- a/fleche/doc.mli
+++ b/fleche/doc.mli
@@ -3,6 +3,7 @@
 (* Copyright 2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
 (* Copyright 2019-2024 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
 (* Copyright 2024-2025 Emilio J. Gallego Arias -- LGPL 2.1 / GPL3+      *)
+(* Copyright 2025      CNRS                    -- LGPL 2.1 / GPL3+      *)
 (* Written by: Emilio J. Gallego Arias & coq-lsp contributors           *)
 (************************************************************************)
 


### PR DESCRIPTION
Released Rocq versions are not safe yet, see rocq-prover/rocq#19177

You can enable it using the `--int_backend=Mp` command line parameter.