### PR TITLE
[goals] New option to display goals in "non-compacted" form.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,9 @@
    checking of Rocq's `Require`s when needed. The algorithm is not
    smart at all yet, as it invalidates all the requires for all open
    files. (@ejgallego, @helguo, #1059)
+ - [goals] New option (LSP, petanque, API) to display and retrieve
+   goals without the compacted context. See protocol docs for more
+   information. (@ejgallego, alexJ, #1065, cc #1043)
 
 # coq-lsp 0.2.4: (W)Activation
 ------------------------------

--- a/controller/lsp_core.ml
+++ b/controller/lsp_core.ml
@@ -381,6 +381,8 @@ let get_pp_format params =
     get_pp_format_from_config ()
   | None -> get_pp_format_from_config ()
 
+let get_compact params = Option.default true (obool_field "compact" params)
+
 let get_pretac params =
   Option.append (ostring_field "command" params) (ostring_field "pretac" params)
 
@@ -399,9 +401,10 @@ let get_goals_mode params =
 
 let do_goals ~params =
   let pp_format = get_pp_format params in
+  let compact = get_compact params in
   let mode = get_goals_mode params in
   let pretac = get_pretac params in
-  let handler = Rq_goals.goals ~pp_format ~mode ~pretac () in
+  let handler = Rq_goals.goals ~pp_format ~compact ~mode ~pretac () in
   do_position_request ~postpone:true ~handler ~params
 
 let do_definition =

--- a/controller/rq_document.ml
+++ b/controller/rq_document.ml
@@ -20,7 +20,9 @@ let mk_error ~diags =
 let get_goal_info ~token ~pr ~st =
   let open Fleche in
   let open Coq.Protect.E.O in
-  let+ goals = Info.Goals.goals ~token ~pr ~st in
+  (* XXX Add an option if desired *)
+  let compact = true in
+  let+ goals = Info.Goals.goals ~token ~pr ~compact ~st in
   let program = Info.Goals.program ~st in
   (goals, Some program)
 

--- a/controller/rq_goals.ml
+++ b/controller/rq_goals.ml
@@ -75,7 +75,7 @@ let run_pretac ~token ~loc ~st pretac =
   | None -> Coq.Protect.E.ok st
   | Some tac -> Fleche.Doc.run ~token ?loc ~st tac
 
-let get_goal_info ~pp_format ~token ~doc ~point ~mode ~pretac () =
+let get_goal_info ~pp_format ~compact ~token ~doc ~point ~mode ~pretac () =
   let open Fleche in
   let node = Info.LC.node ~doc ~point mode in
   match node with
@@ -87,7 +87,7 @@ let get_goal_info ~pp_format ~token ~doc ~point ~mode ~pretac () =
     let loc = None in
     let* st = run_pretac ~token ~loc ~st pretac in
     let pr = pp ~pp_format in
-    let+ goals = Info.Goals.goals ~token ~pr ~st in
+    let+ goals = Info.Goals.goals ~token ~pr ~compact ~st in
     let program = Info.Goals.program ~st in
     (goals, Some program)
 
@@ -102,7 +102,7 @@ let get_node_info ~doc ~point ~mode =
   let error = Option.bind node mk_error in
   (range, messages, error)
 
-let goals ~pp_format ~mode ~pretac () ~token ~doc ~point =
+let goals ~pp_format ~compact ~mode ~pretac () ~token ~doc ~point =
   let open Fleche in
   let uri, version = (doc.Doc.uri, doc.version) in
   let textDocument = Lsp.Doc.VersionedTextDocumentIdentifier.{ uri; version } in
@@ -111,7 +111,7 @@ let goals ~pp_format ~mode ~pretac () ~token ~doc ~point =
   in
   let open Coq.Protect.E.O in
   let+ goals, program =
-    get_goal_info ~pp_format ~token ~doc ~point ~mode ~pretac ()
+    get_goal_info ~pp_format ~compact ~token ~doc ~point ~mode ~pretac ()
   in
   let range, messages, error = get_node_info ~doc ~point ~mode in
   let pp_msg = pp_msgs ~pp_format in
@@ -122,7 +122,7 @@ let goals ~pp_format ~mode ~pretac () ~token ~doc ~point =
       { textDocument; position; range; goals; program; messages; error })
   |> Result.ok
 
-let goals ~pp_format ~mode ~pretac () ~token ~doc ~point =
+let goals ~pp_format ~compact ~mode ~pretac () ~token ~doc ~point =
   let lines = Fleche.Doc.lines doc in
-  let f () = goals ~pp_format ~mode ~pretac () ~token ~doc ~point in
+  let f () = goals ~pp_format ~compact ~mode ~pretac () ~token ~doc ~point in
   Request.R.of_execution ~lines ~name:"goals" ~f ()

--- a/controller/rq_goals.mli
+++ b/controller/rq_goals.mli
@@ -14,6 +14,7 @@ type format =
     pre-processing and formatting using the provided parameters. *)
 val goals :
      pp_format:format
