### PR TITLE
[lsp] [getDocument] Allow to get goals in one shot.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@ unreleased
  - [fleche] Support "rocq" markdown delimiters in .mv files
    (@ejgallego, #987)
  - [workspace] Support _RocqProject (@ejgallego, #988, fixes #934)
+ - [lsp] [getDocument] Allow to get goals in one shot. We also
+   refactor the response type to accommodate different
+   meta-data. Note: (!) breaking change. (@ejgallego, #985, fixes
+   #862, thanks to the Alectryon team)
 
 # coq-lsp 0.2.3: Barrage
 ------------------------

--- a/controller/rq_document.mli
+++ b/controller/rq_document.mli
@@ -5,4 +5,10 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-val request : (Yojson.Safe.t, string) Request.document
+val request :
+     ast:bool
+  -> goals:Rq_goals.format option
+  -> unit
+  -> (Yojson.Safe.t, string) Request.document
+
+(* Used by coq/getDocument *)

--- a/editor/code/lib/types.ts
+++ b/editor/code/lib/types.ts
@@ -90,24 +90,27 @@ export type PpString = Pp | string;
 
 export interface FlecheDocumentParams {
   textDocument: VersionedTextDocumentIdentifier;
+  ast?: boolean;
+  goals?: "Pp" | "Str";
 }
 
 // Status of the document, Yes if fully checked, range contains the last seen lexical token
-interface CompletionStatus {
+export interface CompletionStatus {
   status: ["Yes" | "Stopped" | "Failed"];
   range: Range;
 }
 
-// Implementation-specific span information, for now the serialized Ast if present.
-type SpanInfo = any;
-
-interface RangedSpan {
+// Implementation-specific span information, `range` is assured, the
+// other parameters will be present when requested in the call For
+// goals, we use the printing mode specified at initalization time
+export interface SpanInfo<Pp> {
   range: Range;
-  span?: SpanInfo;
+  ast?: any;
+  goals?: GoalAnswer<Pp>;
 }
 
-export interface FlecheDocument {
-  spans: RangedSpan[];
+export interface FlecheDocument<Pp> {
+  spans: SpanInfo<Pp>[];
   completed: CompletionStatus;
 }
 

--- a/editor/code/src/client.ts
+++ b/editor/code/src/client.ts
@@ -397,10 +397,12 @@ export function activateCoqLSP(
     heatMap.toggle();
   };
 
-  // Document request setup
-  const docReq = new RequestType<FlecheDocumentParams, FlecheDocument, void>(
-    "coq/getDocument"
-  );
+  // Document request setup, improve the type so the Pp format is matched
+  const docReq = new RequestType<
+    FlecheDocumentParams,
+    FlecheDocument<PpString>,
+    void
+  >("coq/getDocument");
 
   const getDocument = (editor: TextEditor) => {
     let uri = editor.document.uri;
@@ -409,7 +411,11 @@ export function activateCoqLSP(
       uri.toString(),
       version
     );
-    let params: FlecheDocumentParams = { textDocument };
+    let params: FlecheDocumentParams = {
+      textDocument,
+      ast: true,
+      goals: "Str",
+    };
     client.sendRequest(docReq, params).then((fd) => {
       // EJGA: uri_result could be used to set the suggested save path
       // for the new editor, however we need to see how to do that

--- a/etc/doc/PROTOCOL.md
+++ b/etc/doc/PROTOCOL.md
@@ -453,17 +453,20 @@ interface CoqFileProgressParams {
 ### Document Ast Request
 
 The `coq/getDocument` request returns a serialized version of Fleche's
-document. It is modelled after LSP's standard
-`textDocument/documentSymbol`, but returns instead the full document
-contents as understood by Flèche.
+document, plus some additional information for each sentence / node.
+
+It is modelled after LSP's standard `textDocument/documentSymbol`, but
+returns instead the full document contents as understood by Flèche.
 
 Caveats: Flèche notion of document is evolving, in particular you
-should not assume that the document will remain a list, but it will
-become a tree at some point.
+should not assume that the document will remain a list, more structure
+could be happening..
 
 ```typescript
 interface FlecheDocumentParams {
     textDocument: VersionedTextDocumentIdentifier;
+    ast ?: boolean;
+    goals ?: 'Pp' | 'Str';
 }
 ```
 
@@ -474,12 +477,13 @@ interface CompletionStatus {
     range : Range
 };
 
-// Implementation-specific span information, for now the serialized Ast if present.
-type SpanInfo = any;
-
-interface RangedSpan {
+// Implementation-specific span information, `range` is assured, the
+// other parameters will be present when requested in the call For
+// goals, we use the printing mode specified at initalization time
+interface SpanInfo {
     range : Range;
-    span?: SpanInfo
+    ast ?: any;
+    goals ?: GoalsAnswer<Pp>;
 };
 
 interface FlecheDocument {
@@ -516,6 +520,12 @@ The request will return `null`, or fail if not successful.
 <!-- TOC --><a name="changelog-3"></a>
 #### Changelog
 
+- v0.2.4: non-backwards compatible change! `RangedSpan` type is
+  removed in favor of `SpanInfo`. `SpanInfo` now contains a list of
+  properties, for now `range`, `ast`, `goals`, which are returned
+  depending on the request parameters, except for `range` which is
+  always present. New (optional) fields `ast` and `goals` are added to
+  `FlecheDocumentParams`.
 - v0.1.6: first version
 
 <!-- TOC --><a name="performance-data-notification"></a>

--- a/lsp/jCoq.ml
+++ b/lsp/jCoq.ml
@@ -87,9 +87,16 @@ module Declare = struct
     module View = struct
       module Obl = struct
         type t = [%import: Declare.OblState.View.Obl.t] [@@deriving to_yojson]
+
+        let of_yojson obj =
+          Serlib.Serlib_base.opaque_of_yojson ~typ:"Declare.OblState.View.Obl.t"
+            obj
       end
 
       type t = [%import: Declare.OblState.View.t] [@@deriving to_yojson]
+
+      let of_yojson obj =
+        Serlib.Serlib_base.opaque_of_yojson ~typ:"Declare.OblState.View.t" obj
     end
   end
 end

--- a/lsp/jFleche.ml
+++ b/lsp/jFleche.ml
@@ -93,7 +93,7 @@ module GoalsAnswer = struct
     ; messages : 'pp Message.t list
     ; error : 'pp option [@default None]
     }
-  [@@deriving to_yojson]
+  [@@deriving yojson]
 end
 
 (** Pull Diagnostics *)
@@ -106,16 +106,17 @@ module CompletionStatus = struct
 end
 
 module RangedSpan = struct
-  type t =
+  type 'pp t =
     { range : Lang.Range.t
-    ; span : Ast.t option [@default None]
+    ; ast : Ast.t option [@default None]
+    ; goals : 'pp GoalsAnswer.t option [@default None]
     }
   [@@deriving yojson]
 end
 
 module FlecheDocument = struct
-  type t =
-    { spans : RangedSpan.t list
+  type 'pp t =
+    { spans : 'pp RangedSpan.t list
     ; completed : CompletionStatus.t
     }
   [@@deriving yojson]

--- a/lsp/jFleche.mli
+++ b/lsp/jFleche.mli
@@ -75,16 +75,17 @@ module CompletionStatus : sig
 end
 
 module RangedSpan : sig
-  type t =
+  type 'pp t =
     { range : Lang.Range.t
-    ; span : Coq.Ast.t option [@default None]
+    ; ast : Coq.Ast.t option [@default None]
+    ; goals : 'pp GoalsAnswer.t option [@default None]
     }
-  [@@deriving to_yojson]
+  [@@deriving yojson]
 end
 
 module FlecheDocument : sig
-  type t =
-    { spans : RangedSpan.t list
+  type 'pp t =
+    { spans : 'pp RangedSpan.t list
     ; completed : CompletionStatus.t
     }
   [@@deriving to_yojson]

--- a/plugins/goaldump/main.ml
+++ b/plugins/goaldump/main.ml
@@ -2,6 +2,7 @@ module Lsp = Fleche_lsp
 open Fleche
 
 (* Put these in an utility function for plugins *)
+(* Duplicated with rq_document *)
 let of_execution ~io ~what (v : (_, _) Coq.Protect.E.t) =
   match v with
   | { r; feedback = _ } -> (


### PR DESCRIPTION
We allow the getDocument request to get goals in one shot, we refactor the response type as to allow us to make it more extensible for future use.

Note, this is a breaking change.

Thanks to Clément Pit-Claudel and Alectryon team.

Fixes: #862