### PR TITLE
[rocq] Abstract Rocq's `Pp` and `Loc` types.

### DIFF
--- a/compiler/output.ml
+++ b/compiler/output.ml
@@ -1,9 +1,10 @@
 module Lsp = Fleche_lsp
 
-let pp_diag fmt (d : Lang.Diagnostic.t) =
+let pp_diag fmt (d : Pp.t Lang.Diagnostic.t) =
+  let pp msg = `String (Coq.Pp_t.to_string msg) in
   Format.fprintf fmt "@[%a@]"
     (Yojson.Safe.pretty_print ~std:true)
-    (Lsp.JLang.Diagnostic.to_yojson d)
+    (Lsp.JLang.Diagnostic.to_yojson pp d)
 
 let pp_diags fmt dl =
   Format.fprintf fmt "@[%a@]" (Format.pp_print_list pp_diag) dl

--- a/compiler/output.mli
+++ b/compiler/output.mli
@@ -9,4 +9,4 @@ val init :
 (* val report : unit -> unit *)
 
 (** Output diagnostics *)
-val pp_diags : Format.formatter -> Lang.Diagnostic.t list -> unit
+val pp_diags : Format.formatter -> Coq.Pp_t.t Lang.Diagnostic.t list -> unit

--- a/controller/dune
+++ b/controller/dune
@@ -5,12 +5,15 @@
  (public_name coq-lsp.request)
  (modules request)
  (wrapped false)
- (libraries coq fleche))
+ (libraries coq lang fleche))
 
 (library
  (name controller)
  (modules :standard \ request)
  (libraries
+  ppx_deriving_yojson.runtime
+  yojson
+  lang
   coq
   fleche
   request

--- a/controller/lsp_core.ml
+++ b/controller/lsp_core.ml
@@ -12,6 +12,7 @@
     LSP interface, BEWARE of deps, this must be able to run in a Web Worker
     context *)
 
+module IS = Lang.Compat.IntSet
 module F = Format
 module J = Yojson.Safe
 module U = Yojson.Safe.Util
@@ -48,7 +49,7 @@ module Helpers = struct
            need to reflect this on the type just to undo it later; as this
            message morally doesn't belong here *)
         let message = Format.asprintf "json parsing failed: %s" err in
-        CErrors.user_err (Pp.str message)
+        CErrors.user_err (Coq.Pp_t.str message)
     in
     let Lsp.Doc.TextDocumentIdentifier.{ uri } = document in
     uri
@@ -126,7 +127,7 @@ module State = struct
   let is_in_dir ~dir ~file =
     let dir_c = split_in_components dir in
     let file_c = split_in_components file in
-    CList.prefix_of String.equal dir_c file_c
+    Lang.Compat.List.prefix_of String.equal dir_c file_c
 
   let workspace_of_uri ~io ~uri ~state =
     let { root_state; workspaces; default_workspace; _ } = state in
@@ -181,12 +182,12 @@ module Rq : sig
        ofn_rq:(Lsp.Base.Response.t -> unit)
     -> token:Coq.Limits.Token.t
     -> doc:Fleche.Doc.t
-    -> Int.Set.t
+    -> IS.t
     -> unit
 end = struct
   let feedback_to_message fb =
     Lsp.JFleche.Message.(
-      of_coq_message fb |> map ~f:Pp.string_of_ppcmds
+      of_coq_message fb |> map ~f:Coq.Pp_t.to_string
       |> to_yojson (fun s -> `String s))
 
   let feedback_to_data fbs =
@@ -272,7 +273,7 @@ end = struct
     | Action.Data p -> query ~ofn_rq ~token ~id p
 
   let serve_postponed ~ofn_rq ~token ~doc rl =
-    Int.Set.iter (serve_postponed ~ofn_rq ~token ~doc) rl
+    IS.iter (serve_postponed ~ofn_rq ~token ~doc) rl
 end
 
 (***********************************************************************)
@@ -305,7 +306,7 @@ let do_change ~ofn_rq ~io ~token params =
     let invalid_rq = Fleche.Theory.change ~io ~token ~uri ~version ~raw in
     let code = -32802 in
     let message = "Request got old in server" in
-    Int.Set.iter (Rq.cancel ~ofn_rq ~code ~message) invalid_rq
+    IS.iter (Rq.cancel ~ofn_rq ~code ~message) invalid_rq
 
 let do_close params =
   let uri = Helpers.get_uri params in
@@ -439,7 +440,7 @@ let get_goals_format params =
   | None -> None
 
 let do_document ~params =
-  let ast = obool_field "ast" params |> Option.default false in
+  let ast = obool_field "ast" params |> Stdlib.Option.value ~default:false in
   let goals = get_goals_format params in
   let handler = Rq_document.request ~ast ~goals () in
   do_document_request_maybe ~params ~handler
@@ -723,7 +724,7 @@ end = struct
     | Lsp.Base.Message.Notification { method_; params }
       when String.equal method_ "proof/goals" ->
       let uri, version = Helpers.get_uri_oversion params in
-      let version = Option.default (-1) version in
+      let version = Stdlib.Option.value ~default:(-1) version in
       Some (method_, uri, version)
     | _ -> None
 
@@ -791,7 +792,7 @@ let dispatch_or_resume_check ~io ~ofn ~state =
     (* let method_name = Lsp.Base.Message.method_ com in *)
     (* L.trace "process_queue" "exn in method: %s" method_name; *)
     L.trace "print_exn [OCaml]" "%s" (Printexc.to_string exn);
-    L.trace "print_exn [Coq  ]" "%a" Pp.pp_with CErrors.(iprint iexn);
+    L.trace "print_exn [Coq  ]" "%a" Coq.Pp_t.pp_with CErrors.(iprint iexn);
     L.trace "print_bt  [OCaml]" "%s" bt;
     Some (Yield state)
 
@@ -817,7 +818,9 @@ struct
   let message ~lvl ~message = Lsp.Base.mk_logMessage ~lvl ~message |> ofn
 
   let diagnostics ~uri ~version diags =
