### PR TITLE
[lsp] Don't raise on URI parsing error.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@ unreleased
    refactor the response type to accommodate different
    meta-data. Note: (!) breaking change. (@ejgallego, #985, fixes
    #862, thanks to the Alectryon team)
+ - Better error handling in URI parsing (@ejgallego, #994, thanks to
+   Adrien from Zulip)
 
 # coq-lsp 0.2.3: Barrage
 ------------------------

--- a/lsp/jLang.ml
+++ b/lsp/jLang.ml
@@ -21,7 +21,12 @@ module LUri = struct
     type t = Lang.LUri.File.t
 
     let to_yojson uri = `String (Lang.LUri.File.to_string_uri uri)
-    let invalid_uri msg obj = raise (Yojson.Safe.Util.Type_error (msg, obj))
+
+    let invalid_uri msg obj =
+      let msg =
+        Format.asprintf "@[%s@] for object: @[%a@]" msg Yojson.Safe.pp obj
+      in
+      Error msg
 
     let of_yojson uri =
       match uri with

--- a/serlib/serlib_base.ml
+++ b/serlib/serlib_base.ml
@@ -37,7 +37,8 @@ let sexp_of_opaque ~typ _exp =
     Sexplib.Sexp.Atom ("["^typ^": ABSTRACT]")
 
 let opaque_of_yojson ~typ _obj =
-  raise (Ser_error ("["^typ^": ABSTRACT / cannot deserialize]"))
+  let msg = Format.asprintf "[%s: ABSTRACT / cannot deserialize from json]" typ in
+  Error msg
 
 let opaque_to_yojson ~typ _obj =
   let msg = "["^typ^": ABSTRACT]" in


### PR DESCRIPTION
This was making URI parsing errors very hard to catch, thanks to Adrian in Zulip for noticing this.