### PR TITLE
[petanque] Add feedback field to errors and `Run_result.t`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,9 @@
    obtain feedback messages such as debug messages even when a request
    fails. This also opens the door to better protocol handling and
    petanque integration (@ejgallego, #959, #961)
+ - [petanque] Add feedback field to `Run_result.t`, this is important
+   for many use cases. We also return feedback on petanque errors.
+   (@ejgallego, @JulesViennotFranca, #960)
 
 # coq-lsp 0.2.2: To Virtual or not To Virtual
 ---------------------------------------------

--- a/controller/request.ml
+++ b/controller/request.ml
@@ -23,11 +23,16 @@ module Error = struct
     }
 
   let make ?(feedback = []) code payload = { code; payload; feedback }
+
+  let map ~f { code; payload; feedback } =
+    let payload = f payload in
+    { code; payload; feedback }
 end
 
 module R = struct
   type ('r, 'e) t = ('r, 'e Error.t) Result.t
 
+  let map_error ~f = Result.map_error (Error.map ~f)
   let code = -32803
 
   let print_err ~name e =

--- a/controller/request.mli
+++ b/controller/request.mli
@@ -22,6 +22,8 @@ end
 module R : sig
   type ('r, 'e) t = ('r, 'e Error.t) Result.t
 
+  val map_error : f:('e -> 'f) -> ('r, 'e) t -> ('r, 'f) t
+
   (* We don't allow to pass the feedback to the [f] handler yet, that's not
      hard, but I'd suggest waiting until the conversion of character points is
      working better. *)

--- a/petanque/agent.ml
+++ b/petanque/agent.ml
@@ -72,10 +72,12 @@ module Error = struct
 
   let coq e = Coq e
   let system e = System e
+  let make e ~feedback = Request.Error.make (to_code e) e ~feedback
+  let make_request e = make e ~feedback:[]
 end
 
 module R = struct
-  type 'a t = ('a, Error.t) Result.t
+  type 'a t = ('a, Error.t) Request.R.t
 end
 
 module Run_opts = struct
@@ -90,15 +92,17 @@ module Run_result = struct
     { st : 'a
     ; hash : int option [@default None]
     ; proof_finished : bool
+    ; feedback : (int * string) list
     }
 end
 
 let find_thm ~(doc : Fleche.Doc.t) ~thm =
   let { Fleche.Doc.toc; _ } = doc in
+  let feedback = [] in
   match CString.Map.find_opt thm toc with
   | None ->
     let msg = Format.asprintf "@[[find_thm] Theorem not found!@]" in
-    Error (Error.Theorem_not_found msg)
+    Error Error.(make (Theorem_not_found msg) ~feedback)
   | Some node -> (
     (* If the node has an error we cannot assume the state is valid *)
     match List.filter Lang.Diagnostic.is_error node.diags with
@@ -109,7 +113,7 @@ let find_thm ~(doc : Fleche.Doc.t) ~thm =
           "@[[find_thm] Theorem found but failed with Coq error:@\n @[%a@]!@]"
           Pp.pp_with err.message
       in
-      Error (Error.Theorem_not_found msg))
+      Error Error.(make (Theorem_not_found msg) ~feedback))
 
 let execute_precommands ~token ~memo ~pre_commands ~(node : Fleche.Doc.Node.t) =
   match (pre_commands, node.prev, node.ast) with
@@ -121,14 +125,26 @@ let execute_precommands ~token ~memo ~pre_commands ~(node : Fleche.Doc.Node.t) =
     Fleche.Memo.Interp.eval ~token (st, ast.v)
   | _, _, _ -> Coq.Protect.E.ok node.state
 
+(* XXX Fix better by making protect errors and request errors share the loc
+   type, so we can execute with Coq locations *)
+let clean_fb fbs =
+  List.map
+    (fun (lvl, { Coq.Message.Payload.msg; _ }) ->
+      (lvl, { Coq.Message.Payload.range = None; quickFix = None; msg }))
+    fbs
+
 let protect_to_result (r : _ Coq.Protect.E.t) : (_, _) Result.t =
   match r with