-    Lsp.Core.mk_diagnostics ~uri ~version diags |> ofn
+    (* For LSP, diagnostic messages should be string *)
+    let pp msg = `String (Coq.Pp_t.to_string msg) in
+    Lsp.Core.mk_diagnostics ~uri ~version ~pp diags |> ofn
 
   let fileProgress ~uri ~version progress =
     Lsp.JFleche.mk_progress ~uri ~version progress |> ofn

--- a/controller/request.ml
+++ b/controller/request.ml
@@ -38,7 +38,7 @@ module R = struct
   let print_err ~name e =
     match e with
     | Coq.Protect.Error.Anomaly { msg; _ } | User { msg; _ } ->
-      Format.asprintf "Error in %s request: %a" name Pp.pp_with msg
+      Format.asprintf "Error in %s request: %a" name Coq.Pp_t.pp_with msg
 
   let of_execution ~lines ~name ~f x : ('r, string) t =
     let Coq.Protect.E.{ r; feedback } = f x in

--- a/controller/request.mli
+++ b/controller/request.mli
@@ -30,7 +30,7 @@ module R : sig
   val of_execution :
        lines:string Array.t
     -> name:string
-    -> f:('a -> (('r, string) t, Loc.t) Coq.Protect.E.t)
+    -> f:('a -> (('r, string) t, Coq.Loc_t.t) Coq.Protect.E.t)
     -> 'a
     -> ('r, string) t
 end

--- a/controller/rq_action.ml
+++ b/controller/rq_action.ml
@@ -41,7 +41,7 @@ let filter_map_cut f l =
   | res -> Some res
 
 (* Return list of pairs of diags, qf *)
-let get_qf (d : Lang.Diagnostic.t) : _ option =
+let get_qf (d : Coq.Pp_t.t Lang.Diagnostic.t) : _ option =
   Option.bind d.data (function
     | { Lang.Diagnostic.Data.quickFix = Some qf; _ } -> Some (d, qf)
     | _ -> None)
@@ -71,5 +71,6 @@ let request ~range ~token:_ ~(doc : Fleche.Doc.t) =
   List.concat_map bf qf
 
 let request ~range ~token ~(doc : Fleche.Doc.t) =
+  let pp = Fleche_lsp.JCoq.Pp_t.to_yojson in
   let res = request ~range ~token ~doc in
-  Ok (`List (List.map Lsp.Core.CodeAction.to_yojson res))
+  Ok (`List (List.map (Lsp.Core.CodeAction.to_yojson pp) res))

--- a/controller/rq_completion.ml
+++ b/controller/rq_completion.ml
@@ -58,7 +58,7 @@ let mk_unicode_completion_item point (label, newText) =
 let unicode_list point : Yojson.Safe.t list =
   let ulist = Unicode_bindings.from_config () in
   (* Coq's CList.map is tail-recursive *)
-  CList.map (mk_unicode_completion_item point) ulist
+  List.map (mk_unicode_completion_item point) ulist
 
 let completion ~token:_ ~(doc : Fleche.Doc.t) ~point =
   (* Instead of get_char_at_point we should have a CompletionContext.t, to be

--- a/controller/rq_definition.ml
+++ b/controller/rq_definition.ml
@@ -5,12 +5,13 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
+module SM = Lang.Compat.String.Map
 open Fleche_lsp.Core
 
 let get_from_toc ~doc id_at_point =
   let { Fleche.Doc.toc; _ } = doc in
   Fleche.Io.Log.trace "rq_definition" "get_from_toc";
-  match CString.Map.find_opt id_at_point toc with
+  match SM.find_opt id_at_point toc with
   | Some node ->
     let uri = doc.uri in
     let range = node.range in

--- a/controller/rq_document.ml
+++ b/controller/rq_document.ml
@@ -79,5 +79,5 @@ let request ~ast ~goals () ~token ~doc =
   let completed = to_completed completed in
   JFleche.FlecheDocument.(
     { spans; completed }
-    |> to_yojson (fun x -> x) (fun x -> Fleche_lsp.JCoq.Pp.to_yojson x))
+    |> to_yojson (fun x -> x) (fun x -> Fleche_lsp.JCoq.Pp_t.to_yojson x))
   |> Result.ok

--- a/controller/rq_goals.ml
+++ b/controller/rq_goals.ml
@@ -10,7 +10,9 @@ module Lsp = Fleche_lsp
 (* Replace by ppx when we can print goals properly in the client *)
 let mk_messages node =
   Option.map Fleche.Doc.Node.messages node
-  |> Option.cata (List.map Lsp.JFleche.Message.of_coq_message) []
+  |> Stdlib.Option.fold
+       ~some:(List.map Lsp.JFleche.Message.of_coq_message)
+       ~none:[]
 
 let mk_error node =
   let open Fleche in
@@ -55,7 +57,7 @@ let layout_term env sigma t =
 
 let pp ~pp_format ~token env evd x =
   match pp_format with
-  | Pp -> Fleche.Info.Goals.to_pp ~token env evd x |> Lsp.JCoq.Pp.to_yojson
+  | Pp -> Fleche.Info.Goals.to_pp ~token env evd x |> Lsp.JCoq.Pp_t.to_yojson
   | Str ->
     let pp = Fleche.Info.Goals.to_pp ~token env evd x in
     `String (Pp.string_of_ppcmds pp)
@@ -65,8 +67,8 @@ let pp ~pp_format ~token env evd x =
 
 let pp_msgs ~pp_format =
   match pp_format with
-  | Str | Box -> fun x -> `String (Pp.string_of_ppcmds x)
-  | Pp -> fun x -> Lsp.JCoq.Pp.to_yojson x
+  | Str | Box -> fun x -> `String (Coq.Pp_t.to_string x)
+  | Pp -> fun x -> Lsp.JCoq.Pp_t.to_yojson x
 
 let run_pretac ~token ~loc ~st pretac =
   match pretac with

--- a/controller/rq_symbols.ml
+++ b/controller/rq_symbols.ml
@@ -10,7 +10,7 @@ module Lsp = Fleche_lsp
 let rec mk_syminfo info =
   let Lang.Ast.Info.{ range; name; kind; detail; children } = info in
   let { Lang.With_range.range = selectionRange; v = name } = name in
-  let name = Option.default "_" name in
+  let name = Stdlib.Option.value ~default:"_" name in
   let children = Option.map (List.map mk_syminfo) children in
   (* Need to fix this at coq.ast level *)
   (* let selectionRange = Option.get name_loc in *)

--- a/coq-layout-engine/dune
+++ b/coq-layout-engine/dune
@@ -2,7 +2,14 @@
  (name layout)
  (public_name coq-lsp.layout-printer)
  (libraries
+  rocq-runtime.clib
+  rocq-runtime.lib
+  rocq-runtime.kernel
+  rocq-runtime.library
+  rocq-runtime.engine
+  rocq-runtime.pretyping
   rocq-runtime.interp
   rocq-runtime.parsing
   rocq-runtime.printing
+  tyxml.functor
   tyxml))

--- a/coq/dune
+++ b/coq/dune
@@ -9,7 +9,28 @@
    from
    (memprof-limits -> limits_mp_impl.real.ml)
    (!memprof-limits -> limits_mp_impl.fake.ml))
+  ; base interacts poorly with -linkall, which in turn pulls
+  ; ppx_inline_test setup and enables the record backtrace runtime
+  ; option :/ :7
+  ; base
+  ; ppx_base
+  ; base.base_internalhash_types
+  ; ppx_hash.runtime-lib
+  ; ppx_compare.runtime-lib
   lang
+  ; findlib
+  rocq-runtime.clib
+  rocq-runtime.lib
+  rocq-runtime.config
+  rocq-runtime.kernel
+  rocq-runtime.library
+  rocq-runtime.engine
+  rocq-runtime.pretyping
+  rocq-runtime.interp
+  rocq-runtime.gramlib
+  rocq-runtime.parsing
+  rocq-runtime.printing
+  rocq-runtime.proofs
   rocq-runtime.vernac
   coq-lsp.serlib
   ; EJGA: This is due to Coq.Args, feel free to move to its own lib if

--- a/coq/loc_t.ml
+++ b/coq/loc_t.ml
@@ -1,0 +1,29 @@
+(************************************************************************)
+(* Copyright 2019 MINES ParisTech -- Dual License LGPL 2.1+ / GPL3+     *)
+(* Copyright 2019-2024 Inria      -- Dual License LGPL 2.1+ / GPL3+     *)
+(* Copyright 2024-2025 Emilio J. Gallego Arias -- LGPL 2.1+ / GPL3+     *)
+(* Copyright 2025      CNRS                    -- LGPL 2.1+ / GPL3+     *)
+(* Written by: Emilio J. Gallego Arias & coq-lsp contributors           *)
+(************************************************************************)
+(* Rocq Language Server Protocol: Rocq Loc API                          *)
+(************************************************************************)
+
+type source = Loc.source =
+  (* OCaml won't allow using DirPath.t in InFile *)
+  | InFile of
+      { dirpath : string option
+      ; file : string
+      }
+  | ToplevelInput
+
+let initial = Loc.initial
+
+type t = Loc.t =
+  { fname : source  (** Filename or toplevel input. *)
+  ; line_nb : int  (** Start line number. *)
+  ; bol_pos : int  (** Position of the beginning of start line. *)
+  ; line_nb_last : int  (** End line number. *)
+  ; bol_pos_last : int  (** Position of the beginning of end line. *)
+  ; bp : int  (** Start position. *)
+  ; ep : int  (** End position. *)
+  }

--- a/coq/message.mli
+++ b/coq/message.mli
@@ -11,10 +11,10 @@ module Payload : sig
   type 'l t =
     { range : 'l option
     ; quickFix : 'l Lang.Qf.t list option
-    ; msg : Pp.t
+    ; msg : Pp_t.t
     }
 
-  val make : ?range:'l -> ?quickFix:'l Lang.Qf.t list -> Pp.t -> 'l t
+  val make : ?range:'l -> ?quickFix:'l Lang.Qf.t list -> Pp_t.t -> 'l t
   val map : f:('l -> 'm) -> 'l t -> 'm t
 end
 

--- a/coq/parsing.ml
+++ b/coq/parsing.ml
@@ -8,6 +8,14 @@
 (* Rocq Language Server Protocol: Rocq parsing API                       *)
 (*************************************************************************)
 
+module Lexer = struct
+  let after = CLexer.after
+end
+
+module Stream = struct
+  let of_string = Gramlib.Stream.of_string
+end
+
 module Pcoq = Procq
 module Parsable = Pcoq.Parsable
 

--- a/coq/parsing.mli
+++ b/coq/parsing.mli
@@ -8,6 +8,14 @@
 (* Rocq Language Server Protocol: Rocq parsing API                       *)
 (*************************************************************************)
 
+module Lexer : sig
+  val after : Loc_t.t -> Loc_t.t
+end
+
+module Stream : sig
+  val of_string : ?offset:int -> string -> (unit, char) Gramlib.Stream.t
+end
+
 module Parsable : sig
   type t
 

--- a/coq/pp_t.ml
+++ b/coq/pp_t.ml
@@ -1,0 +1,43 @@
+(************************************************************************)
+(* Copyright 2019 MINES ParisTech -- Dual License LGPL 2.1+ / GPL3+     *)
+(* Copyright 2019-2024 Inria      -- Dual License LGPL 2.1+ / GPL3+     *)
+(* Copyright 2024-2025 Emilio J. Gallego Arias -- LGPL 2.1+ / GPL3+     *)
+(* Copyright 2025      CNRS                    -- LGPL 2.1+ / GPL3+     *)
+(* Written by: Emilio J. Gallego Arias & coq-lsp contributors           *)
+(************************************************************************)
+(* Rocq Language Server Protocol: Rocq PP API                           *)
+(************************************************************************)
+
+type t = Pp.t
+type pp_tag = Pp.pp_tag
+
+type block_type = Pp.block_type =
+  | Pp_hbox
+  | Pp_vbox of int
+  | Pp_hvbox of int
+  | Pp_hovbox of int
+      (** [Pp_hovbox] produces boxes according to [Format.open_box] not
+          [Format.open_hovbox] *)
+
+type doc_view = Pp.doc_view =
+  | Ppcmd_empty
+  | Ppcmd_string of string
+  | Ppcmd_sized_string of int * string
+  | Ppcmd_glue of t list
+  | Ppcmd_box of block_type * t
+  | Ppcmd_tag of pp_tag * t
+  (* Are those redundant? *)
+  | Ppcmd_print_break of int * int
+  | Ppcmd_force_newline
+  | Ppcmd_comment of string list
+
+let pp_with = Pp.pp_with
+let mt = Pp.mt
+let spc = Pp.spc
+let brk = Pp.brk
+let str = Pp.str
+let int = Pp.int
+let ( ++ ) = Pp.( ++ )
+let to_string = Pp.string_of_ppcmds
+let repr = Pp.repr
+let unrepr = Pp.unrepr

--- a/coq/state.ml
+++ b/coq/state.ml
@@ -98,6 +98,16 @@ module Proof = struct
   let hash x =
     let meaningful, total = (128, 256) in
     Hashtbl.hash_param meaningful total x
+
+  module Program = struct
+    module Obl = Declare.OblState.View.Obl
+
+    type t = Declare.OblState.View.t = private
+      { opaque : bool
+      ; remaining : int
+      ; obligations : Obl.t array
+      }
+  end
 end
 
 let lemmas ~st = st.Vernacstate.interp.lemmas

--- a/coq/state.mli
+++ b/coq/state.mli
@@ -23,10 +23,27 @@ module Proof : sig
   val equal : t -> t -> bool
   val hash : t -> int
   val to_coq : t -> Vernacstate.LemmaStack.t
+
+  module Program : sig
+    module Obl : sig
+      type t = Declare.OblState.View.Obl.t = private
+        { name : Names.Id.t
+        ; loc : Loc_t.t option
+        ; status : bool * Evar_kinds.obligation_definition_status
+        ; solved : bool
+        }
+    end
+
+    type t = Declare.OblState.View.t = private
+      { opaque : bool
+      ; remaining : int
+      ; obligations : Obl.t array
+      }
+  end
 end
 
 val lemmas : st:t -> Proof.t option
-val program : st:t -> Declare.OblState.View.t Names.Id.Map.t
+val program : st:t -> Proof.Program.t Names.Id.Map.t
 
 (** Execute a command in state [st]. Unfortunately this can produce anomalies as
     Coq state setting is imperative, so we need to wrap it in protect. *)

--- a/dune-project
+++ b/dune-project
@@ -7,3 +7,8 @@
 
 (name coq-lsp)
 
+; (implicit_transitive_deps false)
+
+; This requires Dune 3.20, let's keep it off for now until we
+; understand the impact
+; (implicit_transitive_deps false-if-hidden-includes-supported)

--- a/fleche/contents.ml
+++ b/fleche/contents.ml
@@ -170,7 +170,7 @@ type t =
 
 let get_last_text text =
   let offset = String.length text in
-  let lines = CString.split_on_char '\n' text |> Array.of_list in
+  let lines = String.split_on_char '\n' text |> Array.of_list in
   let n_lines = Array.length lines in
   let last_line = if n_lines < 1 then "" else Array.get lines (n_lines - 1) in
   let character = Lang.Utf.length_utf16 last_line in

--- a/fleche/dune
+++ b/fleche/dune
@@ -1,4 +1,4 @@
 (library
  (name fleche)
  (public_name coq-lsp.fleche)
- (libraries coq lang fleche_waterproof))
+ (libraries unix coq lang fleche_waterproof yojson))

