### PR TITLE
Adapt to rocq-prover/rocq#21254 (stop catching async exns)

### DIFF
--- a/coq/protect.ml
+++ b/coq/protect.ml
@@ -73,7 +73,7 @@ let eval_exn ~token ~f x =
     in
     let payload = Message.Payload.make ?range ?quickFix msg in
     Vernacstate.Interp.invalidate_cache ();
-    if CErrors.is_anomaly e then R.Completed (Error (Anomaly payload))
+    if CErrors.is_async e || CErrors.is_sync_anomaly e then R.Completed (Error (Anomaly payload))
     else R.Completed (Error (User payload))
 
 let _bind_exn ~f x =


### PR DESCRIPTION
Not sure how we should consider async exns in this code, for now I made them considered as anomalies.