### PR TITLE
[opam] [deps] Relax OCaml constraint to 4.12

### DIFF
--- a/controller/nt_cache_trim.ml
+++ b/controller/nt_cache_trim.ml
@@ -46,7 +46,7 @@ let caches () =
   ]
 
 let firstn n l =
-  let num = Stdlib.Int.min n (List.length l) in
+  let num = min n (List.length l) in
   CList.firstn num l
 
 let pp_cache fmt (name, freqs) =

--- a/coq-lsp.opam
+++ b/coq-lsp.opam
@@ -20,7 +20,7 @@ doc: "https://ejgallego.github.io/coq-lsp/"
 depends: [
 
     ("ocaml" {>= "5.0"} & "ocaml" { < "5.3"}
-  | ("ocaml" {>= "4.14"} & "memprof-limits" { >= "0.2.1" } ))
+  | ("ocaml" {>= "4.12"} & "memprof-limits" { >= "0.2.1" } ))
 
   "dune"         { >= "3.13.0" } # Version interval [3.8-3.12] was
                                  # broken for composed builds with Coq


### PR DESCRIPTION
We need 4.12 for the WASM build, so we better test it on CI.