### PR TITLE
[controller] [lsp] Include Rocq feedback on request errors.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,6 +58,11 @@
    enable it, you can still do it with the `--int_backend=Mp` command
    line option (@ejgallego, #957, fixes #857, reported by @dariusf,
    cc: rocq-prover/rocq#19177)
+ - [lsp] [controller] Include Rocq feedback on request errors, using
+   the optional `data` field. This is useful to still be able to
+   obtain feedback messages such as debug messages even when a request
+   fails. This also opens the door to better protocol handling and
+   petanque integration (@ejgallego, #959)
 
 # coq-lsp 0.2.2: To Virtual or not To Virtual
 ---------------------------------------------

--- a/controller/dune
+++ b/controller/dune
@@ -1,7 +1,23 @@
+; Should we move this to Fleche?
+
+(library
+ (name request)
+ (public_name coq-lsp.request)
+ (modules request)
+ (wrapped false)
+ (libraries coq fleche))
+
 (library
  (name controller)
- (modules :standard \ coq_lsp)
- (libraries coq fleche petanque petanque_json fleche_lsp dune-build-info))
+ (modules :standard \ request coq_lsp)
+ (libraries
+  coq
+  fleche
+  request
+  petanque
+  petanque_json
+  fleche_lsp
+  dune-build-info))
 
 (executable
  (name coq_lsp)

--- a/controller/request.mli
+++ b/controller/request.mli
@@ -1,62 +1,74 @@
 (************************************************************************)
-(*         *   The Coq Proof Assistant / The Coq Development Team       *)
-(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
-(* <O___,, *       (see CREDITS file for the list of authors)           *)
-(*   \VV/  **************************************************************)
-(*    //   *    This file is distributed under the terms of the         *)
-(*         *     GNU Lesser General Public License Version 2.1          *)
-(*         *     (see LICENSE file for the text of the license)         *)
+(* Flèche => document manager: Document                                 *)
+(* Copyright 2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2019-2024 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
+(* Copyright 2024-2025 Emilio J. Gallego Arias -- LGPL 2.1 / GPL3+      *)
+(* Copyright 2025      CNRS                    -- LGPL 2.1 / GPL3+      *)
+(* Written by: Emilio J. Gallego Arias & coq-lsp contributors           *)
 (************************************************************************)
 
-(************************************************************************)
-(* Coq Language Server Protocol                                         *)
-(* Copyright 2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
-(* Copyright 2019-2023 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
-(* Written by: Emilio J. Gallego Arias                                  *)
-(************************************************************************)
+(* Request errors, we include execution feedback which could be very
+   important *)
+module Error : sig
+  type 'a t =
+    { code : int
+    ; payload : 'a
+    ; feedback : Pp.t list
+    }
+
+  val make : ?feedback:Pp.t list -> int -> 'a -> 'a t
+end
 
 module R : sig
-  type t = (Yojson.Safe.t, int * string) Result.t
+  type ('r, 'e) t = ('r, 'e Error.t) Result.t
 
   (* We don't allow to pass the feedback to the [f] handler yet, that's not
      hard, but I'd suggest waiting until the conversion of character points is
      working better. *)
   val of_execution :
-    name:string -> f:('a -> (t, Loc.t) Coq.Protect.E.t) -> 'a -> t
+       name:string
+    -> f:('a -> (('r, string) t, Loc.t) Coq.Protect.E.t)
+    -> 'a
+    -> ('r, string) t
 end
 
 (* We could classify the requests that don't need to call-back Coq (and thus
    don't need the interruption token; but it is not worth it. *)
-type document = token:Coq.Limits.Token.t -> doc:Fleche.Doc.t -> R.t
+type ('r, 'e) document =
+  token:Coq.Limits.Token.t -> doc:Fleche.Doc.t -> ('r, 'e) R.t
 
-type position =
-  token:Coq.Limits.Token.t -> doc:Fleche.Doc.t -> point:int * int -> R.t
+type ('r, 'e) position =
+     token:Coq.Limits.Token.t
+  -> doc:Fleche.Doc.t
+  -> point:int * int
+  -> ('r, 'e) R.t
 
 (** Requests that require data access *)
 module Data : sig
-  type t =
+  type ('r, 'e) t =
     | Immediate of
         { uri : Lang.LUri.File.t
-        ; handler : document
+        ; handler : ('r, 'e) document
         }
     | DocRequest of
         { uri : Lang.LUri.File.t
         ; postpone : bool
-        ; handler : document
+        ; handler : ('r, 'e) document
         }
     | PosRequest of
         { uri : Lang.LUri.File.t
         ; point : int * int
         ; version : int option
         ; postpone : bool
-        ; handler : position
+        ; handler : ('r, 'e) position
         }
 
   (* Debug printing *)
-  val data : Format.formatter -> t -> unit
-  val dm_request : t -> Lang.LUri.File.t * bool * Fleche.Theory.Request.request
-  val serve : token:Coq.Limits.Token.t -> doc:Fleche.Doc.t -> t -> R.t
-end
+  val data : Format.formatter -> ('r, 'e) t -> unit
 
-(** Returns an empty list of results for any position / document *)
-val empty : position
+  val dm_request :
+    ('r, 'e) t -> Lang.LUri.File.t * bool * Fleche.Theory.Request.request
+
+  val serve :
+    token:Coq.Limits.Token.t -> doc:Fleche.Doc.t -> ('r, 'e) t -> ('r, 'e) R.t
+end

--- a/controller/rq_action.mli
+++ b/controller/rq_action.mli
@@ -1,1 +1,1 @@
-val request : range:Lang.Range.t -> Request.document
+val request : range:Lang.Range.t -> (Yojson.Safe.t, string) Request.document

--- a/controller/rq_completion.mli
+++ b/controller/rq_completion.mli
@@ -15,4 +15,4 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-val completion : Request.position
+val completion : (Yojson.Safe.t, string) Request.position

--- a/controller/rq_definition.ml
+++ b/controller/rq_definition.ml
@@ -28,11 +28,11 @@ let locate_extended qid =
 
 let find_name_in dp name =
   match Coq.Module.make dp with
-  | Error err -> Error (err_code, lp_to_string err)
+  | Error err -> Error (Request.Error.make err_code (lp_to_string err))
   | Ok mod_ -> (
     let uri = Coq.Module.uri mod_ in
     match Coq.Module.find mod_ name with
-    | Error err -> Error (err_code, err)
+    | Error err -> Error (Request.Error.make err_code err)
     | Ok range -> Ok (Option.map (fun range -> Location.{ uri; range }) range))
 
 let get_from_file id_at_point =

--- a/controller/rq_definition.mli
+++ b/controller/rq_definition.mli
@@ -5,4 +5,4 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-val request : Request.position
+val request : (Yojson.Safe.t, string) Request.position

--- a/controller/rq_document.mli
+++ b/controller/rq_document.mli
@@ -5,4 +5,4 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-val request : Request.document
+val request : (Yojson.Safe.t, string) Request.document

--- a/controller/rq_goals.mli
+++ b/controller/rq_goals.mli
@@ -16,4 +16,4 @@ val goals :
   -> mode:Fleche.Info.approx
   -> pretac:string option
   -> unit
-  -> Request.position
+  -> (Yojson.Safe.t, string) Request.position

--- a/controller/rq_hover.mli
+++ b/controller/rq_hover.mli
@@ -5,7 +5,7 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-val hover : Request.position
+val hover : (Yojson.Safe.t, string) Request.position
 
 open Fleche
 

--- a/controller/rq_lens.mli
+++ b/controller/rq_lens.mli
@@ -5,4 +5,4 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-val request : Request.document
+val request : (Yojson.Safe.t, string) Request.document

--- a/controller/rq_selectionRange.mli
+++ b/controller/rq_selectionRange.mli
@@ -15,4 +15,5 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-val request : points:(int * int) list -> Request.position
+val request :
+  points:(int * int) list -> (Yojson.Safe.t, string) Request.position

--- a/controller/rq_symbols.mli
+++ b/controller/rq_symbols.mli
@@ -5,4 +5,4 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-val symbols : Request.document
+val symbols : (Yojson.Safe.t, string) Request.document

--- a/etc/doc/PROTOCOL.md
+++ b/etc/doc/PROTOCOL.md
@@ -135,6 +135,27 @@ to determine the content type. Supported extensions are:
   snippets between `\begin{coq}/\end{coq}` LaTeX environments will be
   interpreted as Coq code.
 
+## Implementation-specific data fields
+
+Rocq will often generate "feedback" messages when trying to execute
+commands, for example debug messages, or to return solutions to
+commands such as `Search` or `Print`.
+
+Rocq "feedback" is very context dependent, feedback related to
+document sentences is recorded in the document, and can be obtained
+with the `coq/goals` request below.
+
+Feedback related to specific command requests is handled via:
+
+- if the request succeeds, feedback should be reflected in the return type results
+- if the request fails, we will set the optional `data` field in the
+  request response to an object of type `RocqErrorData`:
+```
+interface RocqErrorData = {
+  feedback : string[]
+  }
+```
+
 ## Extensions to the LSP specification
 
 As of today, `coq-lsp` implements several extensions to the LSP

--- a/lsp/base.ml
+++ b/lsp/base.ml
@@ -77,7 +77,16 @@ module Response = struct
         }
 
   let mk_ok ~id ~result = Ok { id; result }
-  let mk_error ~id ~code ~message = Error { id; code; message; data = None }
+
+  let mk_error ~id ~code ~message ~feedback =
+    let data =
+      match feedback with
+      | [] -> None
+      | fbs ->
+        let fbs = List.map (fun fb -> `String (Pp.string_of_ppcmds fb)) fbs in
+        Some (`Assoc [ ("feedback", `List fbs) ])
+    in
+    Error { id; code; message; data }
 
   let id = function
     | Ok { id; _ } | Error { id; _ } -> id

--- a/lsp/base.mli
+++ b/lsp/base.mli
@@ -61,7 +61,7 @@ module Response : sig
   val mk_ok : id:int -> result:Yojson.Safe.t -> t
 
   (** Fail a request *)
-  val mk_error : id:int -> code:int -> message:string -> t
+  val mk_error : id:int -> code:int -> message:string -> feedback:Pp.t list -> t
 
   val id : t -> int
 end

--- a/petanque/json/dune
+++ b/petanque/json/dune
@@ -3,4 +3,4 @@
  (public_name coq-lsp.petanque.json)
  (preprocess
   (staged_pps ppx_import ppx_deriving_yojson))
- (libraries fleche_lsp petanque))
+ (libraries request fleche_lsp petanque))

--- a/petanque/json/interp.mli
+++ b/petanque/json/interp.mli
@@ -6,15 +6,15 @@
 
 (* API for embedding petanque into a different protocol, needs to be moved to a
    core request library *)
-type 'a r = ('a, int * string) Result.t
-
 module Action : sig
   type t =
-    | Now of (token:Coq.Limits.Token.t -> Yojson.Safe.t r)
+    | Now of (token:Coq.Limits.Token.t -> (Yojson.Safe.t, string) Request.R.t)
     | Doc of
         { uri : Lang.LUri.File.t
         ; handler :
-            token:Coq.Limits.Token.t -> doc:Fleche.Doc.t -> Yojson.Safe.t r
+               token:Coq.Limits.Token.t
+            -> doc:Fleche.Doc.t
+            -> (Yojson.Safe.t, string) Request.R.t
         }
 end
 
@@ -28,9 +28,8 @@ val handle_request :
   -> params:(string * Yojson.Safe.t) list
   -> 'a
 
-(* aux function *)
-val of_pet_err :
-  ('a, Petanque.Agent.Error.t) result -> ('a, int * string) Result.t
+(* aux function, XXX: fixme to include feedback *)
+val of_pet_err : ('a, Petanque.Agent.Error.t) result -> ('a, string) Request.R.t
 
 (* Mostly Internal for pet-shell extensions; not for public consumption *)
 val do_request :

--- a/petanque/json_shell/interp_shell.ml
+++ b/petanque/json_shell/interp_shell.ml
@@ -27,12 +27,15 @@ let request ~fn ~token ~id ~method_ ~params =
       (* JSON-RPC method not found *)
       let code = -32601 in
       let message = Format.asprintf "method %s not found" method_ in
-      Error (code, message)
+      Error (Request.Error.make code message)
   in
   let do_handle = do_handle ~fn in
   match handle_request ~do_handle ~unhandled ~token ~method_ ~params with
   | Ok result -> Lsp.Base.Response.mk_ok ~id ~result
-  | Error (code, message) -> Lsp.Base.Response.mk_error ~id ~code ~message
+  | Error Request.Error.{ code; payload; feedback } ->
+    (* for now *)
+    let message = payload in
+    Lsp.Base.Response.mk_error ~id ~code ~message ~feedback
 
 type doc_handler =
      token:Coq.Limits.Token.t


### PR DESCRIPTION
We use the optional `data` field from the LSP specification.

This is useful to be able to obtain feedback messages such as debug messages even when a request fails.

This also opens the door to better protocol handling and petanque integration.

We don't't update the VSCode to use this yet, but maybe we should do it soon.