### PR TITLE
[ci] Test coq-lsp on OxCaml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,11 @@ jobs:
           - os: ubuntu-latest
             ocaml: 5.2.x
           - os: ubuntu-latest
+            ocaml: ocaml-variants.5.2.0+ox
+            repositories: |
+              ox: https://github.com/oxcaml/opam-repository.git
+              default: https://github.com/ocaml/opam-repository.git
+          - os: ubuntu-latest
             ocaml: 5.3.x
           - os: macos-latest
             ocaml: 4.14.x
@@ -56,6 +61,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
 
+    env:
+      opam-default-repos: "default: https://github.com/ocaml/opam-repository.git"
+
     steps:
       - name: 🔭 Checkout code
         uses: actions/checkout@v5
@@ -66,6 +74,7 @@ jobs:
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml }}
+          opam-repositories: ${{ matrix.repositories || env.opam-default-repos }}
           dune-cache: true
 
       - name: 🐫🐪🐫 Get dependencies

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,7 @@ unreleased
    `Pcoq.unfreeze` but that is not enough, in particular the call to
    `get_default_proof_mode` will not be correct (@ejgallego, @pimotte,
    #1011, fixes #656)
+ - [ci] CI support for OxCaml (@ejgallego, #1009)
 
 # coq-lsp 0.2.3: Barrage
 ------------------------

--- a/coq-lsp.opam
+++ b/coq-lsp.opam
@@ -43,7 +43,7 @@ depends: [
   # "rocq-prover"          { >= "9.1" < "9.2"  }
 
   # [release branch] Remove
-  "zarith" {>= "1.13"}
+  "zarith" {>= "1.12"}
 
   # serlib deps: see what we need to keep for release
   "ppx_deriving"        { >= "5.2"                 }


### PR DESCRIPTION
We relax zarith as only 1.12 is available in ox repos.