### PR TITLE
[rocq] Create output directory on .vo file save

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,13 @@
    #1050)
  - [compiler] Fix handling of literate files (@ejgallego, #, reported
    by @jim-portegies)
+ - [rocq] Create output directory on .vo file save if it doesn't
+   exists. This is very useful in the web context where we don't yet
+   have a proper virtual FS setup, thus making the "Save .vo file"
+   command fail (@ejgallego, #1054)
+ - [web worker] Add LSP root to Rocq's loadpath, this makes .vo file
+   loading work even when no worker FS setup could happen (@ejgallego,
+   #1054)
 
 # coq-lsp 0.2.4: (W)Activation
 ------------------------------

--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -58,11 +58,8 @@ let go ~int_backend args =
   let () = Coq.Limits.select_best int_backend in
   let () = Coq.Limits.start () in
   let token = Coq.Limits.Token.create () in
-  let workspaces =
-    List.map
-      (fun dir -> (dir, Coq.Workspace.guess ~token ~cmdline ~debug ~dir))
-      roots
-  in
+  let make_ws dir = (dir, Coq.Workspace.guess ~token ~cmdline ~debug ~dir ()) in
+  let workspaces = List.map make_ws roots in
   List.iter (log_workspace ~io) workspaces;
   let () = apply_config ~max_errors in
   let cc = Cc.{ root_state; workspaces; default; io; token } in

--- a/controller/lsp_core.mli
+++ b/controller/lsp_core.mli
@@ -39,6 +39,7 @@ val lsp_init_process :
      ofn:(Lsp.Base.Message.t -> unit)
   -> io:Fleche.Io.CallBack.t
   -> cmdline:Coq.Workspace.CmdLine.t
+  -> ?add_root:bool
   -> debug:bool
   -> Lsp.Base.Message.t
   -> Init_effect.t

--- a/coq/workspace.mli
+++ b/coq/workspace.mli
@@ -88,9 +88,11 @@ end
 
 val guess :
      token:Limits.Token.t
+  -> ?add_root:bool
   -> debug:bool
   -> cmdline:CmdLine.t
   -> dir:string
+  -> unit
   -> (t, string) Result.t
 
 (* Fallback workspace *)

--- a/lsp-server/wasm/wacoq_worker.ml
+++ b/lsp-server/wasm/wacoq_worker.ml
@@ -63,7 +63,12 @@ let _log_interrupt ~io =
   Fleche.Io.Report.message_ ~io ~lvl ~message
 
 let on_init ~io ~root_state ~cmdline ~debug cmd =
-  match Lsp_core.lsp_init_process ~ofn:post_message ~io ~cmdline ~debug cmd with
+  (* Add root workspace directory as default loadpath. *)
+  let add_root = true in
+  match
+    Lsp_core.lsp_init_process ~add_root ~ofn:post_message ~io ~cmdline ~debug
+      cmd
+  with
   | Lsp_core.Init_effect.Exit -> (* XXX: bind to worker.close () *) None
   | Lsp_core.Init_effect.Loop -> None
   | Lsp_core.Init_effect.Success workspaces ->

--- a/petanque/json_shell/shell.ml
+++ b/petanque/json_shell/shell.ml
@@ -18,7 +18,7 @@ let cmdline : Coq.Workspace.CmdLine.t =
 let setup_workspace ~token ~init ~debug ~root =
   let dir = Lang.LUri.File.to_string_file root in
   (let open Coq.Compat.Result.O in
-   let+ workspace = Coq.Workspace.guess ~token ~debug ~cmdline ~dir in
+   let+ workspace = Coq.Workspace.guess ~token ~debug ~cmdline ~dir () in
    let files = Coq.Files.make () in
    Fleche.Doc.Env.make ~init ~workspace ~files)
   |> Result.map_error (fun msg -> Petanque.Agent.Error.(make_request (coq msg)))


### PR DESCRIPTION
This is very useful in the web context where we don't yet have a proper virtual FS setup, thus we request to save a `/working_dir/foo.vo` with the "Save .vo file" command, however it fails due `/working_dir` not being present in the worker.

We should properly fix this by implementing the LSP virtual FS, but for now this should do the trick.

In order for this to work well, we also modify the worker workspace
setup so we can add the LSP root folder to Rocq's search path.