--- a/fleche/info.ml
+++ b/fleche/info.ml
@@ -158,8 +158,8 @@ module Goals = struct
     Io.Log.feedback "to_pp" feedback;
     match r with
     | Coq.Protect.R.Completed (Ok pr) -> pr
-    | Coq.Protect.R.Completed (Error _pr) -> Pp.str "printer failed!"
-    | Interrupted -> Pp.str "printer interrupted!"
+    | Coq.Protect.R.Completed (Error _pr) -> Coq.Pp_t.str "printer failed!"
+    | Interrupted -> Coq.Pp_t.str "printer interrupted!"
 
   let pr_goal ~token ~pr st =
     let lemmas = Coq.State.lemmas ~st in
@@ -189,6 +189,6 @@ module Completion = struct
     Coq.State.in_state ~token ~st prefix ~f:(fun prefix ->
         let* p = to_qualid prefix in
         Nametab.completion_canditates p
-        |> List.map (fun x -> Pp.string_of_ppcmds (pr_extref x))
+        |> List.map (fun x -> Coq.Pp_t.to_string (pr_extref x))
         |> some)
 end

--- a/fleche/info.mli
+++ b/fleche/info.mli
@@ -43,24 +43,26 @@ module O : S with module P := Offset
 
 (** We move towards a more modular design here, for preprocessing *)
 module Goals : sig
-  val get_goals_unit : st:Coq.State.t -> (unit, Pp.t) Coq.Goals.reified option
+  val get_goals_unit :
+    st:Coq.State.t -> (unit, Coq.Pp_t.t) Coq.Goals.reified option
 
   val get_goals :
        st:Coq.State.t
-    -> (Environ.env * Evd.evar_map * EConstr.t, Pp.t) Coq.Goals.reified option
+    -> (Environ.env * Evd.evar_map * EConstr.t, Coq.Pp_t.t) Coq.Goals.reified
+       option
 
   type 'a printer =
     token:Coq.Limits.Token.t -> Environ.env -> Evd.evar_map -> EConstr.t -> 'a
 
-  val to_pp : Pp.t printer
+  val to_pp : Coq.Pp_t.t printer
 
   val goals :
        token:Coq.Limits.Token.t
     -> pr:'a printer
     -> st:Coq.State.t
