### PR TITLE
[fleche] [rocq] New options and data fields to expose document comments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,11 @@
  - [goals] New option (LSP, petanque, API) to display and retrieve
    goals without the compacted context. See protocol docs for more
    information. (@ejgallego, alexJ, #1065, cc #1043)
+ - [fleche] [rocq] New options and data fields to expose document
+   comments.  This is experimental, pass the `--record_comments` flags
+   to `rocq-lsp`, `fcc`, or `pet-server` to enable it. Once this flag
+   is passed, comments for a document will be stored in the new
+   `doc.comments` field. (@ejgallego, alexJ, #1069, fixes #353)
 
 # coq-lsp 0.2.4: (W)Activation
 ------------------------------

--- a/compiler/args.ml
+++ b/compiler/args.ml
@@ -16,6 +16,7 @@ type t =
         (** Maximum erros before aborting the compilation *)
   ; coq_diags_level : int
         (** Whether to include feedback messages in the diagnostics *)
+  ; record_comments : bool  (** Record comments (experimental) *)
   }
 
 let compute_default_plugins ~no_vo ~plugins =

--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -1,9 +1,10 @@
 (* Duplicated with coq_lsp *)
-let coq_init ~debug =
+let coq_init ~debug ~record_comments =
   let load_module = Dynlink.loadfile in
   let load_plugin = Coq.Loader.plugin_handler None in
   let vm, warnings = (true, None) in
-  Coq.Init.(coq_init { debug; load_module; load_plugin; vm; warnings })
+  Coq.Init.(
+    coq_init { debug; record_comments; load_module; load_plugin; vm; warnings })
 
 let replace_test_path exp message =
   let home_re = Str.regexp (exp ^ ".*$") in
@@ -44,6 +45,7 @@ let go ~int_backend args =
       ; plugins
       ; max_errors
       ; coq_diags_level
+      ; record_comments
       } =
     args
   in
@@ -52,7 +54,7 @@ let go ~int_backend args =
   let io = Output.init ~display ~perfData ~coq_diags_level in
   (* Initialize Coq *)
   let debug = debug || Fleche.Debug.backtraces || !Fleche.Config.v.debug in
-  let root_state = coq_init ~debug in
+  let root_state = coq_init ~debug ~record_comments in
   let roots = if List.length roots < 1 then [ Sys.getcwd () ] else roots in
   let default = Coq.Workspace.default ~debug ~cmdline in
   let () = Coq.Limits.select_best int_backend in

--- a/compiler/fcc.ml
+++ b/compiler/fcc.ml
@@ -4,7 +4,7 @@ open Fcc_lib
 
 let fcc_main int_backend roots display debug plugins files coqlib findlib_config
     ocamlpath rload_path load_path require_libraries no_vo max_errors
-    coq_diags_level =
+    coq_diags_level record_comments =
   let vo_load_path = rload_path @ load_path in
   let args = [] in
   let cmdline =
@@ -27,6 +27,7 @@ let fcc_main int_backend roots display debug plugins files coqlib findlib_config
       ; plugins
       ; max_errors
       ; coq_diags_level
+      ; record_comments
       }
   in
   Driver.go ~int_backend args
@@ -99,7 +100,7 @@ let fcc_cmd : int Cmd.t =
     Term.(
       const fcc_main $ int_backend $ roots $ display $ debug $ plugins $ file
       $ coqlib $ findlib_config $ ocamlpath $ rload_paths $ qload_paths
-      $ ri_from $ no_vo $ max_errors $ coq_diags_level)
+      $ ri_from $ no_vo $ max_errors $ coq_diags_level $ record_comments)
   in
   let exits = Exit_codes.[ fatal; stopped; scheduled; uri_failed ] in
   Cmd.(v (Cmd.info "fcc" ~exits ~version ~doc ~man) fcc_term)

--- a/controller/rq_hover.ml
+++ b/controller/rq_hover.ml
@@ -363,6 +363,21 @@ module State_hash : HoverProvider = struct
   let h = Handler.WithNode h
 end
 
+module Comment_info = struct
+  let pr_comment fmt ((start, end_), cm) =
+    Format.fprintf fmt "@[(%d,%d) %s@]" start end_ cm
+
+  let h ~token:_ ~(doc : Fleche.Doc.t) ~point:_ ~node:_ =
+    if !Fleche.Config.v.show_comments_on_hover then
+      Some
+        Format.(
+          asprintf "@[%d comments found@\n```@\n@[<v>%a@]@]@\n```"
+            (List.length doc.comments) (pp_print_list pr_comment) doc.comments)
+    else None
+
+  let h = Handler.WithDoc h
+end
+
 module Register = struct
   let handlers : Handler.t list ref = ref []
   let add fn = handlers := fn :: !handlers
