### PR TITLE
Add config manager and messages_limit configuration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -82,8 +82,12 @@
    visualizing with perfetto.dev (@ejgallego, AlexJ, Gaëtan Gilbert,
    #1076)
  - [fcc] New options `--save_vof` and `--load_vof` that can save a
-   Fleche version of a document to a `.vof` file, thus avoiding
-   `.vo` recompilation for example when calling `fcc --plugin=...` for a given file (@ejgallego, Alexj, #, )
+   Fleche version of a document to a `.vof` file, thus avoiding `.vo`
+   recompilation for example when calling `fcc --plugin=...` for a
+   given file (@ejgallego, Alexj, #1077)
+ - [vscode] Add config manager for handling client configuration
+   changes in the infoview. Add configuration option for number of
+   messages displayed (@Durbatuluk1701, #1067)
 
 # coq-lsp 0.2.4: (W)Activation
 ------------------------------

--- a/editor/code/lib/types.ts
+++ b/editor/code/lib/types.ts
@@ -4,6 +4,23 @@ import {
   Range,
 } from "vscode-languageserver-types";
 
+export enum ShowGoalsOnCursorChange {
+  Never = 0,
+  OnMouse = 1,
+  OnMouseAndKeyboard = 2,
+  OnMouseKeyboardCommand = 3,
+}
+
+export interface CoqLspClientConfig {
+  show_goals_on: ShowGoalsOnCursorChange;
+  pp_format: "Str" | "Pp" | "Box";
+  compact_hypotheses: boolean;
+  check_on_scroll: boolean;
+  messages_limit: number;
+}
+
+export type ConfigFieldKey = keyof CoqLspClientConfig;
+
 export interface Hyp<Pp> {
   names: Pp[];
   def?: Pp;
@@ -167,7 +184,22 @@ export interface InfoError {
   params: ErrorData;
 }
 
-export type CoqMessagePayload = RenderGoals | WaitingForInfo | InfoError;
+export interface ConfigChangeEvent {
+  field: ConfigFieldKey;
+  oldValue: any;
+  newValue: any;
+}
+
+export interface ConfigChanged {
+  method: "configChanged";
+  params: { changes: ConfigChangeEvent[] };
+}
+
+export type CoqMessagePayload =
+  | RenderGoals
+  | WaitingForInfo
+  | InfoError
+  | ConfigChanged;
 
 export interface CoqMessageEvent extends MessageEvent {
   data: CoqMessagePayload;

--- a/editor/code/package.json
+++ b/editor/code/package.json
@@ -327,6 +327,11 @@
             "type": "boolean",
             "default": false,
             "description": "If enabled, errors and messages will be shown using the `goal_after_tactic` setting, otherwise, they always correspond to the requested position"
+          },
+          "coq-lsp.messages_limit": {
+            "type": "number",
+            "default": 100,
+            "description": "Maximum number of messages to display in the Goals/Info panel. Set to 0 to disable the limit."
           }
         }
       },

--- a/editor/code/src/client.ts
+++ b/editor/code/src/client.ts
@@ -15,7 +15,6 @@ import {
   languages,
   Uri,
   TextEditorVisibleRangesChangeEvent,
-  InputBoxOptions,
 } from "vscode";
 
 import * as vscode from "vscode";
@@ -42,6 +41,7 @@ import {
   AstAtPosParams,
   ViewRangeParams,
   BoxString,
+  CoqLspClientConfig,
 } from "../lib/types";
 
 import {
@@ -52,7 +52,8 @@ import {
   coqServerStatus,
   rocqExecInfo,
 } from "./status";
-import { CoqLspClientConfig, CoqLspServerConfig, CoqSelector } from "./config";
+import { ClientConfig, CoqLspServerConfig, CoqSelector } from "./config";
+import { configManager } from "./configManager";
 import { InfoPanel, goalReq } from "./goals";
 import { FileProgressManager } from "./progress";
 import { coqPerfData, PerfDataView } from "./perf";
@@ -132,7 +133,11 @@ export function activateCoqLSP(
 
   // Update config on client and server
   function configDidChange(wsConfig: any): CoqLspServerConfig {
-    config = CoqLspClientConfig.create(wsConfig);
+    config = ClientConfig.create(wsConfig);
+
+    // Notify the config manager (it will propagate changes as necessary)
+    configManager.updateConfig(config);
+
     let client_version = context.extension.packageJSON.version;
     let settings = CoqLspServerConfig.create(client_version, wsConfig);
     let params: DidChangeConfigurationParams = { settings };

--- a/editor/code/src/config.ts
+++ b/editor/code/src/config.ts
@@ -1,4 +1,5 @@
 import { TextDocumentFilter } from "vscode-languageclient";
+import { CoqLspClientConfig } from "../lib/types";
 
 export interface UnicodeCompletionConfig {
   enabled: "off" | "normal" | "extended";
@@ -64,20 +65,6 @@ export namespace CoqLspServerConfig {
   }
 }
 
-export enum ShowGoalsOnCursorChange {
-  Never = 0,
-  OnMouse = 1,
-  OnMouseAndKeyboard = 2,
-  OnMouseKeyboardCommand = 3,
-}
-
-export interface CoqLspClientConfig {
-  show_goals_on: ShowGoalsOnCursorChange;
-  pp_format: "Str" | "Pp" | "Box";
-  compact_hypotheses: boolean;
-  check_on_scroll: boolean;
-}
-
 function pp_type_to_pp_format(pp_type: 0 | 1 | 2): "Str" | "Pp" | "Box" {
   switch (pp_type) {
     case 0:
@@ -89,13 +76,14 @@ function pp_type_to_pp_format(pp_type: 0 | 1 | 2): "Str" | "Pp" | "Box" {
   }
 }
 
-export namespace CoqLspClientConfig {
+export namespace ClientConfig {
   export function create(wsConfig: any): CoqLspClientConfig {
     let obj: CoqLspClientConfig = {
       show_goals_on: wsConfig.show_goals_on,
       pp_format: pp_type_to_pp_format(wsConfig.pp_type),
       check_on_scroll: wsConfig.check_on_scroll,
       compact_hypotheses: wsConfig.compact_hypotheses,
+      messages_limit: wsConfig.messages_limit,
     };
     return obj;
   }

--- a/editor/code/src/configManager.ts
+++ b/editor/code/src/configManager.ts
@@ -1,0 +1,101 @@
+import { WebviewPanel } from "vscode";
+import {
+  ConfigChangeEvent,
+  ConfigChanged,
+  CoqLspClientConfig,
+  ConfigFieldKey,
+} from "../lib/types";
+
+export interface ConfigSubscription {
+  fields: ConfigFieldKey[];
+  callback: (changes: ConfigChangeEvent[]) => void;
+}
+
+/**
+ * Manages client configuration changes and subscriptions
+ */
+export class ConfigManager {
+  private currentConfig: CoqLspClientConfig | null = null;
+  private webviewPanels: Set<WebviewPanel> = new Set();
+
+  /**
+   * Register a webview panel to receive config update messages
+   */
+  registerWebview(panel: WebviewPanel): void {
+    this.webviewPanels.add(panel);
+
+    // Clean up when panel is disposed
+    panel.onDidDispose(() => {
+      this.webviewPanels.delete(panel);
+    });
+
+    // Send initial config if available
+    if (this.currentConfig) {
+      const changes = this.detectChanges(null, this.currentConfig);
+      this.notifyWebviews(changes);
+    }
+  }
+
+  /**
+   * Unregister a webview panel
+   */
+  unregisterWebview(panel: WebviewPanel): void {
+    this.webviewPanels.delete(panel);
+  }
+
+  /**
+   * Update the configuration and notify all subscribers
+   */
+  updateConfig(newConfig: CoqLspClientConfig): void {
+    const changes = this.detectChanges(this.currentConfig, newConfig);
+
+    if (changes.length > 0) {
+      // Update current config
+      this.currentConfig = newConfig;
+      this.notifyWebviews(changes);
+    }
+  }
+
+  /**
+   * Detect changes between old and new config
+   * @returns A list of the differences in ConfigChangeEvents
+   */
+  private detectChanges(
+    oldConfig: CoqLspClientConfig | null,
+    newConfig: CoqLspClientConfig
+  ): ConfigChangeEvent[] {
+    const changes: ConfigChangeEvent[] = [];
+    // NOTE: sort of an unsafe cast here
+    const keys = Object.keys(newConfig) as ConfigFieldKey[];
+
+    for (const field of keys) {
+      // Only compute differences.
+      // NOTE: if oldConfig is null, we consider all fields as changed
+      if (!oldConfig || oldConfig[field] !== newConfig[field]) {
+        changes.push({
+          field,
+          oldValue: oldConfig ? oldConfig[field] : undefined,
+          newValue: newConfig[field],
+        });
+      }
+    }
+
+    return changes;
+  }
+
+  /**
+   * Post configuration changes to all registered webviews
+   */
+  private notifyWebviews(changes: ConfigChangeEvent[]): void {
+    for (const panel of this.webviewPanels) {
+      const msg: ConfigChanged = {
+        method: "configChanged",
+        params: { changes },
+      };
+      panel.webview.postMessage(msg);
+    }
+  }
+}
+
+// Global config manager instance
+export const configManager = new ConfigManager();

--- a/editor/code/src/goals.ts
+++ b/editor/code/src/goals.ts
@@ -13,6 +13,7 @@ import {
   CoqMessagePayload,
   ErrorData,
 } from "../lib/types";
+import { configManager } from "./configManager";
 
 import {
   URI,
@@ -64,6 +65,12 @@ export class InfoPanel {
       { preserveFocus: true, viewColumn: ViewColumn.Two },
       webviewOpts
     );
+
+    /**
+     * Register the panel with the config manager:
+     * Essentially, the goals panel needs to be apprised of all config changes so its children can receive config messages
+     */
+    configManager.registerWebview(this.panel);
 
     const styleUri = this.panel.webview.asWebviewUri(
       Uri.joinPath(this.extensionUri, "out", "views", "info", "index.css")

--- a/editor/code/views/info/Info.tsx
+++ b/editor/code/views/info/Info.tsx
@@ -7,6 +7,7 @@ import {
   CoqMessageEvent,
   ErrorData,
 } from "../../lib/types";
+import { useConfigValue } from "./configManager";
 
 // Main panel components
 import { FileInfo } from "./FileInfo";
@@ -39,6 +40,8 @@ export function InfoPanel() {
   let [error, setError] = useState<ErrorData | null>();
   let [goals, setGoals] = useState<GoalAnswer<BoxString, PpString>>();
 
+  const messagesLimit = useConfigValue<number>("messages_limit", 100);
+
   function infoViewDispatch(event: CoqMessageEvent) {
     switch (event.data.method) {
       case "renderGoals":
@@ -51,6 +54,9 @@ export function InfoPanel() {
       case "infoError":
         setError(event.data.params);
         doInfoError(event.data.params);
+        break;
+      case "configChanged":
+        // Config changes handled by useConfigValue hook
         break;
       default:
         console.log("rocq infoview [Info.tsx]: unknown method", event.data);
@@ -80,9 +86,10 @@ export function InfoPanel() {
 
   if (!goals) return null;
 
-  // We limit the number of messages as to workaround slow rendering
-  // in pretty print mode, to be fixed.
-  let messages = goals.messages.slice(0, 100);
+  let messages =
+    messagesLimit === 0
+      ? goals.messages
+      : goals.messages.slice(0, messagesLimit);
 
   // Normal goal display otherwise
   return (

--- a/editor/code/views/info/configManager.ts
+++ b/editor/code/views/info/configManager.ts
@@ -1,0 +1,85 @@
+import { useState, useEffect, useCallback, useMemo } from "react";
+import {
+  CoqMessageEvent,
+  ConfigChangeEvent,
+  CoqLspClientConfig,
+  ConfigFieldKey,
+} from "../../lib/types";
+
+/**
+ * Hook to subscribe to specific configuration fields
+ * @param fields - Array of field names to watch for changes
+ * @param onConfigChange - Callback when any of the watched fields change
+ */
+export function useConfigSubscription(
+  fields: ConfigFieldKey[],
+  onConfigChange: (changes: ConfigChangeEvent[]) => void
+): CoqLspClientConfig | null {
+  const [config, setConfig] = useState<CoqLspClientConfig | null>(null);
+
+  useEffect(() => {
+    function handleConfigMessage(event: CoqMessageEvent) {
+      const { method, params } = event.data;
+
+      switch (method) {
+        case "configChanged":
+          // Filter to only the fields we're subscribed to
+          const relevantChanges = params.changes.filter((change) =>
+            fields.includes(change.field)
+          );
+
+          if (relevantChanges.length > 0) {
+            // Update config state
+            setConfig((prevConfig) => {
+              // TODO: Is the below unsafe?
+              const newConfig: CoqLspClientConfig = prevConfig
+                ? { ...prevConfig }
+                : ({} as CoqLspClientConfig);
+              for (const change of relevantChanges) {
+                (newConfig as any)[change.field] = change.newValue;
+              }
+              return newConfig;
+            });
+
+            // Notify callback
+            onConfigChange(relevantChanges);
+          }
+          break;
+      }
+    }
+
+    window.addEventListener("message", handleConfigMessage);
+    return () => window.removeEventListener("message", handleConfigMessage);
+  }, [fields, onConfigChange]);
+
+  return config;
+}
+
+/**
+ * Hook to get a specific configuration value with live updates
+ * @param field - The configuration field to watch
+ * @param defaultValue - Default value if config is not yet loaded
+ */
+export function useConfigValue<T>(field: ConfigFieldKey, defaultValue: T): T {
+  // TODO: With some typescript fanciness, we could probably infer T from CoqLspClientConfig[field]
+  const [value, setValue] = useState<T>(defaultValue);
+
+  // Memoize the callback
+  const handleConfigChange = useCallback(
+    (changes: ConfigChangeEvent[]) => {
+      const change = changes.find((c) => c.field === field);
+      // We only perform an update if relevant config changes occurred
+      if (change) {
+        setValue(change.newValue);
+      }
+    },
+    [field]
+  );
+
+  // Memoize fields
+  const fields = useMemo(() => [field], [field]);
+
+  useConfigSubscription(fields, handleConfigChange);
+
+  return value;
+}


### PR DESCRIPTION
This PR contributes the following:
1. A general purpose client configuration manager
2. Specific use of said configuration manager for new client option `messages_limit`

Messages Limit: "Maximum number of messages to display in the Goals/Info panel. Set to 0 to disable the limit."

New Behavior:
![rocq-lsp-message-limits-gif](https://github.com/user-attachments/assets/0ab4e7b7-8f0b-4c55-8f23-ffd6846bbc11)


I think I made some *interesting* (possibly wrong) design choices for the `configManager.ts`, so definitely open to discussion and iteration on it. 
I do like the idea of a general purpose and easy to use configuration manager for the client (as I have thoughts on other client configurations that could be added via `useConfigValue`)