-    -> (('a, Pp.t) Coq.Goals.reified option, Loc.t) Coq.Protect.E.t
+    -> (('a, Coq.Pp_t.t) Coq.Goals.reified option, Coq.Loc_t.t) Coq.Protect.E.t
 
-  val program : st:Coq.State.t -> Declare.OblState.View.t Names.Id.Map.t
+  val program : st:Coq.State.t -> Coq.State.Proof.Program.t Names.Id.Map.t
 end
 
 module Completion : sig
@@ -68,5 +70,5 @@ module Completion : sig
        token:Coq.Limits.Token.t
     -> st:Coq.State.t
     -> string
-    -> (string list option, Loc.t) Coq.Protect.E.t
+    -> (string list option, Coq.Loc_t.t) Coq.Protect.E.t
 end

--- a/fleche/io.ml
+++ b/fleche/io.ml
@@ -20,7 +20,10 @@ module CallBack = struct
     { trace : string -> ?verbose:string -> string -> unit
     ; message : lvl:Level.t -> message:string -> unit
     ; diagnostics :
-        uri:Lang.LUri.File.t -> version:int -> Lang.Diagnostic.t list -> unit
+           uri:Lang.LUri.File.t
+        -> version:int
+        -> Coq.Pp_t.t Lang.Diagnostic.t list
+        -> unit
     ; fileProgress :
         uri:Lang.LUri.File.t -> version:int -> Progress.Info.t list -> unit
     ; perfData : uri:Lang.LUri.File.t -> version:int -> Perf.t -> unit
@@ -80,12 +83,12 @@ module Log = struct
     (* Fixme, use the extra parameter *)
     trace hdr "[%s]: @[%a@]" hdr Yojson.Safe.(pretty_print ~std:false) obj
 
-  let pp_fb fmt (fb : Loc.t Coq.Message.t) =
+  let pp_fb fmt (fb : Coq.Loc_t.t Coq.Message.t) =
     let _lvl, { Coq.Message.Payload.msg; _ } = fb in
-    Format.fprintf fmt "%a" Pp.pp_with msg
+    Format.fprintf fmt "%a" Coq.Pp_t.pp_with msg
 
   let feedback part feedback =
-    if not (CList.is_empty feedback) then
+    if not (Lang.Compat.List.is_empty feedback) then
       (* We put the feedback contents in the verbose part of the trace
          message. *)
       let pp_sep = Format.pp_print_cut in

--- a/fleche/io.mli
+++ b/fleche/io.mli
@@ -23,7 +23,10 @@ module CallBack : sig
     ; message : lvl:Level.t -> message:string -> unit
           (** Send a user-visible message *)
     ; diagnostics :
-        uri:Lang.LUri.File.t -> version:int -> Lang.Diagnostic.t list -> unit
+           uri:Lang.LUri.File.t
+        -> version:int
+        -> Coq.Pp_t.t Lang.Diagnostic.t list
+        -> unit
     ; fileProgress :
         uri:Lang.LUri.File.t -> version:int -> Progress.Info.t list -> unit
     ; perfData : uri:Lang.LUri.File.t -> version:int -> Perf.t -> unit
@@ -64,7 +67,7 @@ module Log : sig
   val trace_object : string -> Yojson.Safe.t -> unit
 
   (** For unhandled feedback, for example when running hover, remove eventually? *)
-  val feedback : string -> Loc.t Coq.Message.t list -> unit
+  val feedback : string -> Coq.Loc_t.t Coq.Message.t list -> unit
 end
 
 module Report : sig
@@ -79,7 +82,7 @@ module Report : sig
        io:CallBack.t
     -> uri:Lang.LUri.File.t
     -> version:int
-    -> Lang.Diagnostic.t list
+    -> Coq.Pp_t.t Lang.Diagnostic.t list
     -> unit
 
   val fileProgress :

--- a/fleche/memo.ml
+++ b/fleche/memo.ml
@@ -167,12 +167,12 @@ end
 (* XXX: Move elsewhere *)
 module Loc_utils : sig
   val adjust_offset :
-       stm_loc:Loc.t
-    -> cached_loc:Loc.t
-    -> ('a, Loc.t) Coq.Protect.E.t
-    -> ('a, Loc.t) Coq.Protect.E.t
+       stm_loc:Coq.Loc_t.t
+    -> cached_loc:Coq.Loc_t.t
+    -> ('a, Coq.Loc_t.t) Coq.Protect.E.t
+    -> ('a, Coq.Loc_t.t) Coq.Protect.E.t
 end = struct
-  let loc_offset (l1 : Loc.t) (l2 : Loc.t) =
+  let loc_offset (l1 : Coq.Loc_t.t) (l2 : Coq.Loc_t.t) =
     let line_offset = l2.line_nb - l1.line_nb in
     let bol_offset = l2.bol_pos - l1.bol_pos in
     let line_last_offset = l2.line_nb_last - l1.line_nb_last in
@@ -192,7 +192,7 @@ end = struct
       , line_last_offset
       , bol_last_offset
       , bp_offset
-      , ep_offset ) (loc : Loc.t) =
+      , ep_offset ) (loc : Coq.Loc_t.t) =
     { loc with
       line_nb = loc.line_nb + line_offset
     ; bol_pos = loc.bol_pos + bol_offset
@@ -213,7 +213,9 @@ module type EvalType = sig
 
   type output
 
-  val eval : token:Coq.Limits.Token.t -> t -> (output, Loc.t) Coq.Protect.E.t
+  val eval :
+    token:Coq.Limits.Token.t -> t -> (output, Coq.Loc_t.t) Coq.Protect.E.t
+
   val input_info : t -> string
 end
 
@@ -224,13 +226,13 @@ module type S = sig
 
   (** [eval i] Eval an input [i] *)
   val eval :
-    token:Coq.Limits.Token.t -> input -> (output, Loc.t) Coq.Protect.E.t
+    token:Coq.Limits.Token.t -> input -> (output, Coq.Loc_t.t) Coq.Protect.E.t
 
   (** [eval i] Eval an input [i] and produce stats *)
   val evalS :
        token:Coq.Limits.Token.t
     -> input
-    -> (output, Loc.t) Coq.Protect.E.t * Stats.t
+    -> (output, Coq.Loc_t.t) Coq.Protect.E.t * Stats.t
 
   (** [size ()] Return the cache size in words, expensive *)
   val size : unit -> int
@@ -283,7 +285,7 @@ end
 module type LocEvalType = sig
   include EvalType
 
-  val loc_of_input : t -> Loc.t
+  val loc_of_input : t -> Coq.Loc_t.t
 end
 
 module CEval (E : LocEvalType) = struct
@@ -294,7 +296,7 @@ module CEval (E : LocEvalType) = struct
 
   module Result = struct
     (* We store the location as to compute an offset for cached results *)
-    type t = Loc.t * (E.output, Loc.t) Coq.Protect.E.t * CS.t
+    type t = Coq.Loc_t.t * (E.output, Coq.Loc_t.t) Coq.Protect.E.t * CS.t
   end
 
   type cache = Result.t HC.t

--- a/fleche/memo.mli
+++ b/fleche/memo.mli
@@ -32,13 +32,13 @@ module type S = sig
 
   (** [eval i] Eval an input [i] *)
   val eval :
-    token:Coq.Limits.Token.t -> input -> (output, Loc.t) Coq.Protect.E.t
+    token:Coq.Limits.Token.t -> input -> (output, Coq.Loc_t.t) Coq.Protect.E.t
 
   (** [eval i] Eval an input [i] and produce stats *)
   val evalS :
        token:Coq.Limits.Token.t
     -> input
-    -> (output, Loc.t) Coq.Protect.E.t * Stats.t
+    -> (output, Coq.Loc_t.t) Coq.Protect.E.t * Stats.t
 
   (** [size ()] Return the cache size in words, expensive *)
   val size : unit -> int

--- a/fleche/perf_analysis.ml
+++ b/fleche/perf_analysis.ml
@@ -14,10 +14,11 @@ let rec list_take n = function
 
 let mk_info (n : Doc.Node.t) =
   let time, memory, cache_hit, time_hash =
-    Option.cata
-      (fun (stats : Memo.Stats.t) ->
-        (stats.stats.time, stats.stats.memory, stats.cache_hit, stats.time_hash))
-      (0.0, 0.0, false, 0.0) n.info.stats
+    let none = (0.0, 0.0, false, 0.0) in
+    let some (stats : Memo.Stats.t) =
+      (stats.stats.time, stats.stats.memory, stats.cache_hit, stats.time_hash)
+    in
+    Stdlib.Option.fold ~none ~some n.info.stats
   in
   Info.{ time; memory; cache_hit; time_hash }
 

--- a/fleche/stats.ml
+++ b/fleche/stats.ml
@@ -20,7 +20,7 @@ type t =
 
 let stats : (Kind.t, t) Hashtbl.t = Hashtbl.create 1000
 let z = { time = 0.0; memory = 0.0 }
-let find kind = Hashtbl.find_opt stats kind |> Option.default z
+let find kind = Hashtbl.find_opt stats kind |> Stdlib.Option.value ~default:z
 
 module Global = struct
   type nonrec 'a stats = t

--- a/fleche/theory.mli
+++ b/fleche/theory.mli
@@ -8,12 +8,14 @@
 (* Flèche => document manager: theories                                 *)
 (************************************************************************)
 
+module IS = Lang.Compat.IntSet
+
 module Check : sig
   (** Check pending documents, return [None] if there is none pending, or
       [Some rqs] the list of requests ready to execute after the check. Sends
       progress and diagnostics notifications using output function [ofn]. *)
   val maybe_check :
-    io:Io.CallBack.t -> token:Coq.Limits.Token.t -> (Int.Set.t * Doc.t) option
+    io:Io.CallBack.t -> token:Coq.Limits.Token.t -> (IS.t * Doc.t) option
 
   val set_scheduler_hint : uri:Lang.LUri.File.t -> point:int * int -> unit
 end
@@ -36,7 +38,7 @@ val change :
   -> uri:Lang.LUri.File.t
   -> version:int
   -> raw:string
-  -> Int.Set.t
+  -> IS.t
 
 (** Close a document *)
 val close : uri:Lang.LUri.File.t -> unit

--- a/lang/compat.ml
+++ b/lang/compat.ml
@@ -174,3 +174,41 @@ module OCaml4_14 = struct
       | _ -> dec_invalid 1
   end
 end
+
+module List = struct
+  type 'a eq = 'a -> 'a -> bool
+
+  let is_empty = function
+    | [] -> true
+    | _ :: _ -> false
+
+  let insert p v l =
+    let rec insrec = function
+      | [] -> [ v ]
+      | h :: tl -> if p v h then v :: h :: tl else h :: insrec tl
+    in
+    insrec l
+
+  let remove cmp x l = List.filter (fun y -> not (cmp x y)) l
+
+  let count f l =
+    let rec aux acc = function
+      | [] -> acc
+      | h :: t -> if f h then aux (acc + 1) t else aux acc t
+    in
+    aux 0 l
+
+  let prefix_of cmp prefl l =
+    let rec prefrec = function
+      | h1 :: t1, h2 :: t2 -> cmp h1 h2 && prefrec (t1, t2)
+      | [], _ -> true
+      | _ -> false
+    in
+    prefrec (prefl, l)
+end
+
+module String = struct
+  module Map = Map.Make (String)
+end
+
+module IntSet : Set.S with type elt = int = Set.Make (Int)

--- a/lang/compat.mli
+++ b/lang/compat.mli
@@ -14,3 +14,32 @@ module OCaml4_14 : sig
     val get_utf_8_uchar : string -> int -> Uchar.utf_decode
   end
 end
+
+(* CList from Rocq *)
+module List : sig
+  type 'a eq = 'a -> 'a -> bool
+
+  (** Introduced in 5.1 *)
+  val is_empty : 'a list -> bool
+
+  (** Insert at the (first) position so that if the list is ordered wrt to the
+      total order given as argument, the order is preserved *)
+  val insert : 'a eq -> 'a -> 'a list -> 'a list
+
+  (** [remove eq a l] Remove all occurrences of [a] in [l] *)
+  val remove : 'a eq -> 'a -> 'a list -> 'a list
+
+  (** Count the number of elements satisfying a predicate *)
+  val count : ('a -> bool) -> 'a list -> int
+
+  (** [prefix_of eq l1 l2] returns [true] if [l1] is a prefix of [l2], [false]
+      otherwise. It uses [eq] to compare elements *)
+  val prefix_of : 'a eq -> 'a list eq
+end
+
+(* CString from Rocq *)
+module String : sig
+  module Map : Map.S with type key = String.t
+end
+
+module IntSet : Set.S with type elt = int

--- a/lang/diagnostic.ml
+++ b/lang/diagnostic.ml
@@ -4,10 +4,14 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
+module QualId = struct
+  type t = string list
+end
+
 module FailedRequire = struct
   type t =
-    { prefix : Libnames.qualid option
-    ; refs : Libnames.qualid list
+    { prefix : QualId.t option
+    ; refs : QualId.t list
     }
 end
 
@@ -28,10 +32,10 @@ module Severity = struct
   let hint = 4
 end
 
-type t =
+type 'a t =
   { range : Range.t
   ; severity : Severity.t
-  ; message : Pp.t
+  ; message : 'a
   ; data : Data.t option [@default None]
   }
 

--- a/lang/diagnostic.mli
+++ b/lang/diagnostic.mli
@@ -4,10 +4,14 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
+module QualId : sig
+  type t = string list
+end
+
 module FailedRequire : sig
   type t =
-    { prefix : Libnames.qualid option
-    ; refs : Libnames.qualid list
+    { prefix : QualId.t option
+    ; refs : QualId.t list
     }
 end
 
@@ -28,11 +32,11 @@ module Severity : sig
   val hint : t (* 4 *)
 end
 
-type t =
+type 'a t =
   { range : Range.t
   ; severity : Severity.t
-  ; message : Pp.t
+  ; message : 'a
   ; data : Data.t option [@default None]
   }
 
-val is_error : t -> bool
+val is_error : 'a t -> bool

--- a/lang/dune
+++ b/lang/dune
@@ -2,7 +2,7 @@
  (name lang)
  (public_name coq-lsp.lang)
  (modules :standard \ utf_tests)
- (libraries uri rocq-runtime.library))
+ (libraries uri))
 
 ; We had to do this due to ppx_inline_test enabling backtraces
 

--- a/lang/lUri.mli
+++ b/lang/lUri.mli
@@ -12,7 +12,7 @@ val of_string : string -> t
 (** Checks if a URI points to a (local) file *)
 val is_file_path : t -> bool
 
-(** Uris that are filesystem paths *)
+(** Uris that are filesystem paths [file:///...] *)
 module File : sig
   type uri = t
   type t

--- a/lsp-server/jsoo/jsso.ml
+++ b/lsp-server/jsoo/jsso.ml
@@ -39,10 +39,11 @@ let rec obj_to_json (cobj : < .. > Js.t) : Yojson.Safe.t =
       Firebug.console##info "undefined branch!!!!";
       `Null)
     else (
-      Firebug.console##error "failure in coq_lsp_worker:obj_to_json";
-      Firebug.console##error cobj;
-      Firebug.console##error (Json.output cobj);
-      raise (Failure "coq_lsp_worker:obj_to_json"))
+      (Firebug.console##error "failure in coq_lsp_worker:obj_to_json";
+       Firebug.console##error cobj;
+       Firebug.console##error (Json.output cobj);
+       raise (Failure "coq_lsp_worker:obj_to_json"))
+      [@alert "-deprecated"])
 
 (* Old code, which is only useful for debug *)
 (* let json_string = Js.to_string (Json.output cobj) in *)

--- a/lsp-server/native/coq_lsp.ml
+++ b/lsp-server/native/coq_lsp.ml
@@ -39,8 +39,9 @@ let rec process_queue ~delay ~io ~ofn ~state : unit =
 
 let concise_cb ofn =
   let diagnostics ~uri ~version diags =
+    let pp msg = `String (Coq.Pp_t.to_string msg) in
     if List.length diags > 0 then
-      Lsp.Core.mk_diagnostics ~uri ~version diags |> ofn
+      Lsp.Core.mk_diagnostics ~uri ~version ~pp diags |> ofn
   in
   Fleche.Io.CallBack.
     { trace = (fun _hdr ?verbose:_ _msg -> ())

--- a/lsp/base.ml
+++ b/lsp/base.ml
@@ -123,7 +123,9 @@ module Message = struct
 
   let request_of_yojson method_ dict =
     let params =
-      List.assoc_opt "params" dict |> Option.map U.to_assoc |> Option.default []
+      List.assoc_opt "params" dict
+      |> Option.map U.to_assoc
+      |> Stdlib.Option.value ~default:[]
     in
     match List.assoc_opt "id" dict with
     | None -> Notification { Notification.method_; params }

--- a/lsp/core.ml
+++ b/lsp/core.ml
@@ -126,18 +126,18 @@ end
 
 (** Publish Diagnostics params *)
 module PublishDiagnosticsParams = struct
-  type t =
+  type 'a t =
     { uri : JLang.LUri.File.t
     ; version : int
-    ; diagnostics : JLang.Diagnostic.t list
+    ; diagnostics : 'a JLang.Diagnostic.t list
     }
   [@@deriving to_yojson]
 end
 
-let mk_diagnostics ~uri ~version diagnostics : Base.Notification.t =
+let mk_diagnostics ~uri ~version ~pp diagnostics : Base.Notification.t =
   let params =
     PublishDiagnosticsParams.(
-      { uri; version; diagnostics } |> to_yojson |> Yojson.Safe.Util.to_assoc)
+      { uri; version; diagnostics } |> to_yojson pp |> Yojson.Safe.Util.to_assoc)
   in
   Base.Notification.make ~method_:"textDocument/publishDiagnostics" ~params ()
 
@@ -154,10 +154,10 @@ module DocumentDiagnosticParams = struct
 end
 
 module FullDocumentDiagnosticReport = struct
-  type t =
+  type 'a t =
     { kind : string
     ; resultId : string option [@default None]
-    ; items : JLang.Diagnostic.t list
+    ; items : 'a JLang.Diagnostic.t list
     }
   [@@deriving to_yojson]
 end
@@ -171,17 +171,17 @@ module UnchangedDocumentDiagnosticReport = struct
 end
 
 module DocumentDiagnosticReportPartialResult = struct
-  type t =
+  type 'a t =
     { relatedDocuments :
-        (JLang.LUri.File.t * FullDocumentDiagnosticReport.t) list
+        (JLang.LUri.File.t * 'a FullDocumentDiagnosticReport.t) list
     }
   [@@deriving to_yojson]
 end
 
 (* CodeAction *)
 module CodeActionContext = struct
-  type t =
-    { diagnostics : Lang.Diagnostic.t list
+  type 'a t =
+    { diagnostics : 'a Lang.Diagnostic.t list
     ; only : string option [@default None]
     ; triggerKind : int option [@default None]
     }
@@ -189,19 +189,19 @@ module CodeActionContext = struct
 end
 
 module CodeActionParams = struct
-  type t =
+  type 'a t =
     { textDocument : Doc.TextDocumentIdentifier.t
     ; range : Lang.Range.t
-    ; context : CodeActionContext.t
+    ; context : 'a CodeActionContext.t
     }
   [@@deriving to_yojson]
 end
 
 module CodeAction = struct
-  type t =
+  type 'a t =
     { title : string
     ; kind : string option [@default None]
-    ; diagnostics : Lang.Diagnostic.t list [@default []]
+    ; diagnostics : 'a Lang.Diagnostic.t list [@default []]
     ; isPreferred : bool option [@default None]
     ; edit : Workspace.WorkspaceEdit.t option [@default None]
     }

--- a/lsp/core.mli
+++ b/lsp/core.mli
@@ -5,8 +5,7 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-(** Core LSP protocoal and language types *)
-
+(** Core LSP protocol and language types *)
 module Location : sig
   type t =
     { uri : Lang.LUri.File.t
@@ -125,10 +124,10 @@ end
 
 (** Publish Diagnostics params *)
 module PublishDiagnosticsParams : sig
-  type t =
+  type 'a t =
     { uri : JLang.LUri.File.t
     ; version : int
-    ; diagnostics : JLang.Diagnostic.t list
+    ; diagnostics : 'a JLang.Diagnostic.t list
     }
   [@@deriving to_yojson]
 end
@@ -137,7 +136,8 @@ end
 val mk_diagnostics :
      uri:Lang.LUri.File.t
   -> version:int
-  -> Lang.Diagnostic.t list
+  -> pp:('a -> Yojson.Safe.t)
+  -> 'a Lang.Diagnostic.t list
   -> Base.Notification.t
 
 (** Pull Diagnostics *)
@@ -153,10 +153,10 @@ module DocumentDiagnosticParams : sig
 end
 
 module FullDocumentDiagnosticReport : sig
-  type t =
+  type 'a t =
     { kind : string
     ; resultId : string option [@default None]
-    ; items : JLang.Diagnostic.t list
+    ; items : 'a JLang.Diagnostic.t list
           (* relatedDocuments to be added in 0.2.x *)
     }
   [@@deriving to_yojson]
@@ -174,17 +174,17 @@ end
     followed by n DocumentDiagnosticReportPartialResult literals defined as
     follows: *)
 module DocumentDiagnosticReportPartialResult : sig
-  type t =
+  type 'a t =
     { relatedDocuments :
-        (Lang.LUri.File.t * FullDocumentDiagnosticReport.t) list
+        (Lang.LUri.File.t * 'a FullDocumentDiagnosticReport.t) list
     }
   [@@deriving to_yojson]
 end
 
 (* CodeAction *)
 module CodeActionContext : sig
-  type t =
-    { diagnostics : Lang.Diagnostic.t list
+  type 'a t =
+    { diagnostics : 'a Lang.Diagnostic.t list
     ; only : string option [@default None]
     ; triggerKind : int option [@default None]
     }
@@ -192,19 +192,19 @@ module CodeActionContext : sig
 end
 
 module CodeActionParams : sig
-  type t =
+  type 'a t =
     { textDocument : Doc.TextDocumentIdentifier.t
     ; range : Lang.Range.t
-    ; context : CodeActionContext.t
+    ; context : 'a CodeActionContext.t
     }
   [@@deriving to_yojson]
 end
 
 module CodeAction : sig
-  type t =
+  type 'a t =
     { title : string
     ; kind : string option [@default None]
-    ; diagnostics : Lang.Diagnostic.t list [@default []]
+    ; diagnostics : 'a Lang.Diagnostic.t list [@default []]
     ; isPreferred : bool option [@default None]
     ; edit : Workspace.WorkspaceEdit.t option [@default None]
     }

--- a/lsp/dune
+++ b/lsp/dune
@@ -3,4 +3,4 @@
  (public_name coq-lsp.lsp)
  (preprocess
   (staged_pps ppx_import ppx_deriving_yojson))
- (libraries lang fleche yojson threads))
+ (libraries lang coq serlib fleche yojson threads))

--- a/lsp/jCoq.mli
+++ b/lsp/jCoq.mli
@@ -1,0 +1,30 @@
+(*************************************************************************)
+(* Copyright 2015-2019 MINES ParisTech -- Dual License LGPL 2.1+ / GPL3+ *)
+(* Copyright 2019-2024 Inria           -- Dual License LGPL 2.1+ / GPL3+ *)
+(* Copyright 2024-2025 Emilio J. Gallego Arias  -- LGPL 2.1+ / GPL3+     *)
+(* Copyright 2025      CNRS                     -- LGPL 2.1+ / GPL3+     *)
+(* Written by: Emilio J. Gallego Arias & coq-lsp contributors            *)
+(*************************************************************************)
+
+(** This module contains the serialization functions for some Rocq's types *)
+
+module Pp_t : sig
+  type t = Coq.Pp_t.t [@@deriving yojson]
+end
+
+module Goals : sig
+  type ('a, 'pp) t = ('a, 'pp) Coq.Goals.t [@@deriving yojson]
+  type ('a, 'pp) reified = ('a, 'pp) Coq.Goals.reified [@@deriving yojson]
+end
+
+module Ast : sig
+  type t = Coq.Ast.t [@@deriving yojson]
+end
+
+module State : sig
+  module Proof : sig
+    module Program : sig
+      type t = Coq.State.Proof.Program.t [@@deriving yojson]
+    end
+  end
+end

--- a/lsp/jFleche.ml
+++ b/lsp/jFleche.ml
@@ -16,7 +16,7 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-module Pp = JCoq.Pp
+module Pp_t = JCoq.Pp_t
 module Ast = JCoq.Ast
 module Lang = JLang
 module Names = Serlib.Ser_names
@@ -101,8 +101,7 @@ module GoalsAnswer = struct
     ; position : Lang.Point.t
     ; range : Lang.Range.t option [@default None]
     ; goals : ('goals, 'pp) JCoq.Goals.reified option [@default None]
-    ; program : JCoq.Declare.OblState.View.t Names.Id.Map.t option
-          [@default None]
+    ; program : JCoq.State.Proof.Program.t Names.Id.Map.t option [@default None]
     ; messages : 'pp Message.t list
     ; error : 'pp option [@default None]
     }

--- a/lsp/jFleche.mli
+++ b/lsp/jFleche.mli
@@ -47,7 +47,7 @@ module Message : sig
     }
   [@@deriving yojson]
 
-  val of_coq_message : Lang.Range.t Coq.Message.t -> Pp.t t
+  val of_coq_message : Lang.Range.t Coq.Message.t -> Coq.Pp_t.t t
   val map : f:('a -> 'b) -> 'a t -> 'b t
 end
 
@@ -57,8 +57,7 @@ module GoalsAnswer : sig
     ; position : Lang.Point.t
     ; range : Lang.Range.t option [@default None]
     ; goals : ('goals, 'pp) JCoq.Goals.reified option [@default None]
-    ; program : JCoq.Declare.OblState.View.t Names.Id.Map.t option
-          [@default None]
+    ; program : JCoq.State.Proof.Program.t Names.Id.Map.t option [@default None]
     ; messages : 'pp Message.t list
     ; error : 'pp option [@default None]
     }

--- a/lsp/jLang.ml
+++ b/lsp/jLang.ml
@@ -5,7 +5,7 @@
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 
-module Pp = JCoq.Pp
+module Pp_t = JCoq.Pp_t
 
 module Point = struct
   type t = [%import: Lang.Point.t] [@@deriving yojson]
@@ -90,16 +90,9 @@ module Qf = struct
 end
 
 module Diagnostic = struct
-  module Mode = struct
-    type t =
-      | String
-      | Pp
-
-    let default = ref String
-    let set v = default := v
+  module QualId = struct
+    type t = [%import: Lang.Diagnostic.QualId.t] [@@deriving yojson]
   end
-
-  module Libnames = Serlib.Ser_libnames
 
   module FailedRequire = struct
     type t = [%import: Lang.Diagnostic.FailedRequire.t] [@@deriving yojson]
@@ -119,37 +112,8 @@ module Diagnostic = struct
     type t = [%import: Lang.Diagnostic.Severity.t] [@@deriving yojson]
   end
 
-  module DiagnosticString = struct
-    type t =
-      { range : Range.t
-      ; severity : Severity.t
-      ; message : string
-      ; data : Data.t option [@default None]
-      }
-    [@@deriving yojson]
-
-    let conv { Lang.Diagnostic.range; severity; message; data } =
-      let message = Pp.string_of_ppcmds message in
-      { range; severity; message; data }
-
-    let vnoc { range; severity; message; data } =
-      let message = Pp.str message in
-      { Lang.Diagnostic.range; severity; message; data }
-  end
-
-  type t = [%import: (Lang.Diagnostic.t[@with Lang.Range.t := Range.t])]
+  type t = [%import: ('a Lang.Diagnostic.t[@with Lang.Range.t := Range.t])]
   [@@deriving yojson]
-
-  let of_yojson json =
-    let open Ppx_deriving_yojson_runtime in
-    match !Mode.default with
-    | String -> DiagnosticString.(of_yojson json >|= vnoc)
-    | Pp -> of_yojson json
-
-  let to_yojson p =
-    match !Mode.default with
-    | String -> DiagnosticString.(to_yojson (conv p))
-    | Pp -> to_yojson p
 end
 
 module Stdlib = JStdlib

--- a/lsp/jLang.mli
+++ b/lsp/jLang.mli
@@ -36,18 +36,7 @@ module LUri : sig
 end
 
 module Diagnostic : sig
-  module Mode : sig
-    (** Flèche diagnostics store the message as a Pp.t box format, but usually
-        LSP standard mandates the [message] field to be a string, thus we allow
-        clients to select the mode. *)
-    type t =
-      | String
-      | Pp
-
-    val set : t -> unit
-  end
-
-  type t = Lang.Diagnostic.t [@@deriving yojson]
+  type 'a t = 'a Lang.Diagnostic.t [@@deriving yojson]
 end
 
 module Ast : sig

--- a/petanque/agent.ml
+++ b/petanque/agent.ml
@@ -5,6 +5,8 @@
 (* Written by: Emilio J. Gallego Arias & coq-lsp contributors           *)
 (************************************************************************)
 
+module SM = Lang.Compat.String.Map
+
 module State = struct
   type t = Coq.State.t
 
@@ -104,7 +106,7 @@ end
 let find_thm ~(doc : Fleche.Doc.t) ~thm =
   let { Fleche.Doc.toc; _ } = doc in
   let feedback = [] in
-  match CString.Map.find_opt thm toc with
+  match SM.find_opt thm toc with
   | None ->
     let msg = Format.asprintf "@[[find_thm] Theorem not found!@]" in
     Error Error.(make (Theorem_not_found msg) ~feedback)
@@ -116,7 +118,7 @@ let find_thm ~(doc : Fleche.Doc.t) ~thm =
       let msg =
         Format.asprintf
           "@[[find_thm] Theorem found but failed with Coq error:@\n @[%a@]!@]"
-          Pp.pp_with err.message
+          Coq.Pp_t.pp_with err.message
       in
       Error Error.(make (Theorem_not_found msg) ~feedback))
 
@@ -145,17 +147,21 @@ let protect_to_result (r : _ Coq.Protect.E.t) : (_, _) Result.t =
     Error Error.(make Interrupted ~feedback)
   | { r = Completed (Error (User { msg; _ })); feedback } ->
     let feedback = clean_fb feedback in
-    Error Error.(make (Coq (Pp.string_of_ppcmds msg)) ~feedback)
+    Error Error.(make (Coq (Coq.Pp_t.to_string msg)) ~feedback)
   | { r = Completed (Error (Anomaly { msg; _ })); feedback } ->
     let feedback = clean_fb feedback in
-    Error Error.(make (Anomaly (Pp.string_of_ppcmds msg)) ~feedback)
+    Error Error.(make (Anomaly (Coq.Pp_t.to_string msg)) ~feedback)
   | { r = Completed (Ok r); feedback } -> Ok (r feedback)
 
 let proof_finished { Coq.Goals.goals; stack; shelf; given_up; _ } =
   let check_stack stack =
-    CList.(for_all (fun (l, r) -> is_empty l && is_empty r)) stack
+    List.(
+      for_all (fun (l, r) ->
+          Lang.Compat.List.is_empty l && Lang.Compat.List.is_empty r))
+      stack
   in
-  List.for_all CList.is_empty [ goals; shelf; given_up ] && check_stack stack
+  List.for_all Lang.Compat.List.is_empty [ goals; shelf; given_up ]
+  && check_stack stack
 
 (* At some point we want to return both hashes *)
 module Hash_kind = struct
@@ -175,7 +181,7 @@ let hash_mode = Hash_kind.Proof
 (* XXX: duplicated with Request.R.of_execution, refactoring planned (not
    trivial) *)
 let fb_print_string (lvl, { Coq.Message.Payload.msg; _ }) =
-  (lvl, Pp.string_of_ppcmds msg)
+  (lvl, Coq.Pp_t.to_string msg)
 
 let analyze_after_run ~hash st feedback =
   let proof_finished =
@@ -247,8 +253,8 @@ let run_at_pos ~token ?opts ~doc ~point ~command () :
 
 let goals ~token ~st =
   let f goals =
-    let f = Coq.Goals.Reified_goal.map ~f:Pp.string_of_ppcmds in
-    let g = Pp.string_of_ppcmds in
+    let f = Coq.Goals.Reified_goal.map ~f:Coq.Pp_t.to_string in
+    let g = Coq.Pp_t.to_string in
     (* XXX: Fixme, take feedback into account *)
     fun _feedback -> Option.map (Coq.Goals.map ~f ~g) goals
   in
@@ -279,7 +285,14 @@ end
 
    XXX move this caching to Flèche. *)
 module Memo = struct
-  module H = Hashtbl.Make (CString)
+  (* String.hash added in 5.0 *)
+  module MyString = struct
+    include String
+
+    let hash = Stdlib.Hashtbl.hash
+  end
+
+  module H = Hashtbl.Make (MyString)
 
   let table_glob = H.create 1000
 
@@ -355,7 +368,7 @@ let simple_run_result res feedback =
 
 let ast ~token ~st ~text () : Coq.Ast.t option Run_result.t R.t =
   (let open Coq.Protect.E.O in
-   let pa = Coq.Parsing.Parsable.make Gramlib.Stream.(of_string text) in
+   let pa = Coq.Parsing.(Parsable.make Stream.(of_string text)) in
    let+ ast = Coq.Parsing.parse ~token ~st pa in
    simple_run_result ast)
   |> protect_to_result

--- a/petanque/dune
+++ b/petanque/dune
@@ -1,4 +1,4 @@
 (library
  (public_name coq-lsp.petanque)
  (name petanque)
- (libraries fleche request))
+ (libraries lang coq fleche request))

--- a/petanque/json/dune
+++ b/petanque/json/dune
@@ -3,4 +3,4 @@
  (public_name coq-lsp.petanque.json)
  (preprocess
   (staged_pps ppx_import ppx_deriving_yojson))
- (libraries request fleche_lsp petanque))
+ (libraries lang coq fleche request fleche_lsp petanque))

--- a/petanque/json_shell/shell.ml
+++ b/petanque/json_shell/shell.ml
@@ -1,3 +1,5 @@
+module SM = Lang.Compat.String.Map
+
 let init_coq ~debug =
   let load_module = Dynlink.loadfile in
   let load_plugin = Coq.Loader.plugin_handler None in
@@ -116,5 +118,5 @@ let toc_to_info (name, node) =
 let get_toc ~token:_ ~(doc : Fleche.Doc.t) :
     (string * Lang.Ast.Info.t list option) list Petanque.Agent.R.t =
   let { Fleche.Doc.toc; _ } = doc in
-  let toc = CString.Map.bindings toc |> List.filter_map toc_to_info in
+  let toc = SM.bindings toc |> List.filter_map toc_to_info in
   Ok toc

--- a/plugins/explain_errors/dune
+++ b/plugins/explain_errors/dune
@@ -1,4 +1,4 @@
 (library
  (name Explain_errors)
  (public_name coq-lsp.plugin.explain_errors)
- (libraries coq-lsp.fleche))
+ (libraries coq-lsp.lang coq-lsp.coq coq-lsp.fleche))

--- a/plugins/explain_errors/main.ml
+++ b/plugins/explain_errors/main.ml
@@ -6,22 +6,22 @@ let msg_info ~io = Io.(Report.msg ~io ~lvl:Info)
 
 let pp_goals ~token ~st =
   match Coq.State.lemmas ~st with
-  | None -> Pp.str "no goals"
+  | None -> Coq.Pp_t.str "no goals"
   | Some proof -> (
     match Coq.Print.pr_goals ~token ~proof with
     | { Coq.Protect.E.r = Completed (Ok goals); _ } -> goals
     | { Coq.Protect.E.r =
           Completed (Error (User { msg; _ } | Anomaly { msg; _ }))
       ; _
-      } -> Pp.(str "error when printing goals: " ++ msg)
+      } -> Coq.Pp_t.(str "error when printing goals: " ++ msg)
     | { Coq.Protect.E.r = Interrupted; _ } ->
-      Pp.str "goal printing was interrupted")
+      Coq.Pp_t.str "goal printing was interrupted")
 
 module Error_info = struct
   type t =
-    { error : Pp.t
+    { error : Coq.Pp_t.t
     ; command : string
-    ; goals : Pp.t
+    ; goals : Coq.Pp_t.t
     }
 
   let print ~io { error; command; goals } =
@@ -34,12 +34,12 @@ module Error_info = struct
        @\n\
       \ @[%s@]@\n\
        for goals:@\n\
-      \ @[%a@]" Pp.pp_with error command Pp.pp_with goals
+      \ @[%a@]" Coq.Pp_t.pp_with error command Coq.Pp_t.pp_with goals
 end
 
 let extract_errors ~token ~root ~contents (node : Doc.Node.t) =
   let errors = List.filter Lang.Diagnostic.is_error node.diags in
-  let st = Option.cata Doc.Node.state root node.prev in
+  let st = Stdlib.Option.fold ~some:Doc.Node.state ~none:root node.prev in
   let command = Contents.extract_raw ~contents ~range:node.range in
   let goals = pp_goals ~token ~st in
   List.map

--- a/plugins/goaldump/main.ml
+++ b/plugins/goaldump/main.ml
@@ -11,7 +11,8 @@ let of_execution ~io ~what (v : (_, _) Coq.Protect.E.t) =
     | Coq.Protect.R.Completed (Error (Anomaly { msg; _ }))
     | Coq.Protect.R.Completed (Error (User { msg; _ })) ->
       let lvl = Io.Level.Error in
-      Io.Report.msg ~io ~lvl "error when retrieving %s: %a" what Pp.pp_with msg;
+      Io.Report.msg ~io ~lvl "error when retrieving %s: %a" what
+        Coq.Pp_t.pp_with msg;
       None
     | Coq.Protect.R.Interrupted -> None)
 
@@ -43,7 +44,7 @@ module AstGoals = struct
 end
 
 let pp_json pp fmt (astgoal : _ AstGoals.t) =
-  AstGoals.to_yojson pp (fun x -> Lsp.JCoq.Pp.to_yojson x) astgoal
+  AstGoals.to_yojson pp (fun x -> Lsp.JCoq.Pp_t.to_yojson x) astgoal
   |> Yojson.Safe.pretty_print fmt
 
 (* For now we have not added sexp serialization, but we can easily do so *)
@@ -66,7 +67,8 @@ let dump_goals ~io ~token ~out_file ~(doc : Doc.t) pp =
 let pp d =
   (* Set to true to output Pp-formatted goals *)
   let output_pp = false in
-  if output_pp then Lsp.JCoq.Pp.to_yojson d else `String (Pp.string_of_ppcmds d)
+  if output_pp then Lsp.JCoq.Pp_t.to_yojson d
+  else `String (Coq.Pp_t.to_string d)
 
 let dump_ast ~io ~token ~(doc : Doc.t) =
   let uri = doc.uri in

--- a/plugins/save_vo/dune
+++ b/plugins/save_vo/dune
@@ -1,4 +1,4 @@
 (library
  (name Savevo_plugin)
  (public_name coq-lsp.plugin.save_vo)
- (libraries coq-lsp.fleche))
+ (libraries coq-lsp.coq coq-lsp.fleche))

--- a/plugins/simple/dune
+++ b/plugins/simple/dune
@@ -1,4 +1,4 @@
 (library
  (name Example_plugin)
  (public_name coq-lsp.plugin.example)
- (libraries coq-lsp.fleche))
+ (libraries coq-lsp.lang coq-lsp.fleche))

--- a/plugins/univdiff/dune
+++ b/plugins/univdiff/dune
@@ -1,4 +1,4 @@
 (library
  (name Unidiff_plugin)
  (public_name coq-lsp.plugin.univdiff)
- (libraries coq-lsp.fleche))
+ (libraries coq-lsp.lang coq-lsp.coq coq-lsp.fleche))

--- a/serlib/dune
+++ b/serlib/dune
@@ -9,4 +9,24 @@
    ppx_hash
    ppx_compare
    ppx_deriving_yojson))
- (libraries rocq-runtime.vernac sexplib))
+ (libraries
+  ; base
+  ; ppx_base
+  ; base.base_internalhash_types
+  ; ppx_hash.runtime-lib
+  ; ppx_compare.runtime-lib
+  rocq-runtime.lib
+  rocq-runtime.clib
+  rocq-runtime.config
+  rocq-runtime.kernel
+  rocq-runtime.library
+  rocq-runtime.engine
+  rocq-runtime.gramlib
+  rocq-runtime.parsing
+  rocq-runtime.pretyping
+  rocq-runtime.interp
+  rocq-runtime.tactics
+  rocq-runtime.proofs
+  rocq-runtime.printing
+  rocq-runtime.vernac
+  sexplib))

