### PR TITLE
[lsp] Return executed sentence info in goal request.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,6 @@
 unreleased
 ----------
 
- - [lsp] [vscode] Unicode completion commit characters are now configurable via server settings. (@Durbatuluk1701)
  - [js] [deps] Bump to findlib 1.9.8, use vanilla API for loading and
    remove our own local wrapper (@ejgallego, #975).
  - [petanque] New `petanque/ast` and `petanque/ast_at_pos`
@@ -24,6 +23,13 @@ unreleased
    as [Point.offset]. This ensures that leaks of these non-standard
    fields are rarer. (@ejgallego, #995, cc #279, cc #2, thanks to
    Adrien from Zulip)
+ - [lsp] [completion] Rework completion configuration into a
+   `coq-lsp.completion` json object. The `unicode_completion` setting
+   is now deprecated, and has been replaced by
+   `completion.unicode.enable` (@ejgallego, #993)
+ - [lsp] [completion] [vscode] Unicode completion commit characters
+   are now configurable via the server setting variable
+   `completion.unicode.commit_chars`. (@Durbatuluk1701, #993)
 
 # coq-lsp 0.2.3: Barrage
 ------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,9 +15,9 @@ unreleased
    refactor the response type to accommodate different
    meta-data. Note: (!) breaking change. (@ejgallego, #985, fixes
    #862, thanks to the Alectryon team)
- - Better error handling in URI parsing (@ejgallego, #994, thanks to
+ - [lsp] Better error handling in URI parsing (@ejgallego, #994, thanks to
    Adrien from Zulip)
- - Better protocol-level handling for our non-standard `Lang.Point`
+ - [lsp] Better protocol-level handling for our non-standard `Lang.Point`
    and `Lang.Diagnostic` types, via global flags that allow us to
    choose the input/output representation for non-standard field such
    as [Point.offset]. This ensures that leaks of these non-standard
@@ -30,6 +30,12 @@ unreleased
  - [lsp] [completion] [vscode] Unicode completion commit characters
    are now configurable via the server setting variable
    `completion.unicode.commit_chars`. (@Durbatuluk1701, #993)
+ - [goals] [config] New (global) option for goal display method
+   `proof/goals`: `messages_follow_goal`. If `true`, `proof/goals`
+   will show errors and messages for the same sentence goals are
+   shown; if `false`, it will always show errors and messages for the
+   specified `position`, if there is a Rocq sentence at hand
+   (@jpoiret, @ejgallego, #999, fixes: #941)
 
 # coq-lsp 0.2.3: Barrage
 ------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 unreleased
 ----------
 
+ - [lsp] [vscode] Unicode completion commit characters are now configurable via server settings. (@Durbatuluk1701)
  - [js] [deps] Bump to findlib 1.9.8, use vanilla API for loading and
    remove our own local wrapper (@ejgallego, #975).
  - [petanque] New `petanque/ast` and `petanque/ast_at_pos`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,7 @@ out `coq-lsp` development versions with other OPAM packages.
 
 You can just do:
 ```
+make submodules-init            # Only needed if submodules not initialized
 make opam-update-and-reinstall
 ```
 

--- a/controller/rq_completion.ml
+++ b/controller/rq_completion.ml
@@ -49,14 +49,10 @@ let mk_edit (line, character) newText =
   let replace = insert in
   TextEditReplace.{ insert; replace; newText }
 
-let unicode_commit_chars =
-  [ " "; "("; ")"; ","; "."; "-"; "'" ]
-  @ [ "0"; "1"; "2"; "3"; "4"; "5"; "6"; "7"; "8"; "9" ]
-
 let mk_unicode_completion_item point (label, newText) =
   let labelDetails = LabelDetails.{ detail = " ← " ^ newText } in
   let textEdit = mk_edit point newText in
-  let commitCharacters = unicode_commit_chars in
+  let commitCharacters = !Fleche.Config.v.unicode_commit_chars in
   mk_completion ~label ~labelDetails ~textEdit ~commitCharacters ()
 
 let unicode_list point : Yojson.Safe.t list =

--- a/controller/rq_completion.ml
+++ b/controller/rq_completion.ml
@@ -52,7 +52,7 @@ let mk_edit (line, character) newText =
 let mk_unicode_completion_item point (label, newText) =
   let labelDetails = LabelDetails.{ detail = " ← " ^ newText } in
   let textEdit = mk_edit point newText in
-  let commitCharacters = !Fleche.Config.v.unicode_commit_chars in
+  let commitCharacters = !Fleche.Config.v.completion.unicode.commit_chars in
   mk_completion ~label ~labelDetails ~textEdit ~commitCharacters ()
 
 let unicode_list point : Yojson.Safe.t list =

--- a/controller/rq_goals.ml
+++ b/controller/rq_goals.ml
@@ -50,6 +50,17 @@ let get_goal_info ~token ~doc ~point ~mode ~pretac () =
     let program = Info.Goals.program ~st in
     (goals, Some program)
 
+let get_node_info ~doc ~point ~mode =
+  let open Fleche in
+  let mode =
+    if !Fleche.Config.v.messages_follow_goal then mode else Info.Exact
+  in
+  let node = Info.LC.node ~doc ~point mode in
+  let range = Option.map Doc.Node.range node in
+  let messages = mk_messages node in
+  let error = Option.bind node mk_error in
+  (range, messages, error)
+
 let goals ~pp_format ~mode ~pretac () ~token ~doc ~point =
   let open Fleche in
   let uri, version = (doc.Doc.uri, doc.version) in
@@ -59,10 +70,7 @@ let goals ~pp_format ~mode ~pretac () ~token ~doc ~point =
   in
   let open Coq.Protect.E.O in
   let+ goals, program = get_goal_info ~token ~doc ~point ~mode ~pretac () in
-  let node = Info.LC.node ~doc ~point mode in
-  let range = Option.map Fleche.Doc.Node.range node in
-  let messages = mk_messages node in
-  let error = Option.bind node mk_error in
+  let range, messages, error = get_node_info ~doc ~point ~mode in
   let pp = pp ~pp_format in
   Lsp.JFleche.GoalsAnswer.(
     to_yojson pp

--- a/controller/rq_goals.ml
+++ b/controller/rq_goals.ml
@@ -59,7 +59,7 @@ let goals ~pp_format ~mode ~pretac () ~token ~doc ~point =
   in
   let open Coq.Protect.E.O in
   let+ goals, program = get_goal_info ~token ~doc ~point ~mode ~pretac () in
-  let node = Info.LC.node ~doc ~point Exact in
+  let node = Info.LC.node ~doc ~point mode in
   let range = Option.map Fleche.Doc.Node.range node in
   let messages = mk_messages node in
   let error = Option.bind node mk_error in

--- a/controller/unicode_bindings.ml
+++ b/controller/unicode_bindings.ml
@@ -1698,8 +1698,13 @@ let extended =
   ; ("\\_x", "ₓ")
   ]
 
-let from_config () =
+let get_config () =
   match !Fleche.Config.v.unicode_completion with
+  | None -> !Fleche.Config.v.completion.unicode.enabled
+  | Some v -> v
+
+let from_config () =
+  match get_config () with
   | Off -> []
   | Internal_small -> small
   | Normal -> normal

--- a/editor/code/package.json
+++ b/editor/code/package.json
@@ -290,6 +290,11 @@
               "Use jsCoq's Pp rich layout printer",
               "Coq Layout Engine (experimental)"
             ]
+          },
+          "coq-lsp.messages_follow_goal": {
+            "type": "boolean",
+            "default": false,
+            "description": "If enabled, errors and messages will be shown using the `goal_after_tactic` setting, otherwise, they always correspond to the requested position"
           }
         }
       },

--- a/editor/code/package.json
+++ b/editor/code/package.json
@@ -362,6 +362,12 @@
               "extended"
             ],
             "description": "Enable Server-Side Unicode Completion. Coq-lsp provides two character sets, a regular one, and an extended one with more than 1000 symbols."
+          },
+          "coq-lsp.unicode_commit_chars": {
+            "type": "array",
+            "items": { "type": "string" },
+            "default": [" ", "(", ")", ",", ".", "-", "'", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9"],
+            "description": "Characters that will commit a unicode completion. This controls which characters will accept a completion item when typed."
           }
         }
       },

--- a/editor/code/package.json
+++ b/editor/code/package.json
@@ -350,12 +350,13 @@
         }
       },
       {
-        "title": "Input",
+        "title": "Completion",
         "type": "object",
         "properties": {
-          "coq-lsp.unicode_completion": {
+          "coq-lsp.completion.unicode.enabled": {
             "type": "string",
             "default": "normal",
+            "order": 1,
             "enum": [
               "off",
               "normal",
@@ -363,10 +364,31 @@
             ],
             "description": "Enable Server-Side Unicode Completion. Coq-lsp provides two character sets, a regular one, and an extended one with more than 1000 symbols."
           },
-          "coq-lsp.unicode_commit_chars": {
+          "coq-lsp.completion.unicode.commit_chars": {
             "type": "array",
-            "items": { "type": "string" },
-            "default": [" ", "(", ")", ",", ".", "-", "'", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9"],
+            "order": 99,
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              " ",
+              "(",
+              ")",
+              ",",
+              ".",
+              "-",
+              "'",
+              "0",
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9"
+            ],
             "description": "Characters that will commit a unicode completion. This controls which characters will accept a completion item when typed."
           }
         }

--- a/editor/code/src/config.ts
+++ b/editor/code/src/config.ts
@@ -13,6 +13,7 @@ export interface CoqLspServerConfig {
   client_version: string;
   eager_diagnostics: boolean;
   goal_after_tactic: boolean;
+  messages_follow_goal: boolean;
   show_coq_info_messages: boolean;
   show_notices_as_diagnostics: boolean;
   admit_on_bad_qed: boolean;
@@ -37,6 +38,7 @@ export namespace CoqLspServerConfig {
       client_version: client_version,
       eager_diagnostics: wsConfig.eager_diagnostics,
       goal_after_tactic: wsConfig.goal_after_tactic,
+      messages_follow_goal: wsConfig.messages_follow_goal,
       show_coq_info_messages: wsConfig.show_coq_info_messages,
       show_notices_as_diagnostics: wsConfig.show_notices_as_diagnostics,
       admit_on_bad_qed: wsConfig.admit_on_bad_qed,

--- a/editor/code/src/config.ts
+++ b/editor/code/src/config.ts
@@ -1,5 +1,14 @@
 import { TextDocumentFilter } from "vscode-languageclient";
 
+export interface UnicodeCompletionConfig {
+  enabled: "off" | "normal" | "extended";
+  commit_chars: string[];
+}
+
+export interface CompletionConfig {
+  unicode: UnicodeCompletionConfig;
+}
+
 export interface CoqLspServerConfig {
   client_version: string;
   eager_diagnostics: boolean;
@@ -8,7 +17,6 @@ export interface CoqLspServerConfig {
   show_notices_as_diagnostics: boolean;
   admit_on_bad_qed: boolean;
   debug: boolean;
-  unicode_completion: "off" | "normal" | "extended";
   max_errors: number;
   pp_type: 0 | 1 | 2;
   show_stats_on_hover: boolean;
@@ -17,7 +25,7 @@ export interface CoqLspServerConfig {
   show_state_hash_on_hover: boolean;
   check_only_on_request: boolean;
   send_perf_data: boolean;
-  unicode_commit_chars: string[];
+  completion: CompletionConfig;
 }
 
 export namespace CoqLspServerConfig {
@@ -33,7 +41,6 @@ export namespace CoqLspServerConfig {
       show_notices_as_diagnostics: wsConfig.show_notices_as_diagnostics,
       admit_on_bad_qed: wsConfig.admit_on_bad_qed,
       debug: wsConfig.debug,
-      unicode_completion: wsConfig.unicode_completion,
       max_errors: wsConfig.max_errors,
       pp_type: wsConfig.pp_type,
       show_stats_on_hover: wsConfig.show_stats_on_hover,
@@ -42,7 +49,7 @@ export namespace CoqLspServerConfig {
       show_state_hash_on_hover: wsConfig.show_state_hash_on_hover,
       check_only_on_request: wsConfig.check_only_on_request,
       send_perf_data: wsConfig.send_perf_data,
-      unicode_commit_chars: wsConfig.unicode_commit_chars,
+      completion: wsConfig.completion,
     };
   }
 }

--- a/editor/code/src/config.ts
+++ b/editor/code/src/config.ts
@@ -17,6 +17,7 @@ export interface CoqLspServerConfig {
   show_state_hash_on_hover: boolean;
   check_only_on_request: boolean;
   send_perf_data: boolean;
+  unicode_commit_chars: string[];
 }
 
 export namespace CoqLspServerConfig {
@@ -41,6 +42,7 @@ export namespace CoqLspServerConfig {
       show_state_hash_on_hover: wsConfig.show_state_hash_on_hover,
       check_only_on_request: wsConfig.check_only_on_request,
       send_perf_data: wsConfig.send_perf_data,
+      unicode_commit_chars: wsConfig.unicode_commit_chars,
     };
   }
 }

--- a/etc/doc/PROTOCOL.md
+++ b/etc/doc/PROTOCOL.md
@@ -610,6 +610,15 @@ the `initializationOptions` parameter for the LSP `init` method.
 As of today, the server exposes the following parameters:
 
 ```typescript
+export interface UnicodeCompletionConfig {
+    enabled: "off" | "normal" | "extended";
+    commit_chars : string[];
+}
+
+export interface CompletionConfig {
+    unicode: UnicodeCompletionConfig
+}
+
 export interface CoqLspServerConfig {
   client_version: string;
   eager_diagnostics: boolean;
@@ -618,7 +627,7 @@ export interface CoqLspServerConfig {
   show_notices_as_diagnostics: boolean;
   admit_on_bad_qed: boolean;
   debug: boolean;
-  unicode_completion: "off" | "normal" | "extended";
+  unicode_completion: "off" | "normal" | "extended"; // Deprecated
   max_errors: number;
   pp_type: 0 | 1 | 2;
   show_stats_on_hover: boolean;
@@ -627,6 +636,7 @@ export interface CoqLspServerConfig {
   show_state_hash_on_hover: boolean;
   check_only_on_request: boolean;
   send_perf_data: boolean;
+  completion: CompletionConfig
 }
 ```
 
@@ -636,6 +646,9 @@ client.
 <!-- TOC --><a name="changelog-5"></a>
 #### Changelog
 
+- v0.2.4:
+  + Deprecate `unicode_completion` in favor of new `completion:
+    CompletionConfig` configuration record.
 - v0.2.3: New options, `show_universes_on_hover`,
   `show_state_hash_on_hover`, `send_perf_data`.
 - v0.1.9: First public documentation.

--- a/etc/doc/PROTOCOL.md
+++ b/etc/doc/PROTOCOL.md
@@ -280,7 +280,11 @@ interface GoalRequest {
 The `textDocument` and `position` parameters are standard.
 
 Note that `rocq-lsp` will execute the Rocq document up to the
-`position` specified in the request paremeters.
+sentence specified in the request by the `position` and `mode` paremeters.
+
+- `mode` (if absent, the `goal_after_tactic` parameter will be used)
+  controls whether the sentence ending before or after `position` is
+  the subject of the request.
 
 - `pp_format` controls the pretty printing format used in the
   results. `Pp` will return goals using Rocq's pretty-printing type
@@ -289,13 +293,8 @@ Note that `rocq-lsp` will execute the Rocq document up to the
   message bodies in plain text.
 
 - `command`, is a list of Coq commands that will be run just _after_
-  `position` in `textDocument`, but _before_ goals are sent to the
+  the specified sentence, but _before_ goals are sent to the
   user. This is often useful for ephemeral post-processing of goals.
-
-- `mode` (if absent, the `goal_after_tactic` parameter will be used)
-  controls whether the goals returned correspond to `position` or to
-  the previous sentence in the document. `messages` and `error` below
-  are always returned for the specified `position`.
 
 The answer to the `proof/goals` request is a `GoalAnswer` object,
 where:
@@ -360,11 +359,10 @@ The main objects of interest are:
   sentence.
 
 - `GoalAnswer`: In addition to the goals at point, `GoalAnswer`
-  contains messages associated to `position` and the top `error` if
-  pertinent. `range` contains the span of the Rocq sentence at
-  `position`, if exists. Note that Rocq will skip some blank spaces
-  when parsing, so there are parts of a document that have no
-  corresponding `range` attached.
+  contains Rocq messages and the top `error` if pertinent. `range`
+  contains the span of the executed Rocq sentence, if exists. Note
+  that Rocq will skip some blank spaces when parsing, so there are
+  parts of a document that have no corresponding `range` attached.
 
 An example for `stack` is the following Coq script:
 ```coq

--- a/fleche/config.ml
+++ b/fleche/config.ml
@@ -68,8 +68,16 @@ type t =
   ; eager_diagnostics : bool [@default true]
         (** [eager_diagnostics] Send (full) diagnostics after processing each *)
   ; goal_after_tactic : bool [@default true]
-        (** When showing goals and the cursor is in a tactic, if false, show
-            goals before executing the tactic, if true, show goals after *)
+        (** [proof/goals] setting: if [false], show goals before executing the
+            tactic, if [true], show goals after. If there is no sentence at
+            [position], show the goals of the closest sentence in the document
+            backwards. *)
+  ; messages_follow_goal : bool [@default false]
+        (** [proof/goals] setting: if [true], messages and errors will be
+            displayed following the [goal_after_tactic] setting. When [false],
+            the default, we will always shows messages and errors corresponding
+            to the sentence at [position]. If there is no sentence at
+            [position], we show nothing. *)
   ; show_coq_info_messages : bool [@default false]
         (** Show `msg_info` messages in diagnostics *)
   ; show_notices_as_diagnostics : bool [@default false]
@@ -117,7 +125,8 @@ let default =
   ; gc_quick_stats = true
   ; client_version = "any"
   ; eager_diagnostics = true
-  ; goal_after_tactic = false
+  ; goal_after_tactic = true
+  ; messages_follow_goal = false
   ; show_coq_info_messages = false
   ; show_notices_as_diagnostics = false
   ; admit_on_bad_qed = true

--- a/fleche/config.ml
+++ b/fleche/config.ml
@@ -6,12 +6,55 @@
 (* Written by: Emilio J. Gallego Arias & coq-lsp contributors           *)
 (************************************************************************)
 
-module Unicode_completion = struct
-  type t =
-    | Off
-    | Internal_small
-    | Normal
-    | Extended
+module Completion = struct
+  (** Module that enables LaTeX-like completion for unicode symbols *)
+  module Unicode = struct
+    module Mode = struct
+      type t =
+        | Off
+        | Internal_small
+        | Normal
+        | Extended
+    end
+
+    let default_commit_chars =
+      [ " "
+      ; "("
+      ; ")"
+      ; ","
+      ; "."
+      ; "-"
+      ; "'"
+      ; "0"
+      ; "1"
+      ; "2"
+      ; "3"
+      ; "4"
+      ; "5"
+      ; "6"
+      ; "7"
+      ; "8"
+      ; "9"
+      ]
+
+    type t =
+      { enabled : Mode.t
+      ; commit_chars : string list [@default default_commit_chars]
+            (** Characters to use for accepting/commiting a completion during
+                unicode completion *)
+      }
+
+    let default =
+      let enabled = Mode.Normal in
+      let commit_chars = default_commit_chars in
+      { enabled; commit_chars }
+  end
+
+  type t = { unicode : Unicode.t }
+
+  let default =
+    let unicode = Unicode.default in
+    { unicode }
 end
 
 type t =
@@ -38,8 +81,8 @@ type t =
             YMMV. *)
   ; debug : bool [@default false]
         (** Enable debug on Coq side, including backtraces *)
-  ; unicode_completion : Unicode_completion.t
-        [@default Unicode_completion.Normal]
+  ; unicode_completion : Completion.Unicode.Mode.t option [@default None]
+        (** deprecated, use [completion.unicode.enabled] *)
   ; max_errors : int [@default 150]
   ; pp_type : int [@default 0]
         (** Pretty-printing type in Info Panel Request, 0 = string; 1 = Pp.t; 2
@@ -66,9 +109,7 @@ type t =
         (** Send extra diagnostic data on the `data` diagnostic field. *)
   ; send_serverStatus : bool [@default true]
         (** Send server status client notification to the client *)
-  ; unicode_commit_chars : string list [@default [ " "; "("; ")"; ","; "."; "-"; "'"; "0"; "1"; "2"; "3"; "4"; "5"; "6"; "7"; "8"; "9" ]]
-        (** Characters to use for accepting/commiting a completion
-            during unicode completion *)
+  ; completion : Completion.t [@default Completion.default]
   }
 
 let default =
@@ -81,7 +122,7 @@ let default =
   ; show_notices_as_diagnostics = false
   ; admit_on_bad_qed = true
   ; debug = false
-  ; unicode_completion = Normal
+  ; unicode_completion = None
   ; max_errors = 150
   ; pp_type = 0
   ; show_stats_on_hover = false
@@ -95,7 +136,7 @@ let default =
   ; check_only_on_request = false
   ; send_diags_extra_data = false
   ; send_serverStatus = true
-  ; unicode_commit_chars = [ " "; "("; ")"; ","; "."; "-"; "'"; "0"; "1"; "2"; "3"; "4"; "5"; "6"; "7"; "8"; "9" ]
+  ; completion = Completion.default
   }
 
 let v = ref default

--- a/fleche/config.ml
+++ b/fleche/config.ml
@@ -66,6 +66,9 @@ type t =
         (** Send extra diagnostic data on the `data` diagnostic field. *)
   ; send_serverStatus : bool [@default true]
         (** Send server status client notification to the client *)
+  ; unicode_commit_chars : string list [@default [ " "; "("; ")"; ","; "."; "-"; "'"; "0"; "1"; "2"; "3"; "4"; "5"; "6"; "7"; "8"; "9" ]]
+        (** Characters to use for accepting/commiting a completion
+            during unicode completion *)
   }
 
 let default =
@@ -92,6 +95,7 @@ let default =
   ; check_only_on_request = false
   ; send_diags_extra_data = false
   ; send_serverStatus = true
+  ; unicode_commit_chars = [ " "; "("; ")"; ","; "."; "-"; "'"; "0"; "1"; "2"; "3"; "4"; "5"; "6"; "7"; "8"; "9" ]
   }
 
 let v = ref default

--- a/lsp/jFleche.ml
+++ b/lsp/jFleche.ml
@@ -22,25 +22,38 @@ module Lang = JLang
 module Names = Serlib.Ser_names
 
 module Config = struct
-  module Unicode_completion = struct
-    type t = [%import: Fleche.Config.Unicode_completion.t]
+  module Completion = struct
+    module Unicode = struct
+      module Mode = struct
+        type t = [%import: Fleche.Config.Completion.Unicode.Mode.t]
 
-    let to_yojson = function
-      | Off -> `String "off"
-      | Internal_small -> `String "internal"
-      | Normal -> `String "normal"
-      | Extended -> `String "extended"
+        let to_yojson = function
+          | Off -> `String "off"
+          | Internal_small -> `String "internal"
+          | Normal -> `String "normal"
+          | Extended -> `String "extended"
 
-    let of_yojson (j : Yojson.Safe.t) : (t, string) Result.t =
-      match j with
-      | `String "off" -> Ok Off
-      | `String "internal" -> Ok Internal_small
-      | `String "normal" -> Ok Normal
-      | `String "extended" -> Ok Extended
-      | _ ->
-        Error
-          "Fleche.Config.Unicode_completion.t: expected one of \
-           [off,normal,extended]"
+        let of_yojson (j : Yojson.Safe.t) : (t, string) Result.t =
+          match j with
+          | `String "off" -> Ok Off
+          | `String "internal" -> Ok Internal_small
+          | `String "normal" -> Ok Normal
+          | `String "extended" -> Ok Extended
+          | _ ->
+            Error
+              "Fleche.Config.Completion.Unicode.Mode.t: expected one of \
+               [off,normal,extended]"
+      end
+
+      let default_commit_chars =
+        Fleche.Config.Completion.Unicode.default_commit_chars
+
+      type t = [%import: Fleche.Config.Completion.Unicode.t] [@@deriving yojson]
+    end
+
+    let default = Fleche.Config.Completion.default
+
+    type t = [%import: Fleche.Config.Completion.t] [@@deriving yojson]
   end
 
   type t = [%import: Fleche.Config.t] [@@deriving yojson]


### PR DESCRIPTION
All info returned by a `proof/goals` request should be about the sentence requested by the user, whereas currently only `goals` follows this, and `messages`, `error` and `range` are about the sentence under point instead. IMO this is bad UX and may mislead users, as the goal display is de-correlated from the associated info and error messages and range indicators.

There is no loss of information here, as anyways diagnostics are sent back with their range info using the usual LSP mechanisms, and the user can peruse those under point using the standard method of their editor.

WDYT?

PS: I didn't put anything under the changelogs because I don't know what the policy is esp. regarding versioning (this is a breaking change).

fix: #941 