@@ -389,6 +404,7 @@ let () =
     ; InputHelp.h
     ; UniDiff.h
     ; State_hash.h
+    ; Comment_info.h
     ]
 
 let hover ~token ~(doc : Fleche.Doc.t) ~point =

--- a/coq/args.ml
+++ b/coq/args.ml
@@ -88,6 +88,10 @@ let bt =
   let doc = "Enable backtraces" in
   Cmdliner.Arg.(value & flag & info [ "bt" ] ~doc)
 
+let record_comments =
+  let doc = "Record document comments (experimental)" in
+  Cmdliner.Arg.(value & flag & info [ "record_comments" ] ~doc)
+
 let ri_from : (string option * string) list Term.t =
   let doc =
     "FROM Require Import LIBRARY before creating the document, à la From Coq \

--- a/coq/args.mli
+++ b/coq/args.mli
@@ -21,6 +21,7 @@ val ri_from : (string option * string) list Term.t
 val int_backend : Limits.backend option Term.t
 val roots : string list Term.t
 val coq_diags_level : int Term.t
+val record_comments : bool Term.t
 
 (* Internal, used by pet-server, should go away *)
 val coqlib_dyn : string

--- a/coq/init.ml
+++ b/coq/init.ml
@@ -23,6 +23,7 @@ type coq_opts =
   ; load_plugin : Mltop.PluginSpec.t -> unit
         (** callback to load findlib packages *)
   ; debug : bool  (** Enable Coq Debug mode *)