-  | { r = Interrupted; feedback = _ } -> Error Error.Interrupted
-  | { r = Completed (Error (User { msg; _ })); feedback = _ } ->
-    Error (Error.Coq (Pp.string_of_ppcmds msg))
-  | { r = Completed (Error (Anomaly { msg; _ })); feedback = _ } ->
-    Error (Error.Anomaly (Pp.string_of_ppcmds msg))
-  | { r = Completed (Ok r); feedback = _ } -> Ok r
+  | { r = Interrupted; feedback } ->
+    let feedback = clean_fb feedback in
+    Error Error.(make Interrupted ~feedback)
+  | { r = Completed (Error (User { msg; _ })); feedback } ->
+    let feedback = clean_fb feedback in
+    Error Error.(make (Coq (Pp.string_of_ppcmds msg)) ~feedback)
+  | { r = Completed (Error (Anomaly { msg; _ })); feedback } ->
+    let feedback = clean_fb feedback in
+    Error Error.(make (Anomaly (Pp.string_of_ppcmds msg)) ~feedback)
+  | { r = Completed (Ok r); feedback } -> Ok (r feedback)
 
 let proof_finished { Coq.Goals.goals; stack; shelf; given_up; _ } =
   let check_stack stack =
@@ -151,7 +167,12 @@ end
 
 let hash_mode = Hash_kind.Proof
 
-let analyze_after_run ~hash st =
+(* XXX: duplicated with Request.R.of_execution, refactoring planned (not
+   trivial) *)
+let fb_print_string (lvl, { Coq.Message.Payload.msg; _ }) =
+  (lvl, Pp.string_of_ppcmds msg)
+
+let analyze_after_run ~hash st feedback =
   let proof_finished =
     let goals = Fleche.Info.Goals.get_goals_unit ~st in
     match goals with
@@ -160,7 +181,8 @@ let analyze_after_run ~hash st =
     | _ -> false
   in
   let hash = if hash then Hash_kind.hash ~kind:hash_mode st else None in
-  Run_result.{ st; hash; proof_finished }
+  let feedback = List.map fb_print_string feedback in
+  Run_result.{ st; hash; proof_finished; feedback }
 
 (* Would be nice to keep this in sync with the type annotations. *)
 let default_opts = function
@@ -181,7 +203,7 @@ let start ~token ~doc ?opts ?pre_commands ~thm () =
   in
   protect_to_result execution
 
-let run ~token ?opts ~st ~tac () : (_ Run_result.t, Error.t) Result.t =
+let run ~token ?opts ~st ~tac () : (_ Run_result.t, Error.t) Request.R.t =
   let opts = default_opts opts in
   (* Improve with thm? *)
   let memo, hash = (opts.memo, opts.hash) in
@@ -197,7 +219,8 @@ let goals ~token ~st =
   let f goals =
     let f = Coq.Goals.Reified_goal.map ~f:Pp.string_of_ppcmds in
     let g = Pp.string_of_ppcmds in
-    Option.map (Coq.Goals.map ~f ~g) goals
+    (* XXX: Fixme, take feedback into account *)
+    fun _feedback -> Option.map (Coq.Goals.map ~f ~g) goals
   in
   Coq.Protect.E.map ~f (Fleche.Info.Goals.goals ~token ~st) |> protect_to_result
 
@@ -288,5 +311,6 @@ let premises ~token ~st =
   (let open Coq.Protect.E.O in
    let* all_libs = Coq.Library_file.loaded ~token ~st in
    let+ all_premises = Coq.Library_file.toc ~token ~st all_libs in
-   List.map to_premise all_premises)
+   (* XXX: Fixme, take feedback into account *)
+   fun _feedback -> List.map to_premise all_premises)
   |> protect_to_result

--- a/petanque/agent.mli
+++ b/petanque/agent.mli
@@ -55,11 +55,12 @@ module Error : sig
   val to_code : t -> int
   val coq : string -> t
   val system : string -> t
+  val make_request : t -> t Request.Error.t
 end
 
 (** Petanque results *)
 module R : sig
-  type 'a t = ('a, Error.t) Result.t
+  type 'a t = ('a, Error.t) Request.R.t
 end
 
 module Run_opts : sig
@@ -75,6 +76,7 @@ module Run_result : sig
     ; hash : int option [@default None]
           (** [State.Proof.hash st] if enabled / proof is open. *)
     ; proof_finished : bool
+    ; feedback : (int * string) list  (** level and message *)
     }
 end
 

--- a/petanque/dune
+++ b/petanque/dune
@@ -1,4 +1,4 @@
 (library
  (public_name coq-lsp.petanque)
  (name petanque)
- (libraries fleche))
+ (libraries fleche request))

--- a/petanque/json/interp.mli
+++ b/petanque/json/interp.mli
@@ -4,17 +4,18 @@
 (* Copyright 2019-2024 Inria      -- Dual License LGPL 2.1 / GPL3+      *)
 (************************************************************************)
 
+(* Payload specialized to json / string *)
+type json_rpc_result = (Yojson.Safe.t, string) Request.R.t
+
 (* API for embedding petanque into a different protocol, needs to be moved to a
    core request library *)
 module Action : sig
   type t =