--- a/serlib/plugins/extraction/dune
+++ b/serlib/plugins/extraction/dune
@@ -9,4 +9,9 @@
    ppx_deriving_yojson
    ppx_hash
    ppx_compare))
- (libraries rocq-runtime.plugins.extraction serlib))
+ (libraries
+  ; base
+  rocq-runtime.pretyping
+  rocq-runtime.plugins.extraction
+  sexplib
+  serlib))

--- a/serlib/plugins/firstorder/dune
+++ b/serlib/plugins/firstorder/dune
@@ -4,4 +4,8 @@
  (synopsis "Serialization Library for Coq Firstorder Plugin")
  (preprocess
   (staged_pps ppx_import ppx_sexp_conv ppx_hash ppx_compare))
- (libraries rocq-runtime.plugins.firstorder serlib sexplib))
+ (libraries
+  ; base
+  rocq-runtime.plugins.firstorder
+  serlib
+  sexplib))

--- a/serlib/plugins/funind/dune
+++ b/serlib/plugins/funind/dune
@@ -4,4 +4,19 @@
  (synopsis "Serialization Library for Coq Fundind Plugin")
  (preprocess
   (staged_pps ppx_import ppx_sexp_conv ppx_hash ppx_compare))
- (libraries rocq-runtime.plugins.funind serlib serlib_ltac sexplib))
+ (libraries
+  ; base
+  ; ppx_base
+  ; base.base_internalhash_types
+  ; ppx_hash.runtime-lib
+  ; ppx_compare.runtime-lib
+  rocq-runtime.lib
+  rocq-runtime.engine
+  rocq-runtime.pretyping
+  rocq-runtime.proofs
+  rocq-runtime.vernac
+  sexplib
+  serlib
+  rocq-runtime.plugins.ltac
+  serlib_ltac
+  rocq-runtime.plugins.funind))