+  ; record_comments : bool  (** Enable Comment Recording *)
   ; vm : bool  (** Enable Coq's VM *)
   ; warnings : string option  (** Coq's Warnings *)
   }
@@ -53,6 +54,9 @@ let mk_fb_handler q Feedback.{ contents; _ } =
   | _ -> ()
 
 let coq_init opts =
+  (* Global settings, c.f. https://github.com/rocq-prover/rocq/pull/18821 *)
+  CLexer.record_comments := opts.record_comments;
+
   (* Core Coq initialization *)
   Lib.init ();
   Global.set_VM opts.vm;

--- a/coq/init.mli
+++ b/coq/init.mli
@@ -23,6 +23,7 @@ type coq_opts =
   ; load_plugin : Mltop.PluginSpec.t -> unit
         (** callback to load findlib packages *)
   ; debug : bool  (** Enable Coq Debug mode *)
+  ; record_comments : bool  (** Enable Comment Recording *)
   ; vm : bool  (** Enable Coq's VM *)
   ; warnings : string option  (** Coq's Warnings *)
   }

--- a/coq/loc_t.ml
+++ b/coq/loc_t.ml
@@ -27,3 +27,5 @@ type t = Loc.t =
   ; bp : int  (** Start position. *)
   ; ep : int  (** End position. *)
   }
+
+let pp = Loc.pr

--- a/coq/parsing.mli
+++ b/coq/parsing.mli
@@ -21,6 +21,7 @@ module Parsable : sig
 
   val make : ?loc:Loc.t -> (unit, char) Gramlib.Stream.t -> t
   val loc : t -> Loc.t
+  val comments : t -> ((int * int) * string) list
 end
 
 val parse :

--- a/editor/code/package.json
+++ b/editor/code/package.json
@@ -260,6 +260,11 @@
             "default": false,
             "description": "Show universe information and diff for a sentence on hover."
           },
+          "coq-lsp.show_comments_on_hover": {
+            "type": "boolean",
+            "default": false,
+            "description": "Show universe information and diff for a sentence on hover."
+          },
           "coq-lsp.show_state_hash_on_hover": {
             "type": "boolean",
             "default": false,

--- a/editor/code/src/config.ts
+++ b/editor/code/src/config.ts
@@ -24,6 +24,7 @@ export interface CoqLspServerConfig {
   show_loc_info_on_hover: boolean;
   show_universes_on_hover: boolean;
   show_state_hash_on_hover: boolean;
+  show_comments_on_hover: boolean;
   check_only_on_request: boolean;
   send_perf_data: boolean;
   send_execinfo: boolean;
@@ -50,6 +51,7 @@ export namespace CoqLspServerConfig {
       show_loc_info_on_hover: wsConfig.show_loc_info_on_hover,
       show_universes_on_hover: wsConfig.show_universes_on_hover,
       show_state_hash_on_hover: wsConfig.show_state_hash_on_hover,
+      show_comments_on_hover: wsConfig.show_comments_on_hover,
       check_only_on_request: wsConfig.check_only_on_request,
       send_perf_data: wsConfig.send_perf_data,
       send_execinfo: wsConfig.send_execinfo,

--- a/etc/doc/PROTOCOL.md
+++ b/etc/doc/PROTOCOL.md
@@ -696,6 +696,7 @@ export interface CoqLspServerConfig {
   show_loc_info_on_hover: boolean;
   show_universes_on_hover: boolean;
   show_state_hash_on_hover: boolean;
+  show_comments_on_hover: boolean;
   check_only_on_request: boolean;
   send_perf_data: boolean;
   send_execinfo: boolean;
@@ -709,6 +710,7 @@ client.
 <!-- TOC --><a name="changelog-5"></a>
 #### Changelog
 
+- v0.2.5: New option `show_comments_on_hover`
 - v0.2.4:
   + Deprecate `unicode_completion` in favor of new `completion:
     CompletionConfig` configuration record.

--- a/examples/comments_end.v
+++ b/examples/comments_end.v
@@ -5,9 +5,29 @@ Definition a := 3.
 
     Boooo
     Boooo
-    Boooo
+    Baooo
 
 
 
 *)
 
+Definition (* hola *) c := 3.
+
+(* hello *)
+
+(* bar *)
+
+(* moo *)
+
+Definition b := 3.
+
+(*
+
+
+    Boooo
+    More
+    Baooo
+
+
+
+*)

--- a/fleche/config.ml
+++ b/fleche/config.ml
@@ -102,6 +102,8 @@ type t =
         (** Show universe data on hover *)
   ; show_state_hash_on_hover : bool [@default false]
         (** Show state hash on hover, useful for debugging *)
+  ; show_comments_on_hover : bool [@default false]
+        (** Show comments on hover, useful for debugging *)
   ; pp_json : bool [@default false]
         (** Whether to pretty print the protocol JSON on the wire *)
   ; send_perf_data : bool [@default true]
@@ -140,6 +142,7 @@ let default =
   ; show_loc_info_on_hover = false
   ; show_universes_on_hover = false
   ; show_state_hash_on_hover = false
+  ; show_comments_on_hover = false
   ; verbosity = 2
   ; pp_json = false
   ; send_perf_data = true

--- a/fleche/doc.mli
+++ b/fleche/doc.mli
@@ -89,6 +89,8 @@ type t = private
   ; version : int  (** [version] of the document *)
   ; contents : Contents.t  (** [contents] of the document *)
   ; nodes : Node.t list  (** List of document nodes *)
+  ; comments : ((int * int) * string) list
+        (** List of all comments found up to [completed] *)
   ; completed : Completion.t
         (** Status of the document, usually either completed, suspended, or
             waiting for some IO / external event *)

--- a/lsp-server/jsoo/coq_lsp_worker.ml
+++ b/lsp-server/jsoo/coq_lsp_worker.ml
@@ -125,13 +125,14 @@ let loadfile file =
     Format.eprintf "loadfile [dynlink]: %s%!" file;
     time Dynlink.loadfile file)
 
-let coq_init ~debug =
+let coq_init ~debug ~record_comments =
   let loader = Fl_dynload.load_packages ~debug:false ~loadfile in
   let load_module = loadfile in
   let load_plugin = Coq.Loader.plugin_handler (Some loader) in
   (* XXX: Fixme at some point? *)
   let vm, warnings = (false, Some "-vm-compute-disabled") in
-  Coq.Init.(coq_init { debug; load_module; load_plugin; vm; warnings })
+  Coq.Init.(
+    coq_init { debug; record_comments; load_module; load_plugin; vm; warnings })
 
 external rocq_vm_trap : unit -> unit = "rocq_vm_trap"
 
@@ -193,7 +194,8 @@ let main () =
   in
 
   let debug = true in
-  let root_state = coq_init ~debug in
+  let record_comments = false in
+  let root_state = coq_init ~debug ~record_comments in
   Worker.set_onmessage (on_init ~io ~root_state ~cmdline ~debug);
   ()
 

--- a/lsp-server/native/coq_lsp.ml
+++ b/lsp-server/native/coq_lsp.ml
@@ -55,11 +55,12 @@ let concise_cb ofn =
     }
 
 (* Main loop *)
-let coq_init ~debug =
+let coq_init ~debug ~record_comments =
   let load_module = Dynlink.loadfile in
   let load_plugin = Coq.Loader.plugin_handler None in
   let vm, warnings = (true, None) in
-  Coq.Init.(coq_init { debug; load_module; load_plugin; vm; warnings })
+  Coq.Init.(
+    coq_init { debug; record_comments; load_module; load_plugin; vm; warnings })
 
 let exit_notification =
   Lsp.Base.Message.(Notification { method_ = "exit"; params = [] })
@@ -112,7 +113,7 @@ end = struct
 end
 
 let lsp_main bt coqlib findlib_config ocamlpath vo_load_path require_libraries
-    delay int_backend lsp_trace lsp_trace_file =
+    delay int_backend lsp_trace lsp_trace_file record_comments =
   Coq.Limits.select_best int_backend;
   Coq.Limits.start ();
 
@@ -141,7 +142,7 @@ let lsp_main bt coqlib findlib_config ocamlpath vo_load_path require_libraries
 
   (* Core Coq initialization *)
   let debug = bt || Fleche.Debug.backtraces in
-  let root_state = coq_init ~debug in
+  let root_state = coq_init ~debug ~record_comments in
   let cmdline =
     { Coq.Workspace.CmdLine.coqlib
     ; findlib_config
@@ -243,7 +244,8 @@ let lsp_cmd : unit Cmd.t =
       (Cmd.info "coq-lsp" ~version:Fleche.Version.server ~doc ~man)
       Term.(
         const lsp_main $ bt $ coqlib $ findlib_config $ ocamlpath $ vo_load_path
-        $ ri_from $ delay $ int_backend $ lsp_trace $ lsp_trace_file))
+        $ ri_from $ delay $ int_backend $ lsp_trace $ lsp_trace_file
+        $ record_comments))
 
 let main () =
   let ecode = Cmd.eval lsp_cmd in

