### PR TITLE
[compiler] Handle markdown and TeX documents properly.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,8 @@
    #1050)
  - [layout-engine] Add background color for each box kind (@ejgallego,
    #1050)
+ - [compiler] Fix handling of literate files (@ejgallego, #, reported
+   by @jim-portegies)
 
 # coq-lsp 0.2.4: (W)Activation
 ------------------------------

--- a/compiler/compile.ml
+++ b/compiler/compile.ml
@@ -32,13 +32,20 @@ let status_of_doc (doc : Doc.t) =
   | Stopped _ -> 2
   | Failed _ -> 1
 
+let guess_languageId file =
+  match Filename.extension file with
+  | ".mv" -> "markdown"
+  | ".v" -> "rocq"
+  | ".v.tex" -> "latex"
+  | _ -> "rocq"
+
 let compile_file ~cc file : int =
   let { Cc.io; root_state; workspaces; default; token } = cc in
   Io.Report.msg ~io ~lvl:Info "compiling file %s" file;
   match Lang.LUri.(File.of_uri (of_string file)) with
   | Error _ -> 222
   | Ok uri -> (
-    let languageId = "rocq" in
+    let languageId = guess_languageId file in
     let workspace = workspace_of_uri ~io ~workspaces ~uri ~default in
     let files = Coq.Files.make () in
     let env = Doc.Env.make ~init:root_state ~workspace ~files in

--- a/test/compiler/basic/proj1/c.mv
+++ b/test/compiler/basic/proj1/c.mv
@@ -1,0 +1,9 @@
+# This is a sample file to test the compiler for .mv files
+
+```rocq
+Definition c1 := Type.
+```
+
+```coq
+Definition c2 := Type.
+```

--- a/test/compiler/basic/run.t
+++ b/test/compiler/basic/run.t
@@ -25,6 +25,7 @@ Compile a single file, don't generate a `.vo` file:
   a.diags
   a.v
   b.v
+  c.mv
 
 Compile a single file, generate a .vo file
   $ fcc --root proj1 proj1/a.v
@@ -41,6 +42,7 @@ Compile a single file, generate a .vo file
   a.v
   a.vo
   b.v
+  c.mv
 
 Compile a single file, silent
   $ fcc --display=quiet --root proj1 proj1/a.v
@@ -62,6 +64,7 @@ Compile a dependent file
   b.diags
   b.v
   b.vo
+  c.mv
 
 Compile both files
   $ rm proj1/*.vo
@@ -82,6 +85,31 @@ Compile both files
   b.diags
   b.v
   b.vo
+  c.mv
+
+Compile both files and a markdown file
+  $ rm proj1/*.vo
+  $ fcc --root proj1 proj1/a.v proj1/b.v proj1/c.mv
+  [message] Configuration loaded from Command-line arguments
+   - findlib: [TEST_PATH]
+     + findlib config: [TEST_PATH]
+     + findlib default location: [TEST_PATH]
+   - coqlib is at: [TEST_PATH]
+     + 2 Coq path directory bindings in scope
+     + Modules [Corelib.Init.Prelude] will be loaded by default
+  [message] compiling file proj1/a.v
+  [message] compiling file proj1/b.v
+  [message] compiling file proj1/c.mv
+  $ ls proj1
+  a.diags
+  a.v
+  a.vo
+  b.diags
+  b.v
+  b.vo
+  c.diags
+  c.mv
+  c.vo
 
 Compile a dependent file without the dep being built
   $ rm proj1/*.vo
@@ -100,6 +128,8 @@ Compile a dependent file without the dep being built
   b.diags
   b.v
   b.vo
+  c.diags
+  c.mv
   $ cat proj1/a.diags
   $ cat proj1/b.diags
   {


### PR DESCRIPTION
We forgot to setup the right `languageId` in the compiler. We do so based on the extension.

Thanks to Jim Portegies for the bug report.