### PR TITLE
Adapt to rocq-prover/rocq#21189.

### DIFF
--- a/serlib/ser_cooking.ml
+++ b/serlib/ser_cooking.ml
@@ -36,7 +36,7 @@ type abstr_inst_info = {
   abstr_uinst : UVars.Instance.t;
 } [@@deriving sexp,yojson,hash,compare]
 
-type 'a entry_map = 'a Names.Cmap.t * 'a Names.Mindmap.t [@@deriving sexp,yojson,hash,compare]
+type 'a entry_map = 'a Names.Cmap_env.t * 'a Names.Mindmap_env.t [@@deriving sexp,yojson,hash,compare]
 type expand_info = abstr_inst_info entry_map [@@deriving sexp,yojson,hash,compare]
 
 module CIP = struct

--- a/serlib/ser_names.ml
+++ b/serlib/ser_names.ml
@@ -218,7 +218,6 @@ module MutInd = struct
   include SerType.Biject(BijectSpec)
 end
 
-module Mindmap = Ser_cMap.Make(Mindmap)(MutInd)
 module Mindmap_env = Ser_cMap.Make(Mindmap_env)(MutInd)
 
 type 'a tableKey =

--- a/serlib/ser_names.mli
+++ b/serlib/ser_names.mli
@@ -62,7 +62,6 @@ module Cmap_env : Ser_cMap.ExtS with type key = Constant.t and type 'a t = 'a Cm
 
 module MutInd : SerType.SJHC with type t = MutInd.t
 
-module Mindmap : Ser_cMap.ExtS with type key = MutInd.t and type 'a t = 'a Mindmap.t
 module Mindmap_env : Ser_cMap.ExtS with type key = MutInd.t and type 'a t = 'a Mindmap_env.t
 
 module Indset_env : Ser_cSet.ExtS with type elt = inductive and type t = Indset_env.t


### PR DESCRIPTION
This should be backwards compatible and actually fixes a type piercing mismatch that happens to be correct by accident.