### PR TITLE
serlib: adapt to rocq-prover/rocq#22268 (numnot_option gains GlobRef fields)

### DIFF
--- a/serlib/ser_primNotations.ml
+++ b/serlib/ser_primNotations.ml
@@ -17,6 +17,7 @@
 (************************************************************************)
 
 module NumTok = Ser_numTok
+module Names = Ser_names
 module Constrexpr = Ser_constrexpr
 
 type numnot_option =


### PR DESCRIPTION
*[Written by Claude (Fable 5) via Claude Code, on behalf of @JasonGross.]*

Adapts to rocq-prover/rocq#22268: the new `HalfAbstract` constructor of `PrimNotations.numnot_option` carries `Names.GlobRef.t` fields, so the ppx_import derivations in `serlib/ser_primNotations.ml` need the `Ser_names` mapping, following the module-alias pattern already used in this file.

To be merged in sync with rocq-prover/rocq#22268 (this branch is its CI overlay). Verified against that PR's CI; not built locally (missing local opam deps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ttctspSoVoquHLQtbPVZw