--- a/lsp-server/wasm/wacoq_worker.ml
+++ b/lsp-server/wasm/wacoq_worker.ml
@@ -36,12 +36,13 @@ let post_message (msg : Fleche_lsp.Base.Message.t) =
 let findlib_conf = "\ndestdir=\"/static/lib\"path=\"/static/lib\""
 let findlib_path = "/lib/findlib.conf"
 
-let coq_init ~debug =
+let coq_init ~debug ~record_comments =
   let load_module = Dynlink.loadfile in
   let load_plugin = Coq.Loader.plugin_handler None in
   (* XXX: Fixme at some point? *)
   let vm, warnings = (false, Some "-vm-compute-disabled") in
-  Coq.Init.(coq_init { debug; load_module; load_plugin; vm; warnings })
+  Coq.Init.(
+    coq_init { debug; record_comments; load_module; load_plugin; vm; warnings })
 
 (* Start of controller core *)
 open Controller
@@ -180,7 +181,8 @@ let main () =
 
   let debug = false in
   e "boot: phase 4";
-  let root_state = coq_init ~debug in
+  let record_comments = false in
+  let root_state = coq_init ~debug ~record_comments in
 
   e "boot: phase 5";
   (* Specific to WASM, handle new string coming to the worker *)

--- a/petanque/json_shell/pet.ml
+++ b/petanque/json_shell/pet.ml
@@ -61,13 +61,14 @@ let log_error Request.Error.{ payload = err; _ } =
   let message = Petanque.Agent.Error.to_string err in
   message_notification ~lvl:Fleche.Io.Level.Error ~message
 
-let pet_main debug roots http_headers =
+let pet_main debug record_comments roots http_headers =
   Coq.Limits.start ();
   if trace_enabled then (
     Shell.trace_ref := trace_notification;
     Shell.message_ref := message_notification);
   let token = Coq.Limits.Token.create () in
-  Result.iter_error log_error (Shell.init_agent ~token ~debug ~roots);
+  Result.iter_error log_error
+    (Shell.init_agent ~token ~debug ~record_comments ~roots);
   use_http_headers := http_headers;
   loop ~token
 
@@ -94,7 +95,9 @@ let pet_cmd : unit Cmd.t =
   in
   let version = Fleche.Version.server in
   let pet_term =
-    Term.(const pet_main $ Coq.Args.debug $ Coq.Args.roots $ http_headers)
+    Term.(
+      const pet_main $ Coq.Args.debug $ Coq.Args.record_comments
+      $ Coq.Args.roots $ http_headers)
     (* const pet_main $ roots $ display $ debug $ plugins $ file $ coqlib *)
     (* $ coqcorelib $ ocamlpath $ rload_path $ load_path $ rifrom) *)
   in

--- a/petanque/json_shell/server.ml
+++ b/petanque/json_shell/server.ml
@@ -72,7 +72,7 @@ let log_error Request.Error.{ payload = err; _ } =
   Format.eprintf "Error in --root option: %s@\n%!" message
 (* Logs_lwt.info (fun m -> m "%s" message) *)
 
