### PR TITLE
[fleche] Support "rocq" markdown delimiters in .mv files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@ unreleased
  - [serlib] Support for generic Ast analyzers. This opens the door to
    many feature requests such as syntax coloring, dependency
    extraction, etc... (@ejgallego, @JulesViennotFranca, #981)
+ - [fleche] Support "rocq" markdown delimiters in .mv files
+   (@ejgallego, #987)
 
 # coq-lsp 0.2.3: Barrage
 ------------------------

--- a/editor/code/package.json
+++ b/editor/code/package.json
@@ -43,6 +43,7 @@
       {
         "id": "coq",
         "aliases": [
+          "rocq",
           "Coq",
           "coq",
           "Gallina",

--- a/editor/code/syntaxes/markdown-coq-codeblock.json
+++ b/editor/code/syntaxes/markdown-coq-codeblock.json
@@ -9,7 +9,7 @@
   ],
   "repository": {
     "coq-code-block": {
-      "begin": "coq(\\s+[^`~]*)?$",
+      "begin": "(coq|rocq)(\\s+[^`~]*)?$",
       "end": "(^|\\G)(?=\\s*[`~]{3,}\\s*$)",
       "patterns": [
         {

--- a/fleche/contents.ml
+++ b/fleche/contents.ml
@@ -51,8 +51,9 @@ module Markdown = struct
     | [] -> []
     | l :: ls ->
       (* opening vs closing a markdown block *)
-      let code_marker = if coq then "```" else "```coq" in
-      if String.equal code_marker l then gen l :: md_map_lines (not coq) ls
+      let code_marker = if coq then [ "```" ] else [ "```coq"; "```rocq" ] in
+      let check l c = List.exists (String.equal c) l in
+      if check code_marker l then gen l :: md_map_lines (not coq) ls
       else (if coq then l else gen l) :: md_map_lines coq ls
 
   let process text =


### PR DESCRIPTION
cc: #933