### PR TITLE
[lsp] [didOpen] Respect `languageId` parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,8 @@ unreleased
    @pimotte, #1008, cc #833, fixes #907, fixes #908, fixes #913)
  - [opam] Added `x-maintenance-intent` intent field. (@ejgallego,
    #1020)
+ - [lsp] [didOpen] `languageId` now takes priority over uri extension
+   in LSP `didOpen`. (@ejgallego, #1021, fixes #1005)
 
 # coq-lsp 0.2.3: Barrage
 ------------------------

--- a/compiler/compile.ml
+++ b/compiler/compile.ml
@@ -38,11 +38,12 @@ let compile_file ~cc file : int =
   match Lang.LUri.(File.of_uri (of_string file)) with
   | Error _ -> 222
   | Ok uri -> (
+    let languageId = "rocq" in
     let workspace = workspace_of_uri ~io ~workspaces ~uri ~default in
     let files = Coq.Files.make () in
     let env = Doc.Env.make ~init:root_state ~workspace ~files in
     let raw = Coq.Compat.Ocaml_414.In_channel.(with_open_bin file input_all) in
-    let () = Theory.open_ ~io ~token ~env ~uri ~raw ~version:1 in
+    let () = Theory.open_ ~io ~token ~env ~uri ~languageId ~raw ~version:1 in
     match Theory.Check.maybe_check ~io ~token with
     | None -> 102
     | Some (_, doc) ->

--- a/controller/lsp_core.ml
+++ b/controller/lsp_core.ml
@@ -283,11 +283,11 @@ let do_open ~io ~token ~(state : State.t) params =
     field "textDocument" params
     |> Lsp.Doc.TextDocumentItem.of_yojson |> Result.get_ok
   in
-  let Lsp.Doc.TextDocumentItem.{ uri; version; text; _ } = document in
+  let Lsp.Doc.TextDocumentItem.{ uri; version; text; languageId } = document in
   let init, workspace = State.workspace_of_uri ~io ~uri ~state in
   let files = Coq.Files.make () in
   let env = Fleche.Doc.Env.make ~init ~workspace ~files in
-  Fleche.Theory.open_ ~io ~token ~env ~uri ~raw:text ~version
+  Fleche.Theory.open_ ~io ~token ~env ~uri ~languageId ~raw:text ~version
 
 let do_change ~ofn_rq ~io ~token params =
   let uri, version = Helpers.get_uri_version params in

--- a/etc/doc/PROTOCOL.md
+++ b/etc/doc/PROTOCOL.md
@@ -176,15 +176,23 @@ Don't hesitate to open an issue if you need support for different kind
 of URIs in your application / client. The client does support
 `vsls:///` URIs.
 
-Additionally, `coq-lsp` will use the extension of the file in the URI
-to determine the content type. Supported extensions are:
-- `.v`: File will be interpreted as a regular Coq vernacular file,
-- `.mv`: File will be interpreted as a markdown file. Code
-  snippets between `coq` markdown code blocks will be interpreted as
-  Coq code.
-- `.v.tex` or `.lv`: File will be interpreted as a LaTeX file. Code
-  snippets between `\begin{coq}/\end{coq}` LaTeX environments will be
-  interpreted as Coq code.
+Additionally, `coq-lsp` will use the `languageId` field in `didOpen`
+parameters to determine the content type. Supported `languageId` are:
+- `coq` / `rocq`: File will be interpreted as a regular Rocq
+  vernacular file,
+- `markdown`: File will be interpreted as a markdown file. Code
+  snippets between `coq` or `rocq` markdown code blocks will be
+  interpreted as Rocq code.
+- `latex`: File will be interpreted as a LaTeX file. Code snippets
+  between `\begin{coq}/\end{coq}` LaTeX environments (or
+  `\being{rocq}/\end{rocq}` will be interpreted as Rocq code.
+
+By default, the `coq-lsp` VSCode client will activate for files ending
+in some specific extensions, setting their `languageId` as follows:
+
+- `.v`: `languageId = coq`
+- `.mv`: `languageId = markdown`
+- `.v.tex` or `.lv`: `languageId = latex`
 
 <!-- TOC --><a name="implementation-specific-options"></a>
 ## Implementation-specific options

--- a/fleche/contents.mli
+++ b/fleche/contents.mli
@@ -30,7 +30,7 @@ module R : sig
 end
 
 (** Process contents *)
-val make : uri:Lang.LUri.File.t -> raw:string -> t R.t
+val make : uri:Lang.LUri.File.t -> languageId:string -> raw:string -> t R.t
 
 (** Make an object of type [t] but don't process the text, this is only used
     internally to still provide some contents when [make] fails. *)

--- a/fleche/doc.ml
+++ b/fleche/doc.ml
@@ -295,6 +295,7 @@ end
     [Node.t]. *)
 type t =
   { uri : Lang.LUri.File.t  (** [uri] of the document *)
+  ; languageId : string  (** [languageId] of the document *)
   ; version : int  (** [version] of the document *)
   ; contents : Contents.t  (** [contents] of the document *)
   ; nodes : Node.t list  (** List of document nodes *)
@@ -366,24 +367,35 @@ let mk_doc ~token ~env ~uri =
   Memo.Init.evalS ~token (env.Env.init, env.workspace, uri)
 
 (* Create empty doc, in state [~completed] *)
-let empty_doc ~uri ~contents ~version ~env ~root ~nodes ~completed =
+let empty_doc ~uri ~languageId ~contents ~version ~env ~root ~nodes ~completed =
   let lines = contents.Contents.lines in
   let init_loc = init_loc ~uri in
   let init_range = Coq.Utils.to_range ~lines init_loc in
   let toc = CString.Map.empty in
   let diags_dirty = not (CList.is_empty nodes) in
   let completed = completed init_range in
-  { uri; contents; toc; version; env; root; nodes; diags_dirty; completed }
+  { uri
+  ; languageId
+  ; contents
+  ; toc
+  ; version
+  ; env
+  ; root
+  ; nodes
+  ; diags_dirty
+  ; completed
+  }
 
-let error_doc ~range ~message ~uri ~contents ~version ~env =
+let error_doc ~range ~message ~uri ~languageId ~contents ~version ~env =
   let payload = Coq.Message.Payload.make ?range (Pp.str message) in
   let feedback = [ (Diags.err, payload) ] in
   let root = env.Env.init in
   let nodes = [] in
   let completed range = Completion.Failed range in
-  (empty_doc ~uri ~version ~contents ~env ~root ~nodes ~completed, feedback)
+  ( empty_doc ~uri ~languageId ~version ~contents ~env ~root ~nodes ~completed
+  , feedback )
 
-let conv_error_doc ~raw ~uri ~version ~env ~root err =
+let conv_error_doc ~raw ~uri ~languageId ~version ~env ~root err =
   let contents = Contents.make_raw ~raw in
   let lines = contents.lines in
   let err =
@@ -395,36 +407,37 @@ let conv_error_doc ~raw ~uri ~version ~env ~root err =
   let global_stats = Stats.Global.dump () in
   let nodes = process_init_feedback ~lines ~stats ~global_stats root [ err ] in
   let completed range = Completion.Failed range in
-  empty_doc ~uri ~version ~env ~root ~nodes ~completed ~contents
+  empty_doc ~uri ~languageId ~version ~env ~root ~nodes ~completed ~contents
 
-let create ~token ~env ~uri ~version ~contents =
+let create ~token ~env ~uri ~languageId ~version ~contents =
   let () = Stats.reset () in
   let root, stats = mk_doc ~token ~env ~uri in
   ( Coq.Protect.E.map root ~f:(fun root ->
         let nodes = [] in
         let completed range = Completion.Stopped range in
-        empty_doc ~uri ~contents ~version ~env ~root ~nodes ~completed)
+        empty_doc ~uri ~languageId ~contents ~version ~env ~root ~nodes
+          ~completed)
   , stats )
 
 (** Try to create a doc, if Coq execution fails, create a failed doc with the
     corresponding errors; for now we refine the contents step as to better setup
     the initial document. *)
-let handle_doc_creation_exec ~token ~env ~uri ~version ~contents =
+let handle_doc_creation_exec ~token ~env ~uri ~languageId ~version ~contents =
   let { Coq.Protect.E.r; feedback }, stats =
-    create ~token ~env ~uri ~version ~contents
+    create ~token ~env ~uri ~languageId ~version ~contents
   in
   let doc, extra_feedback =
     match r with
     | Interrupted ->
       let message = "Document Creation Interrupted!" in
       let range = None in
-      error_doc ~range ~message ~uri ~version ~contents ~env
+      error_doc ~range ~message ~uri ~languageId ~version ~contents ~env
     | Completed (Error (User { range; msg = err_msg; quickFix = _ }))
     | Completed (Error (Anomaly { range; msg = err_msg; quickFix = _ })) ->
       let message =
         Format.asprintf "Doc.create, internal error: @[%a@]" Pp.pp_with err_msg
       in
-      error_doc ~range ~message ~uri ~version ~contents ~env
+      error_doc ~range ~message ~uri ~languageId ~version ~contents ~env
     | Completed (Ok doc) -> (doc, [])
   in
   let state = doc.root in
@@ -439,21 +452,21 @@ let handle_doc_creation_exec ~token ~env ~uri ~version ~contents =
   let diags_dirty = not (CList.is_empty nodes) in
   { doc with nodes; diags_dirty }
 
-let handle_contents_creation ~env ~uri ~version ~raw f =
-  match Contents.make ~uri ~raw with
+let handle_contents_creation ~env ~uri ~version ~languageId ~raw f =
+  match Contents.make ~uri ~languageId ~raw with
   | Contents.R.Error err ->
     let root = env.Env.init in
-    conv_error_doc ~raw ~uri ~version ~env ~root err
-  | Contents.R.Ok contents -> f ~env ~uri ~version ~contents
+    conv_error_doc ~raw ~uri ~languageId ~version ~env ~root err
+  | Contents.R.Ok contents -> f ~env ~uri ~languageId ~version ~contents
 
-let create ~token ~env ~uri ~version ~raw =
-  handle_contents_creation ~env ~uri ~version ~raw
+let create ~token ~env ~uri ~languageId ~version ~raw =
+  handle_contents_creation ~env ~uri ~version ~languageId ~raw
     (handle_doc_creation_exec ~token)
 
 (* Used in bump, we should consolidate with create *)
 let recreate ~token ~doc ~version ~contents =
-  let env, uri = (doc.env, doc.uri) in
-  handle_doc_creation_exec ~token ~env ~uri ~version ~contents
+  let env, uri, languageId = (doc.env, doc.uri, doc.languageId) in
+  handle_doc_creation_exec ~token ~env ~uri ~languageId ~version ~contents
 
 let recover_up_to_offset ~init_range doc offset =
   Io.Log.trace "prefix" "common prefix offset found at %d" offset;
@@ -490,9 +503,11 @@ let bump_version ~init_range ~version ~contents doc =
   let nodes, completed, toc = compute_common_prefix ~init_range ~contents doc in
   (* Important: uri, root remain the same *)
   let uri = doc.uri in
+  let languageId = doc.languageId in
   let root = doc.root in
   let env = doc.env in
   { uri
+  ; languageId
   ; version
   ; root
   ; nodes
@@ -515,10 +530,10 @@ let bump_version ~token ~version ~(contents : Contents.t) doc =
   | Stopped _ | Yes _ -> bump_version ~init_range ~version ~contents doc
 
 let bump_version ~token ~version ~raw doc =
-  let uri = doc.uri in
-  match Contents.make ~uri ~raw with
+  let uri, languageId = (doc.uri, doc.languageId) in
+  match Contents.make ~uri ~languageId ~raw with
   | Contents.R.Error e ->
-    conv_error_doc ~raw ~uri ~version ~env:doc.env ~root:doc.root e
+    conv_error_doc ~raw ~uri ~languageId ~version ~env:doc.env ~root:doc.root e
   | Contents.R.Ok contents -> bump_version ~token ~version ~contents doc
 
 let add_node ~node doc =

--- a/fleche/doc.mli
+++ b/fleche/doc.mli
@@ -78,6 +78,7 @@ end
     [Node.t]. *)
 type t = private
   { uri : Lang.LUri.File.t  (** [uri] of the document *)
+  ; languageId : string  (** [languageId] of the document *)
   ; version : int  (** [version] of the document *)
   ; contents : Contents.t  (** [contents] of the document *)
   ; nodes : Node.t list  (** List of document nodes *)
@@ -108,6 +109,7 @@ val create :
      token:Coq.Limits.Token.t
   -> env:Env.t
   -> uri:Lang.LUri.File.t
+  -> languageId:string
   -> version:int
   -> raw:string
   -> t

--- a/fleche/theory.ml
+++ b/fleche/theory.ml
@@ -325,10 +325,10 @@ end = struct
     else if not (Option.is_empty !hint) then hint := Some (uri, point)
 end
 
-let open_ ~io ~token ~env ~uri ~raw ~version =
+let open_ ~io ~token ~env ~uri ~languageId ~raw ~version =
   let extra_requires = Register.InjectRequire.fire ~io in
   let env = Doc.Env.inject_requires ~extra_requires env in
-  let doc = Doc.create ~token ~env ~uri ~raw ~version in
+  let doc = Doc.create ~token ~env ~uri ~languageId ~raw ~version in
   Handle.create ~uri ~doc;
   let reason = Reason.OpenDocument in
   Check.schedule ~uri ~reason

--- a/fleche/theory.mli
+++ b/fleche/theory.mli
@@ -24,6 +24,7 @@ val open_ :
   -> token:Coq.Limits.Token.t
   -> env:Doc.Env.t
   -> uri:Lang.LUri.File.t
+  -> languageId:string
   -> raw:string
   -> version:int
   -> unit

--- a/petanque/json_shell/shell.ml
+++ b/petanque/json_shell/shell.ml
@@ -70,10 +70,12 @@ let read_raw ~uri =
   try Ok Coq.Compat.Ocaml_414.In_channel.(with_open_text file input_all)
   with Sys_error err -> Error Petanque.Agent.Error.(make_request (system err))
 
+let languageId = "rocq"
+
 let setup_doc ~token env uri =
   match read_raw ~uri with
   | Ok raw ->
-    let doc = Fleche.Doc.create ~token ~env ~uri ~version:0 ~raw in
+    let doc = Fleche.Doc.create ~token ~env ~uri ~languageId ~version:0 ~raw in
     print_diags doc;
     let target = Fleche.Doc.Target.End in
     Ok (Fleche.Doc.check ~io ~token ~target ~doc ())


### PR DESCRIPTION
The `languageId` parameter now takes priority over uri extension in LSP `didOpen` notification. This means that clients don't need to rely on setting the URI extension to set document type.

Closes #1005.