### PR TITLE
[lsp] Handle protocol extensions better

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,12 @@ unreleased
    #862, thanks to the Alectryon team)
  - Better error handling in URI parsing (@ejgallego, #994, thanks to
    Adrien from Zulip)
+ - Better protocol-level handling for our non-standard `Lang.Point`
+   and `Lang.Diagnostic` types, via global flags that allow us to
+   choose the input/output representation for non-standard field such
+   as [Point.offset]. This ensures that leaks of these non-standard
+   fields are rarer. (@ejgallego, #995, cc #279, cc #2, thanks to
+   Adrien from Zulip)
 
 # coq-lsp 0.2.3: Barrage
 ------------------------

--- a/controller/lsp_core.ml
+++ b/controller/lsp_core.ml
@@ -448,10 +448,8 @@ let do_lens = do_document_request_maybe ~handler:Rq_lens.request
 (* could be smarter *)
 let do_action ~params =
   let range = field "range" params in
-  match Lsp.JLang.Diagnostic.Range.of_yojson range with
-  | Ok range ->
-    let range = Lsp.JLang.Diagnostic.Range.vnoc range in
-    do_immediate ~params ~handler:(Rq_action.request ~range)
+  match Lsp.JLang.Range.of_yojson range with
+  | Ok range -> do_immediate ~params ~handler:(Rq_action.request ~range)
   | Error err ->
     (* XXX: We really need to fix the parsing error handling in lsp_core, we got
        it right in petanque haha *)
@@ -468,9 +466,9 @@ let do_cancel ~ofn_rq ~params =
 let do_cache_trim ~io = Nt_cache_trim.notification ~io
 
 let do_viewRange params =
-  match List.assoc "range" params |> Lsp.JLang.Diagnostic.Range.of_yojson with
+  match List.assoc "range" params |> Lsp.JLang.Range.of_yojson with
   | Ok range ->
-    let { Lsp.JLang.Diagnostic.Range.end_ = { line; character }; _ } = range in
+    let { Lang.Range.end_ = { line; character; offset = _ }; _ } = range in
     L.trace "viewRange" "l: %d c:%d" line character;
     let uri = Helpers.get_uri params in
     Fleche.Theory.Check.set_scheduler_hint ~uri ~point:(line, character);

--- a/lsp/jLang.mli
+++ b/lsp/jLang.mli
@@ -6,6 +6,22 @@
 (************************************************************************)
 
 module Point : sig
+  module Mode : sig
+    (** Internally, Flèche always works with a point type which includes
+        {i both} line/column and offset information. However, this is beyond the
+        LSP standard, so clients can configure the input / output behavior here *)
+    type t =
+      | LineColumn
+          (** Points are standard LSP objects with [line] [character] field;
+              this is the default *)
+      | Offset  (** Points are objects with only the [offset] *)
+      | Full
+          (** Points include / require [line], [character], and [offset] field *)
+
+    (** Set the mode for serialization. *)
+    val set : t -> unit
+  end
+
   type t = Lang.Point.t [@@deriving yojson]
 end
 
@@ -20,25 +36,18 @@ module LUri : sig
 end
 
 module Diagnostic : sig
+  module Mode : sig
+    (** Flèche diagnostics store the message as a Pp.t box format, but usually
+        LSP standard mandates the [message] field to be a string, thus we allow
+        clients to select the mode. *)
+    type t =
+      | String
+      | Pp
+
+    val set : t -> unit
+  end
+
   type t = Lang.Diagnostic.t [@@deriving yojson]
-
-  module Point : sig
-    type t =
-      { line : int
-      ; character : int
-      }
-    [@@deriving yojson]
-  end
-
-  module Range : sig
-    type t =
-      { start : Point.t
-      ; end_ : Point.t [@key "end"]
-      }
-    [@@deriving yojson]
-
-    val vnoc : t -> Lang.Range.t
-  end
 end
 
 module Ast : sig


### PR DESCRIPTION
We introduce two global flags to control how we process input/output for our extended types [Lang.Point] and [Lang.Diagnostic]

- In the case of [Lang.Point], Flèche works internally with both line / column and offsets, however we don't want to require / output offsets when in LSP mode. For now, we allow the clients to select the 3 modes.

  Note that more changes are needed to support properly offset-based editors, but this PR has as a goal to remove breakage from clients that follow LSP.

- For [Lang.Diagnostic], we store the messages in a rich format, but LSP expects a string, so we allow the client to select this.

Thanks to Adrian from Zulip for bringing this problem to my attention.

cc: #279 #2