-    | Now of (token:Coq.Limits.Token.t -> (Yojson.Safe.t, string) Request.R.t)
+    | Now of (token:Coq.Limits.Token.t -> json_rpc_result)
     | Doc of
         { uri : Lang.LUri.File.t
         ; handler :
-               token:Coq.Limits.Token.t
-            -> doc:Fleche.Doc.t
-            -> (Yojson.Safe.t, string) Request.R.t
+            token:Coq.Limits.Token.t -> doc:Fleche.Doc.t -> json_rpc_result
         }
 end
 
@@ -29,7 +30,8 @@ val handle_request :
   -> 'a
 
 (* aux function, XXX: fixme to include feedback *)
-val of_pet_err : ('a, Petanque.Agent.Error.t) result -> ('a, string) Request.R.t
+val of_pet_err :
+  ('a, Petanque.Agent.Error.t) Request.R.t -> ('a, string) Request.R.t
 
 (* Mostly Internal for pet-shell extensions; not for public consumption *)
 val do_request :

--- a/petanque/json/jAgent.ml
+++ b/petanque/json/jAgent.ml
@@ -25,10 +25,6 @@ end
 module Stdlib = Lsp.JStdlib
 module Result = Stdlib.Result
 
-module R = struct
-  type 'a t = [%import: 'a Petanque.Agent.R.t] [@@deriving yojson]
-end
-
 module Goals = struct
   type t = string Lsp.JCoq.Goals.reified_pp option [@@deriving yojson]
 end

--- a/petanque/json/protocol.ml
+++ b/petanque/json/protocol.ml
@@ -9,10 +9,14 @@ open JAgent
    eventually as to make this clearer. *)
 module HType = struct
   type ('p, 'r) t =
-    | Immediate of (token:Coq.Limits.Token.t -> 'p -> 'r R.t)
+    | Immediate of (token:Coq.Limits.Token.t -> 'p -> ('r, Error.t) Request.R.t)
     | FullDoc of
         { uri_fn : 'p -> LUri.File.t
-        ; handler : token:Coq.Limits.Token.t -> doc:Fleche.Doc.t -> 'p -> 'r R.t
+        ; handler :
+               token:Coq.Limits.Token.t
+            -> doc:Fleche.Doc.t
+            -> 'p
+            -> ('r, Error.t) Request.R.t
         }
 end
 

--- a/petanque/json_shell/interp_shell.ml
+++ b/petanque/json_shell/interp_shell.ml
@@ -52,7 +52,7 @@ let request ~fn ~token ~id ~method_ ~params =
 type doc_handler =
      token:Coq.Limits.Token.t
   -> uri:Lang.LUri.File.t
-  -> (Fleche.Doc.t, Petanque.Agent.Error.t) Result.t
+  -> Fleche.Doc.t Petanque.Agent.R.t
 
 let interp ~fn ~token (r : Lsp.Base.Message.t) : Lsp.Base.Message.t option =
   match r with

--- a/petanque/json_shell/interp_shell.mli
+++ b/petanque/json_shell/interp_shell.mli
@@ -10,7 +10,7 @@ module Lsp = Fleche_lsp
 type doc_handler =
      token:Coq.Limits.Token.t
   -> uri:Lang.LUri.File.t
-  -> (Fleche.Doc.t, Petanque.Agent.Error.t) Result.t
+  -> Fleche.Doc.t Petanque.Agent.R.t
 
 val interp :
      fn:doc_handler

--- a/petanque/json_shell/pet.ml
+++ b/petanque/json_shell/pet.ml
@@ -57,7 +57,7 @@ let message_notification ~lvl ~message =
 
 let trace_enabled = true
 
-let log_error err =
+let log_error Request.Error.{ payload = err; _ } =
   let message = Petanque.Agent.Error.to_string err in
   message_notification ~lvl:Fleche.Io.Level.Error ~message
 

--- a/petanque/json_shell/server.ml
+++ b/petanque/json_shell/server.ml
@@ -67,7 +67,7 @@ let create_server ~token sock =
   in
   serve
 
-let log_error err =
+let log_error Request.Error.{ payload = err; _ } =
   let message = Petanque.Agent.Error.to_string err in
   Format.eprintf "Error in --root option: %s@\n%!" message
 (* Logs_lwt.info (fun m -> m "%s" message) *)

--- a/petanque/json_shell/shell.ml
+++ b/petanque/json_shell/shell.ml
@@ -19,7 +19,7 @@ let setup_workspace ~token ~init ~debug ~root =
    let+ workspace = Coq.Workspace.guess ~token ~debug ~cmdline ~dir in
    let files = Coq.Files.make () in
    Fleche.Doc.Env.make ~init ~workspace ~files)