--- a/serlib/plugins/ltac/dune
+++ b/serlib/plugins/ltac/dune
@@ -9,4 +9,24 @@
    ppx_deriving_yojson
    ppx_hash
    ppx_compare))
- (libraries rocq-runtime.plugins.ltac serlib sexplib))
+ (libraries
+  ; base
+  ; ppx_base
+  ; base.base_internalhash_types
+  ; ppx_hash.runtime-lib
+  ; ppx_compare.runtime-lib
+  rocq-runtime.lib
+  rocq-runtime.clib
+  rocq-runtime.kernel
+  rocq-runtime.library
+  rocq-runtime.engine
+  rocq-runtime.pretyping
+  rocq-runtime.interp
+  rocq-runtime.parsing
+  rocq-runtime.printing
+  rocq-runtime.proofs
+  rocq-runtime.tactics
+  rocq-runtime.vernac
+  rocq-runtime.plugins.ltac
+  sexplib
+  serlib))

--- a/serlib/plugins/ltac2/dune
+++ b/serlib/plugins/ltac2/dune
@@ -9,4 +9,10 @@
    ppx_deriving_yojson
    ppx_hash
    ppx_compare))
- (libraries rocq-runtime.plugins.ltac2 serlib sexplib))
+ (libraries
+  ; base
+  rocq-runtime.pretyping
+  rocq-runtime.vernac
+  rocq-runtime.plugins.ltac2
+  serlib
+  sexplib))

