### PR TITLE
[fleche] Support workspace updates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,12 @@
  - [web worker] Add LSP root to Rocq's loadpath, this makes .vo file
    loading work even when no worker FS setup could happen (@ejgallego,
    #1054)
+ - [fleche] New `coq/workspace_update` notification, which tells
+   Flèche that `.vo` files in the workspace may have changed. This
+   will make coq-lsp pick up changes in the filesystem and restart
+   checking of Rocq's `Require`s when needed. The algorithm is not
+   smart at all yet, as it invalidates all the requires for all open
+   files. (@ejgallego, @helguo, #1059)
 
 # coq-lsp 0.2.4: (W)Activation
 ------------------------------

--- a/compiler/compile.ml
+++ b/compiler/compile.ml
@@ -29,7 +29,7 @@ let save_diags_file ~(doc : Fleche.Doc.t) =
 let status_of_doc (doc : Doc.t) =
   match doc.completed with
   | Yes _ -> 0
-  | Stopped _ -> 2
+  | Stopped _ | WorkspaceUpdated _ -> 2
   | Failed _ -> 1
 
 let guess_languageId file =

--- a/controller/lsp_core.ml
+++ b/controller/lsp_core.ml
@@ -468,6 +468,12 @@ let do_cancel ~ofn_rq ~params =
 
 let do_cache_trim ~io = Nt_cache_trim.notification ~io
 
+let do_workspace_update ~ofn_rq =
+  let invalid_rq = Fleche.Theory.workspace_update () in
+  let code = -32802 in
+  let message = "Request got old in server" in
+  IS.iter (Rq.cancel ~ofn_rq ~code ~message) invalid_rq
+
 let do_viewRange params =
   match List.assoc "range" params |> Lsp.JLang.Range.of_yojson with
   | Ok range ->
@@ -602,6 +608,7 @@ let dispatch_notification ~io ~ofn ~token ~state ~method_ ~params : unit =
   (* Specific to coq-lsp *)
   | "coq/viewRange" -> do_viewRange params
   | "coq/trimCaches" -> do_cache_trim ~io
+  | "coq/workspace_update" -> do_workspace_update ~ofn_rq
   (* Cancel Request *)
   | "$/cancelRequest" -> do_cancel ~ofn_rq ~params
   (* NOOPs *)

--- a/controller/rq_document.ml
+++ b/controller/rq_document.ml
@@ -63,6 +63,7 @@ let to_completed = function
     { JFleche.CompletionStatus.status = `Yes; range }
   | Stopped range -> { status = `Stopped; range }
   | Failed range -> { status = `Failed; range }
+  | WorkspaceUpdated range -> { status = `Failed; range }
 
 let request ~ast ~goals () ~token ~doc =
   let { Fleche.Doc.uri; version; nodes; completed; _ } = doc in

--- a/coq/files.ml
+++ b/coq/files.ml
@@ -22,3 +22,6 @@ type t = int [@@deriving hash, compare]
 
 let make () = 0
 let bump i = i + 1
+let hash = Int.hash
+let compare = Int.compare
+let pp = Format.pp_print_int

--- a/coq/files.mli
+++ b/coq/files.mli
@@ -21,3 +21,7 @@ val make : unit -> t
 
 (** [bump ()] Signal the files have changed *)
 val bump : t -> t
+
+val hash : t -> int
+val compare : t -> t -> int
+val pp : Format.formatter -> t -> unit

--- a/editor/code/package.json
+++ b/editor/code/package.json
@@ -136,6 +136,10 @@
         "title": "Coq LSP: Free memory"
       },
       {
+        "command": "coq-lsp.workspace_update",
+        "title": "Coq LSP: Request Rocq workspace refresh"
+      },
+      {
         "command": "coq-lsp.sentenceNext",
         "title": "Coq LSP: Try to jump to next Coq sentence"
       },

--- a/editor/code/src/client.ts
+++ b/editor/code/src/client.ts
@@ -486,6 +486,13 @@ export function activateCoqLSP(
     client.sendNotification(trimNot, {});
   };
 
+  // WS Update notification setup
+  const wsNot = new NotificationType<{}>("coq/workspace_update");
+
+  const workspaceUpdate = () => {
+    client.sendNotification(wsNot, {});
+  };
+
   // Save request setup
   const saveReq = new RequestType<FlecheDocumentParams, void, void>(
     "coq/saveVo"
@@ -563,6 +570,7 @@ export function activateCoqLSP(
   coqCommand("restart", restart);
   coqCommand("toggle", toggle);
   coqCommand("trim", cacheTrim);
+  coqCommand("workspace_update", workspaceUpdate);
 
   coqCommand("toggle_mode", toggle_lazy_checking);
 

--- a/etc/doc/PROTOCOL.md
+++ b/etc/doc/PROTOCOL.md
@@ -19,6 +19,7 @@
     * [.vo file saving](#vo-file-saving)
     * [Performance Data Notification](#performance-data-notification)
     * [Trim cache notification](#trim-cache-notification)
+    * [Workspace Update Notification](#workspace-update-notification)
     * [Viewport notification](#viewport-notification)
     * [Did Change Configuration and Server Configuration parameters](#did-change-configuration-and-server-configuration-parameters)
     * [Server Version Notification](#server-version-notification)
@@ -240,6 +241,7 @@ spec. Note that none of them are stable yet.
 - [.vo file saving](#vo-file-saving)
 - [Performance data notification](#performance-data-notification)
 - [Trim cache notification](#trim-cache-notification)
+- [Workspace Update Notification](#workspace-update-notification)
 - [Viewport notification](#viewport-notification)
 - [Server configuration parameters](#did-change-configuration-and-server-configuration-parameters)
 - [Server version notification](#server-version-notification)
@@ -625,6 +627,16 @@ const coqPerfData : NotificationType<DocumentPerfParams<Range>>
 
 The `coq/trimCaches` notification from client to server tells the
 server to free memory. It has no parameters.
+
+<!-- TOC --><a name="workspace-update-notification"></a>
+### Workspace update notification
+
+The `coq/workspace_update` notification from client to server notifies
+the server that the Rocq external environment has changed, for
+example, when .vo files have been updated.
+
+This can used in combination with other calls like `coq/saveVo` to
+work with multiple files.
 
 <!-- TOC --><a name="viewport-notification"></a>
 ### Viewport notification

--- a/examples/_RocqProject
+++ b/examples/_RocqProject
@@ -1,0 +1,1 @@
+-R . RocqLspExamples

--- a/fleche/doc.mli
+++ b/fleche/doc.mli
@@ -54,7 +54,11 @@ end
 module Completion : sig
   type t = private
     | Yes of Lang.Range.t  (** Location of the last token in the document *)
-    | Stopped of Lang.Range.t  (** Location of the last valid token *)
+    | Stopped of Lang.Range.t
+        (** Location of the last valid token before stopping *)
+    | WorkspaceUpdated of Lang.Range.t
+        (** The Workspace Environment was updated when document was processed up
+            to the range. Document may need full re-check from the beginning. *)
     | Failed of Lang.Range.t  (** Critical failure, like an anomaly *)
 
   val is_completed : t -> bool
@@ -122,6 +126,10 @@ val create :
     `Failed` state. *)
 val bump_version :
   token:Coq.Limits.Token.t -> version:int -> raw:string -> t -> t
+
+(** Notify the document the workspace / environment has changed. For now amounts
+    to re-creating a new document with the updated environment. *)
+val update_env : doc:t -> env:Env.t -> t
 
 (** Checking targets, this specifies what we expect check to reach *)
 module Target : sig

--- a/fleche/memo.ml
+++ b/fleche/memo.ml
@@ -394,27 +394,32 @@ module Admit = SEval (struct
 end)
 
 module InitEval = struct
-  type t = Coq.State.t * Coq.Workspace.t * Lang.LUri.File.t
+  type t = Coq.State.t * Coq.Workspace.t * Coq.Files.t * Lang.LUri.File.t
 
-  let equal (s1, w1, u1) (s2, w2, u2) : bool =
+  let equal (s1, w1, f1, u1) (s2, w2, f2, u2) : bool =
     if Lang.LUri.File.compare u1 u2 = 0 then
       if Coq.Workspace.compare w1 w2 = 0 then
-        if Coq.State.compare s1 s2 = 0 then true else false
+        if Coq.Files.compare f1 f2 = 0 then
+          if Coq.State.compare s1 s2 = 0 then true else false
+        else false
       else false
     else false
 
-  let hash (st, w, uri) =
+  let hash (st, w, f, uri) =
     Hashtbl.hash
-      (Coq.State.hash st, Coq.Workspace.hash w, Lang.LUri.File.hash uri)
+      ( Coq.State.hash st
+      , Coq.Workspace.hash w
+      , Coq.Files.hash f
+      , Lang.LUri.File.hash uri )
 
   type output = Coq.State.t
 
-  let eval ~token (root_state, workspace, uri) =
+  let eval ~token (root_state, workspace, _files, uri) =
     Coq.Init.doc_init ~token ~intern ~root_state ~workspace ~uri
 
-  let input_info (st, ws, file) =
-    Format.asprintf "st %d | ws %d | file %s" (Hashtbl.hash st)
-      (Hashtbl.hash ws)
+  let input_info (st, ws, files, file) =
+    Format.asprintf "st %d | ws %d | fs: %a| file %s" (Hashtbl.hash st)
+      (Hashtbl.hash ws) Coq.Files.pp files
       (Lang.LUri.File.to_string_file file)
 end
 

--- a/fleche/memo.mli
+++ b/fleche/memo.mli
@@ -59,7 +59,8 @@ end
 (** Document creation cache *)
 module Init :
   S
-    with type input = Coq.State.t * Coq.Workspace.t * Lang.LUri.File.t
+    with type input =
+      Coq.State.t * Coq.Workspace.t * Coq.Files.t * Lang.LUri.File.t
      and type output = Coq.State.t
 
 (** Vernacular evaluation cache, invariant w.r.t. Coq's Ast locations, results

--- a/fleche/theory.mli
+++ b/fleche/theory.mli
@@ -31,7 +31,7 @@ val open_ :
   -> version:int
   -> unit
 
-(** Update a document inside a theory, returns the list of not valid requests *)
+(** Update a document inside a theory, returns the set of invalidated requests *)
 val change :
      io:Io.CallBack.t
   -> token:Coq.Limits.Token.t
@@ -39,6 +39,10 @@ val change :
   -> version:int
   -> raw:string
   -> IS.t
+
+(** Notify the theory manager that the workspace has changed, for example due to
+    new .vo files present or updated. Returns the set of invalidated requests *)
+val workspace_update : unit -> IS.t
 
 (** Close a document *)
 val close : uri:Lang.LUri.File.t -> unit


### PR DESCRIPTION
We introduce a new `coq/workspace_update` notification, which tells Flèche that `.vo` files in the workspace may have changed.

This will make coq-lsp pick up changes in the filesystem and restart checking of Rocq's `Require`s when needed. The algorithm is not smart at all yet, as it invalidates all the requires for all open files.