### PR TITLE
[petanque] Add `get_state` calls

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -66,6 +66,9 @@
  - [petanque] Add feedback field to `Run_result.t`, this is important
    for many use cases. We also return feedback on petanque errors.
    (@ejgallego, @JulesViennotFranca, #960)
+ - [petanque] new `get_state_at_pos` and `get_root_state` calls, that
+   allow to retrieve a petanque proof state from position
+   (@JulesViennotFranca, @ejgallego, #962)
 
 # coq-lsp 0.2.2: To Virtual or not To Virtual
 ---------------------------------------------

--- a/controller/lsp_core.ml
+++ b/controller/lsp_core.ml
@@ -490,6 +490,10 @@ let petanque_handle ~token =
     (* Request document execution if not ready *)
     let postpone = true in
     Rq.Action.(Data (DocRequest { uri; postpone; handler }))
+  | Interp.Action.Pos { uri; point; handler } ->
+    let version = None in
+    let postpone = true in
+    Rq.Action.(Data (PosRequest { uri; point; version; postpone; handler }))
 
 let do_petanque ~token method_ params =
   let open Petanque_json in

--- a/petanque/agent.mli
+++ b/petanque/agent.mli
@@ -101,6 +101,19 @@ end
     We could imagine a future where [State.t] need to be managed asynchronously,
     then the same approach that we use for [Doc.t] could happen. *)
 
+(** [get_root_state ?opts ~doc] return the root state of the document [doc]. *)
+val get_root_state :
+  ?opts:Run_opts.t -> doc:Fleche.Doc.t -> unit -> State.t Run_result.t R.t
+
+(** [get_state_at_pos ?opts ~doc ~point] return the state at position [point] in
+    [doc]. *)
+val get_state_at_pos :
+     ?opts:Run_opts.t
+  -> doc:Fleche.Doc.t
+  -> point:int * int
+  -> unit
+  -> State.t Run_result.t R.t
+
 (** [start ~token ~doc ~pre_commands ~thm] start a new proof for theorem [thm]
     in file [uri] under [fn]. [token] can be used to interrupt the computation.
     Returns the proof state or error otherwise. [pre_commands] is a string of

--- a/petanque/json/interp.mli
+++ b/petanque/json/interp.mli
@@ -17,6 +17,15 @@ module Action : sig
         ; handler :
             token:Coq.Limits.Token.t -> doc:Fleche.Doc.t -> json_rpc_result
         }
+    | Pos of
+        { uri : Lang.LUri.File.t
+        ; point : int * int
+        ; handler :
+               token:Coq.Limits.Token.t
+            -> doc:Fleche.Doc.t
+            -> point:int * int
+            -> json_rpc_result
+        }
 end
 
 type 'a handle = token:Coq.Limits.Token.t -> Action.t -> 'a

--- a/petanque/json/protocol.ml
+++ b/petanque/json/protocol.ml
@@ -18,6 +18,16 @@ module HType = struct
             -> 'p
             -> ('r, Error.t) Request.R.t
         }
+    | PosInDoc of
+        { uri_fn : 'p -> LUri.File.t
+        ; pos_fn : 'p -> int * int
+        ; handler :
+               token:Coq.Limits.Token.t
+            -> doc:Fleche.Doc.t
+            -> point:int * int
+            -> 'p
+            -> ('r, Error.t) Request.R.t
+        }
 end
 
 module type Handler = sig
@@ -50,6 +60,75 @@ module Request = struct
     end
 
     module Handler : Handler
+  end
+end
+
+(* get_root_state RPC *)
+module GetRootState = struct
+  let method_ = "petanque/get_root_state"
+
+  module Params = struct
+    type t =
+      { opts : Run_opts.t option [@default None]
+      ; uri : Lsp.JLang.LUri.File.t
+      }
+    [@@deriving yojson]
+  end
+
+  module Response = struct
+    type t = int Run_result.t [@@deriving yojson]
+  end
+
+  module Handler = struct
+    module Params = Params
+
+    module Response = struct
+      type t = State.t Run_result.t [@@deriving yojson]
+    end
+
+    let handler =
+      HType.FullDoc
+        { uri_fn = (fun { Params.uri; _ } -> uri)
+        ; handler =
+            (fun ~token:_ ~doc { opts; uri = _ } ->
+              Agent.get_root_state ?opts ~doc ())
+        }
+  end
+end
+
+(* get_state_at_pos RPC *)
+module GetStateAtPos = struct
+  let method_ = "petanque/get_state_at_pos"
+
+  module Params = struct
+    type t =
+      { uri : Lsp.JLang.LUri.File.t
+      ; opts : Run_opts.t option [@default None]
+      ; line : int
+      ; character : int
+      }
+    [@@deriving yojson]
+  end
+
+  module Response = struct
+    type t = int Run_result.t [@@deriving yojson]
+  end
+
+  module Handler = struct
+    module Params = Params
+
+    module Response = struct
+      type t = State.t Run_result.t [@@deriving yojson]
+    end
+
+    let handler =
+      HType.PosInDoc
+        { uri_fn = (fun { Params.uri; _ } -> uri)
+        ; pos_fn = (fun { line; character; _ } -> (line, character))
+        ; handler =
+            (fun ~token:_ ~doc ~point { uri = _; opts; line = _; character = _ } ->
+              Agent.get_state_at_pos ?opts ~doc ~point ())
+        }
   end
 end
 

--- a/petanque/json_shell/client.ml
+++ b/petanque/json_shell/client.ml
@@ -82,6 +82,14 @@ module S (C : Chans) = struct
     M.call
 
   (* Standard calls *)
+  let get_root_state =
+    let module M = Wrap (GetRootState) (C) in
+    M.call
+
+  let get_state_at_pos =
+    let module M = Wrap (GetStateAtPos) (C) in
+    M.call
+
   let start =
     let module M = Wrap (Start) (C) in
     M.call

--- a/petanque/json_shell/client.mli
+++ b/petanque/json_shell/client.mli
@@ -17,6 +17,12 @@ module S (C : Chans) : sig
   val toc :
     TableOfContents.Params.t -> (TableOfContents.Response.t, string) result
 
+  val get_root_state :
+    GetRootState.Params.t -> (GetRootState.Response.t, string) result
+
+  val get_state_at_pos :
+    GetStateAtPos.Params.t -> (GetStateAtPos.Response.t, string) result
+
   val start : Start.Params.t -> (Start.Response.t, string) result
   val run : RunTac.Params.t -> (RunTac.Response.t, string) result
   val goals : Goals.Params.t -> (Goals.Response.t, string) result

--- a/petanque/json_shell/interp_shell.ml
+++ b/petanque/json_shell/interp_shell.ml
@@ -15,6 +15,10 @@ let do_handle ~fn ~token action =
     let open Coq.Compat.Result.O in
     let* doc = fn ~token ~uri |> of_pet_err in
     handler ~token ~doc
+  | Action.Pos { uri; point; handler } ->
+    let open Coq.Compat.Result.O in
+    let* doc = fn ~token ~uri |> of_pet_err in
+    handler ~token ~doc ~point
 
 (* Duplicate with lsp_core *)
 let feedback_to_message fb =


### PR DESCRIPTION
We also introduce a position action so petanque requests can wait on the position. Written by Jules, with some cleanups by me.

Note we tweak some parameters to follow LSP names, like `line` and `character` for positions.