--- a/serlib/plugins/ltac2_ltac1/dune
+++ b/serlib/plugins/ltac2_ltac1/dune
@@ -9,4 +9,11 @@
    ppx_deriving_yojson
    ppx_hash
    ppx_compare))
- (libraries rocq-runtime.plugins.ltac2_ltac1 serlib sexplib serlib_ltac2))
+ (libraries
+  ; base
+  rocq-runtime.pretyping
+  rocq-runtime.plugins.ltac2
+  rocq-runtime.plugins.ltac2_ltac1
+  sexplib
+  serlib
+  serlib_ltac2))

--- a/serlib/plugins/ring/dune
+++ b/serlib/plugins/ring/dune
@@ -4,4 +4,14 @@
  (synopsis "Serialization Library for Coq Setoid Newring Plugin")
  (preprocess
   (staged_pps ppx_import ppx_sexp_conv ppx_hash ppx_compare))
- (libraries rocq-runtime.plugins.ring serlib serlib_ltac sexplib))
+ (libraries
+  ; base
+  ; ppx_base
+  ; base.base_internalhash_types
+  ; ppx_hash.runtime-lib
+  ; ppx_compare.runtime-lib
+  rocq-runtime.pretyping
+  rocq-runtime.plugins.ring
+  serlib
+  serlib_ltac
+  sexplib))