-  |> Result.map_error Petanque.Agent.Error.coq
+  |> Result.map_error (fun msg -> Petanque.Agent.Error.(make_request (coq msg)))
 
 let trace_stderr hdr ?verbose:_ msg =
   Format.eprintf "@[[trace] %s | %s @]@\n%!" hdr msg
@@ -68,7 +68,7 @@ let print_diags (doc : Fleche.Doc.t) =
 let read_raw ~uri =
   let file = Lang.LUri.File.to_string_file uri in
   try Ok Coq.Compat.Ocaml_414.In_channel.(with_open_text file input_all)
-  with Sys_error err -> Error (Petanque.Agent.Error.system err)
+  with Sys_error err -> Error Petanque.Agent.Error.(make_request (system err))
 
 let setup_doc ~token env uri =
   match read_raw ~uri with
@@ -82,9 +82,10 @@ let setup_doc ~token env uri =
 let build_doc ~token ~uri = setup_doc ~token (Option.get !env) uri
 
 (* Flèche LSP backend handles the conversion at the protocol level *)
-let to_uri uri =
+let to_uri uri : _ Request.R.t =
   Lang.LUri.of_string uri |> Lang.LUri.File.of_uri
-  |> Result.map_error Petanque.Agent.Error.system
+  |> Result.map_error (fun msg ->
+         Petanque.Agent.Error.(make_request (system msg)))
 
 let uri_of_path path = Format.asprintf "file:///%s" path |> to_uri
 
@@ -109,9 +110,7 @@ let toc_to_info (name, node) =
   (name, ast.Fleche.Doc.Node.Ast.ast_info)
 
 let get_toc ~token:_ ~(doc : Fleche.Doc.t) :
-    ( (string * Lang.Ast.Info.t list option) list
-    , Petanque.Agent.Error.t )
-    Result.t =
+    (string * Lang.Ast.Info.t list option) list Petanque.Agent.R.t =
   let { Fleche.Doc.toc; _ } = doc in
   let toc = CString.Map.bindings toc |> List.filter_map toc_to_info in
   Ok toc

--- a/petanque/json_shell/shell.mli
+++ b/petanque/json_shell/shell.mli
@@ -22,13 +22,9 @@ val set_workspace :
   -> unit Agent.R.t
 
 val build_doc :
-     token:Coq.Limits.Token.t
-  -> uri:Lang.LUri.File.t
-  -> (Fleche.Doc.t, Agent.Error.t) Result.t
+  token:Coq.Limits.Token.t -> uri:Lang.LUri.File.t -> Fleche.Doc.t Agent.R.t
 
 val get_toc :
      token:Coq.Limits.Token.t
   -> doc:Fleche.Doc.t
-  -> ( (string * Lang.Ast.Info.t list option) list
-     , Petanque.Agent.Error.t )
-     Result.t
+  -> (string * Lang.Ast.Info.t list option) list Agent.R.t

--- a/petanque/test/basic_api.ml
+++ b/petanque/test/basic_api.ml
@@ -89,7 +89,8 @@ let multi_shot_test ~token ~doc =
 
 let fake_start_test ~token ~doc =
   match Agent.start ~token ~doc ~thm:"foo" () with
-  | Ok _ -> Error (Agent.Error.System "start on foo should have failed")
+  | Ok _ ->
+    Error (Agent.Error.make_request (System "start on foo should have failed"))
   | Error _ -> Ok None
 
 let main () =
@@ -105,7 +106,7 @@ let main () =
 let max = List.fold_left max min_int
 
 let check_no_goals = function
-  | Error err ->
+  | Error Request.Error.{ payload = err; _ } ->
     Format.eprintf "error: in execution: %s@\n%!" (Agent.Error.to_string err);
     dump_msgs ();
     129

--- a/petanque/test/test.v
+++ b/petanque/test/test.v
@@ -5,6 +5,11 @@ Qed.
 From Coq Require Import List.
 Import ListNotations.
 
+(* To test for search and feedbacks *)
+Inductive naat := OO.
+Lemma i_want_to_be_searched : naat.
+Proof. apply OO. Qed.
+
 Lemma rev_snoc_cons A :
   forall (x : A) (l : list A), rev (l ++ [x]) = x :: rev l.
 Proof.


### PR DESCRIPTION
This is important for many use cases. We also return feedback on petanque errors.

cc: @JulesViennotFranca