+  -> compact:bool
   -> mode:Fleche.Info.approx
   -> pretac:string option
   -> unit

--- a/coq/goals.mli
+++ b/coq/goals.mli
@@ -10,7 +10,7 @@
 
 module Reified_goal : sig
   type 'a hyp =
-    { names : string list  (** This will become [Names.Id.t list] in 0.2.0 *)
+    { names : string list
     ; def : 'a option
     ; ty : 'a
     }
@@ -49,9 +49,10 @@ val map : f:('a -> 'b) -> g:('pp -> 'pp') -> ('a, 'pp) t -> ('b, 'pp') t
 
 type ('goals, 'pp) reified = ('goals Reified_goal.t, 'pp) t
 
-(** Stm-independent goal processor *)
+(** Goal processing, [compact] will determine whether we group the hypotheses *)
 val reify :
      ppx:(Environ.env -> Evd.evar_map -> EConstr.t -> 'goals)
+  -> compact:bool
   -> State.Proof.t
   -> ('goals, Pp.t) reified
 

--- a/editor/code/lib/types.ts
+++ b/editor/code/lib/types.ts
@@ -71,6 +71,7 @@ export interface GoalRequest {
   textDocument: VersionedTextDocumentIdentifier;
   position: Position;
   pp_format?: "Box" | "Pp" | "Str";
+  compact?: boolean;
   pretac?: string;
   command?: string;
   mode?: "Prev" | "After";

--- a/editor/code/package.json
+++ b/editor/code/package.json
@@ -308,6 +308,11 @@
               "Coq Layout Engine (experimental)"
             ]
           },
+          "coq-lsp.compact_hypotheses": {
+            "type": "boolean",
+            "default": true,
+            "description": "Whether to group hypotheses with a similar type together in the goal window"
+          },
           "coq-lsp.messages_follow_goal": {
             "type": "boolean",
             "default": false,

--- a/editor/code/src/client.ts
+++ b/editor/code/src/client.ts
@@ -334,7 +334,8 @@ export function activateCoqLSP(
       uri,
       version,
       position,
-      config.pp_format
+      config.pp_format,
+      config.compact_hypotheses
     );
   };
 

--- a/editor/code/src/config.ts
+++ b/editor/code/src/config.ts
@@ -70,6 +70,7 @@ export enum ShowGoalsOnCursorChange {
 export interface CoqLspClientConfig {
   show_goals_on: ShowGoalsOnCursorChange;
   pp_format: "Str" | "Pp" | "Box";
+  compact_hypotheses: boolean;
   check_on_scroll: boolean;
 }
 
@@ -90,6 +91,7 @@ export namespace CoqLspClientConfig {
       show_goals_on: wsConfig.show_goals_on,
       pp_format: pp_type_to_pp_format(wsConfig.pp_type),
       check_on_scroll: wsConfig.check_on_scroll,
+      compact_hypotheses: wsConfig.compact_hypotheses,
     };
     return obj;
   }

--- a/editor/code/src/goals.ts
+++ b/editor/code/src/goals.ts
@@ -176,14 +176,15 @@ export class InfoPanel {
     uri: URI,
     version: number,
     position: Position,
-    pp_format: "Box" | "Pp" | "Str"
+    pp_format: "Box" | "Pp" | "Str",
+    compact: boolean
   ) {
     let textDocument = VersionedTextDocumentIdentifier.create(uri, version);
 
     // Example to test the `command` parameter
     // let command = "idtac.";
     // let cursor: GoalRequest = { textDocument, position, command };
-    let cursor: GoalRequest = { textDocument, position, pp_format };
+    let cursor: GoalRequest = { textDocument, position, pp_format, compact };
     this.updateInfoPanelForCursor(client, cursor);
     this.updateAPIClientForCursor(client, cursor);
   }

--- a/etc/doc/PROTOCOL.md
+++ b/etc/doc/PROTOCOL.md
@@ -285,6 +285,7 @@ interface GoalRequest {
     textDocument: VersionedTextDocumentIdentifier;
     position: Position;
     pp_format?: 'Box' | 'Pp' | 'Str';
+    compact?: boolean;
     pretac?: string;
     command?: string;
     mode?: 'Prev' | 'After';
@@ -301,6 +302,11 @@ Note that `rocq-lsp` will execute the Rocq document up to the
   (to be documented, see our rendered under
   `editor/code/lib/format-pprint`), `String` will return the goals and
   message bodies in plain text.
+
+- `compact` controls whether the hypotheses will be "compacted", that
+  is to say, given for example hypotheses `a`, `b` of type `nat`, they
+  will be displayed as `a, b : nat`, or separately, that is to say
+  `a : nat \n b : nat`.
 
 - `mode` (if absent, the `goal_after_tactic` global configuration
   parameter will be used) controls whether the `goals` returned
@@ -432,6 +438,8 @@ utils for those interested in richer printing formats.
 - v0.2.5:
   + `petanque/get_state_at_pos` will not error if there is no node at point
   + new method `petanque/run_at_pos`
+  + new option `compact` in goal requests (both LSP and petanque) to
+    display "non-compacted" contexts.
 - v0.2.4:
   + behavior of `messages`, `error`, and `range` can now be
     controlled by the `messages_follow_goal` global setting
@@ -965,7 +973,9 @@ of the previous node.
 ### `petanque/goals`
 
 ```typescript
-interface Params = { st: number }
+interface Goal_opts = { compact : bool }
+
+interface Params = { st: number; opts?: Goal_opts }
 ```
 
 ```typescript

--- a/fleche/info.ml
+++ b/fleche/info.ml
@@ -138,13 +138,13 @@ module O = Make (Offset)
 
 (* Related to goal request *)
 module Goals = struct
-  let get_goals_unit ~st =
+  let get_goals_unit ~compact ~st =
     let ppx _env _sigma _x = () in
-    Coq.State.lemmas ~st |> Option.map (Coq.Goals.reify ~ppx)
+    Coq.State.lemmas ~st |> Option.map (Coq.Goals.reify ~ppx ~compact)
 
-  let get_goals ~st =
+  let get_goals ~compact ~st =
     let ppx env sigma x = (env, sigma, x) in
-    Coq.State.lemmas ~st |> Option.map (Coq.Goals.reify ~ppx)
+    Coq.State.lemmas ~st |> Option.map (Coq.Goals.reify ~ppx ~compact)
 
   type 'a printer =
     token:Coq.Limits.Token.t -> Environ.env -> Evd.evar_map -> EConstr.t -> 'a
@@ -161,14 +161,14 @@ module Goals = struct
     | Coq.Protect.R.Completed (Error _pr) -> Coq.Pp_t.str "printer failed!"
     | Interrupted -> Coq.Pp_t.str "printer interrupted!"
 
-  let pr_goal ~token ~pr st =
+  let pr_goal ~token ~compact ~pr st =
     let lemmas = Coq.State.lemmas ~st in
-    Option.map (Coq.Goals.reify ~ppx:(pr ~token)) lemmas
+    Option.map (Coq.Goals.reify ~compact ~ppx:(pr ~token)) lemmas
 
   (* We need to use [in_state] here due to printing not being pure, but we want
      a better design here eventually *)
-  let goals ~token ~pr ~st =
-    Coq.State.in_state ~token ~st ~f:(pr_goal ~token ~pr) st
+  let goals ~token ~pr ~compact ~st =
+    Coq.State.in_state ~token ~st ~f:(pr_goal ~token ~compact ~pr) st
 
   let program ~st = Coq.State.program ~st
 end

--- a/fleche/info.mli
+++ b/fleche/info.mli
@@ -44,10 +44,13 @@ module O : S with module P := Offset
 (** We move towards a more modular design here, for preprocessing *)
 module Goals : sig
   val get_goals_unit :
-    st:Coq.State.t -> (unit, Coq.Pp_t.t) Coq.Goals.reified option
+       compact:bool
+    -> st:Coq.State.t
+    -> (unit, Coq.Pp_t.t) Coq.Goals.reified option
 
   val get_goals :
-       st:Coq.State.t
+       compact:bool
+    -> st:Coq.State.t
     -> (Environ.env * Evd.evar_map * EConstr.t, Coq.Pp_t.t) Coq.Goals.reified
        option
 
@@ -59,6 +62,7 @@ module Goals : sig
   val goals :
        token:Coq.Limits.Token.t
     -> pr:'a printer
+    -> compact:bool
     -> st:Coq.State.t
     -> (('a, Coq.Pp_t.t) Coq.Goals.reified option, Coq.Loc_t.t) Coq.Protect.E.t
 

--- a/petanque/agent.mli
+++ b/petanque/agent.mli
@@ -150,10 +150,16 @@ val run_at_pos :
   -> unit
   -> unit Run_result.t R.t
 
+module Goal_opts : sig
+  type t = { compact : bool }
+end
+
 (** [goals ~token ~st] return the list of goals for a given [st] *)
 val goals :
      token:Coq.Limits.Token.t
   -> st:State.t
+  -> ?opts:Goal_opts.t
+  -> unit
   -> (string, string) Coq.Goals.reified option R.t
 
 module Premise : sig

--- a/petanque/json/jAgent.ml
+++ b/petanque/json/jAgent.ml
@@ -25,6 +25,10 @@ end
 module Stdlib = Lsp.JStdlib
 module Result = Stdlib.Result
 
+module Goal_opts = struct
+  type t = [%import: Petanque.Agent.Goal_opts.t] [@@deriving yojson]
+end
+
 module Goals = struct
   type t = (string, string) Lsp.JCoq.Goals.reified option [@@deriving yojson]
 end

--- a/petanque/json/protocol.ml
+++ b/petanque/json/protocol.ml
@@ -244,7 +244,11 @@ module Goals = struct
   let method_ = "petanque/goals"
 
   module Params = struct
-    type t = { st : int } [@@deriving yojson]
+    type t =
+      { st : int
+      ; opts : Goal_opts.t option [@default None]
+      }
+    [@@deriving yojson]
   end
 
   module Response = struct
@@ -253,13 +257,18 @@ module Goals = struct
 
   module Handler = struct
     module Params = struct
-      type t = { st : State.t } [@@deriving yojson]
+      type t =
+        { st : State.t
+        ; opts : Goal_opts.t option [@default None]
+        }
+      [@@deriving yojson]
     end
 
     module Response = Response
 
     let handler =
-      HType.Immediate (fun ~token { Params.st } -> Agent.goals ~token ~st)
+      HType.Immediate
+        (fun ~token { Params.st; opts } -> Agent.goals ~token ?opts ~st ())
   end
 end
 

--- a/petanque/test/basic_api.ml
+++ b/petanque/test/basic_api.ml
@@ -57,7 +57,7 @@ let snoc_test ~token ~doc =
   let* st = r ~st ~tac:"-" in
   let* st = r ~st ~tac:"now simpl; rewrite IHl." in
   let* st = r ~st ~tac:"Qed." in
-  Agent.goals ~token ~st:(extract_st st)
+  Agent.goals ~token ~st:(extract_st st) ()
 
 let finished_stack_test ~token ~doc =
   let open Coq.Compat.Result.O in
@@ -78,7 +78,7 @@ let finished_stack_test ~token ~doc =
   (* Check that we properly detect no goals with deep stacks. *)
   assert proof_finished;
   let* st = Agent.run ~token ~st ~tac:"Qed." () in
-  Agent.goals ~token ~st:(extract_st st)
+  Agent.goals ~token ~st:(extract_st st) ()
 
 let multi_shot_test ~token ~doc =
   let open Coq.Compat.Result.O in
@@ -88,7 +88,7 @@ let multi_shot_test ~token ~doc =
       ~tac:"induction l. idtac. - reflexivity. - now simpl; rewrite IHl. Qed."
       ()
   in
-  Agent.goals ~token ~st:(extract_st st)
+  Agent.goals ~token ~st:(extract_st st) ()
 
 let fake_start_test ~token ~doc =
   match Agent.start ~token ~doc ~thm:"foo" () with

--- a/petanque/test/json_api.ml
+++ b/petanque/test/json_api.ml
@@ -130,7 +130,7 @@ let run (ic, oc) =
   let* st = r ~st ~tac:"Search naat." in
   check_search st 6;
   (* No goals after qed *)
-  S.goals { st = extract_st st }
+  S.goals { st = extract_st st; opts = None }
 
 let main () =
   let server_out, server_in = Unix.open_process "pet" in

--- a/petanque/test/json_api_failure.ml
+++ b/petanque/test/json_api_failure.ml
@@ -44,7 +44,7 @@ let run (ic, oc) =
   let* st = r ~st ~tac:"-" in
   let* st = r ~st ~tac:"now simpl; rewrite IHl." in
   let* st = r ~st ~tac:"Qed." in
-  S.goals { st = extract_st st }
+  S.goals { st = extract_st st; opts = None }
 
 let main () =
   let server_out, server_in = Unix.open_process "pet" in

--- a/plugins/goaldump/main.ml
+++ b/plugins/goaldump/main.ml
@@ -37,8 +37,9 @@ module AstGoals = struct
     let ast = Option.map (fun n -> n.Doc.Node.Ast.v) node.ast in
     let st = node.state in
     let pr = Info.Goals.to_pp in
+    let compact = true in
     let goals =
-      of_execution ~io ~what:"goals" (Info.Goals.goals ~token ~pr ~st)
+      of_execution ~io ~what:"goals" (Info.Goals.goals ~token ~pr ~compact ~st)
     in
     { raw; range; ast; goals }
 end


### PR DESCRIPTION
We introduce a new option for goal display and retrieval that allows users and developers to requests the proof hypotheses in a "non-compacted" way.

For `a, b : nat`, with `compact=true`:
```
a, b : nat
----------------
.....
```

With `compact=false`:
```
a : nat
b : nat
----------------
.....
```

cc #1043