--- a/serlib/plugins/ssr/dune
+++ b/serlib/plugins/ssr/dune
@@ -10,8 +10,13 @@
    ppx_hash
    ppx_compare))
  (libraries
-  rocq-runtime.plugins.ssreflect
+  ; base
+  sexplib
+  rocq-runtime.engine
+  rocq-runtime.pretyping
   serlib
+  rocq-runtime.plugins.ltac
   serlib_ltac
+  rocq-runtime.plugins.ssrmatching
   serlib_ssrmatching
-  sexplib))
+  rocq-runtime.plugins.ssreflect))

--- a/serlib/plugins/ssrmatching/dune
+++ b/serlib/plugins/ssrmatching/dune
@@ -9,4 +9,13 @@
    ppx_deriving_yojson
    ppx_hash
    ppx_compare))
- (libraries rocq-runtime.plugins.ssrmatching serlib serlib_ltac sexplib))
+ (libraries
+  ; base
+  ; ppx_base
+  ; base.base_internalhash_types
+  ; ppx_hash.runtime-lib
+  ; ppx_compare.runtime-lib
+  rocq-runtime.plugins.ssrmatching
+  serlib
+  serlib_ltac
+  sexplib))

--- a/serlib/plugins/syntax/dune
+++ b/serlib/plugins/syntax/dune
@@ -9,4 +9,9 @@
    ppx_deriving_yojson
    ppx_hash
    ppx_compare))
- (libraries rocq-runtime.plugins.number_string_notation serlib sexplib))
+ (libraries
+  ; base
+  rocq-runtime.pretyping
+  rocq-runtime.plugins.number_string_notation
+  sexplib
+  serlib))


### PR DESCRIPTION
This is very useful for ports to other systems, in particular for the Lambdapi re-port.

Moreover, we have started work towards making `rocq-lsp` more friendly to the `(implicit_transitive_deps false)` setting, which would allow us to statically Flèche from `Rocq` libraries.

cc: #66 , #983