-let pet_main debug roots address port backlog =
+let pet_main debug record_comments roots address port backlog =
   Coq.Limits.start ();
   let token = Coq.Limits.Token.create () in
   let () = Logs.set_reporter (Logs.format_reporter ()) in
@@ -82,7 +82,8 @@ let pet_main debug roots address port backlog =
   (* EJGA: pet-server should handle this at some point *)
   (* Petanque.Shell.trace_ref := trace_notification; *)
   (* Petanque.Shell.message_ref := message_notification); *)
-  Result.iter_error log_error (Shell.init_agent ~token ~debug ~roots);
+  Result.iter_error log_error
+    (Shell.init_agent ~token ~debug ~record_comments ~roots);
   Lwt_main.run @@ serve ()
 
 open Cmdliner
@@ -116,8 +117,8 @@ let pet_cmd : unit Cmd.t =
   let version = Fleche.Version.server in
   let pet_term =
     Term.(
-      const pet_main $ Coq.Args.debug $ Coq.Args.roots $ address $ port
-      $ backlog)
+      const pet_main $ Coq.Args.debug $ Coq.Args.record_comments
+      $ Coq.Args.roots $ address $ port $ backlog)
   in
   Cmd.(v (Cmd.info "pet" ~version ~doc ~man) pet_term)
 

--- a/petanque/json_shell/shell.ml
+++ b/petanque/json_shell/shell.ml
@@ -1,10 +1,11 @@
 module SM = Lang.Compat.String.Map
 
-let init_coq ~debug =
+let init_coq ~debug ~record_comments =
   let load_module = Dynlink.loadfile in
   let load_plugin = Coq.Loader.plugin_handler None in
   let vm, warnings = (true, None) in
-  Coq.Init.(coq_init { debug; load_module; load_plugin; vm; warnings })
+  Coq.Init.(
+    coq_init { debug; record_comments; load_module; load_plugin; vm; warnings })
 
 let cmdline : Coq.Workspace.CmdLine.t =
   { coqlib = Coq.Args.coqlib_dyn
@@ -105,8 +106,8 @@ let set_roots ~token ~debug ~roots =
   let* root = uri_of_path root in
   set_workspace ~token ~debug ~root
 
-let init_agent ~token ~debug ~roots =
-  init_st := Some (init_coq ~debug);
+let init_agent ~token ~debug ~record_comments ~roots =
+  init_st := Some (init_coq ~debug ~record_comments);
   Fleche.Io.CallBack.set io;
   set_roots ~token ~debug ~roots
 

--- a/petanque/json_shell/shell.mli
+++ b/petanque/json_shell/shell.mli
@@ -10,7 +10,11 @@ val message_ref : (lvl:Fleche.Io.Level.t -> message:string -> unit) ref
 
 (** Start the shell, must be called only once. *)
 val init_agent :
-  token:Coq.Limits.Token.t -> debug:bool -> roots:string list -> unit Agent.R.t
+     token:Coq.Limits.Token.t
+  -> debug:bool
+  -> record_comments:bool
+  -> roots:string list
+  -> unit Agent.R.t
 
 (** [set_workspace ~root] Sets project and workspace settings from [root].
     [root] needs to be in URI format. If called repeteadly, overrides the

--- a/petanque/test/basic_api.ml
+++ b/petanque/test/basic_api.ml
@@ -19,11 +19,14 @@ let dump_msgs () = List.iter (Format.eprintf "%s@\n") (List.rev !msgs)
 
 let init ~token =
   let debug = false in
+  let record_comments = false in
   Shell.trace_ref := trace;
   Shell.message_ref := message;
   (* Will this work on Windows? *)
   let open Coq.Compat.Result.O in
-  let _ : _ Result.t = Shell.init_agent ~token ~debug ~roots:[] in
+  let _ : _ Result.t =
+    Shell.init_agent ~token ~debug ~record_comments ~roots:[]
+  in
   (* Twice to test for #766 *)
   let root, uri = prepare_paths () in
   let* () = Shell.set_workspace ~token ~debug ~root in


### PR DESCRIPTION
We introduce new options and data fields to expose document comments, as understood by the Rocq lexer.

Due to lack of testing, this is an experimental feature; pass the `--record_comments` flags to `rocq-lsp`, `fcc`, or `pet-server` to enable it.

Once this flag is passed, comments for a document will be stored in the new `doc.comments` field. Use the `show_comments_on_hover` option to display the comments on hover for debugging purposes.

Fixes #353