### PR TITLE
[code] [web] Fix server config error due to proxy value.

### DIFF
--- a/editor/code/src/config.ts
+++ b/editor/code/src/config.ts
@@ -51,7 +51,9 @@ export namespace CoqLspServerConfig {
       show_state_hash_on_hover: wsConfig.show_state_hash_on_hover,
       check_only_on_request: wsConfig.check_only_on_request,
       send_perf_data: wsConfig.send_perf_data,
-      completion: wsConfig.completion,
+      // VSCode wraps wsConfig.completion into a Proxy, which cannot
+      // be sent to a Web Worker, tricky stuff...
+      completion: JSON.parse(JSON.stringify(wsConfig.completion)),
     };
   }
 }


### PR DESCRIPTION
VSCode will use a proxy for non-literal config values, which will make the LSP Workers fail to initialize due `postMessage` failing.

We workaround that, in the hopes it doesn't occur too often.

This was introduced in #993